### PR TITLE
implement `koch` and setup basic CI pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,64 @@
+name: Build and test
+on:
+  # run on push...
+  push:
+    # ... but ignore the main and temporary merge queue branches
+    branches-ignore:
+      - main
+      - gh-readonly-queue/**
+
+  pull_request:
+    # only run for PRs to main
+    branches:
+      - main
+
+    # only consider certain events
+    type:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+  merge_group:
+    # run when something enters the merge queue
+
+# use bash for all script actions
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  binaries:
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - name: Linux
+            runner: ubuntu-20.04
+          - name: MacOS (M1)
+            runner: macos-14
+          - name: MacOS
+            runner: macos-12
+          - name: Windows
+            runner: windows-2022
+
+    name: "Build binaries (${{ matrix.target.name }})"
+    runs-on: ${{ matrix.target.runner }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # sparse checkout; we're only interested in the head commit
+          fetch-depth: 0
+          filter: tree:0
+
+      # always use the most recent NimSkull version
+      - uses: nim-works/setup-nimskull@0.1.2
+        with:
+          nimskull-version: "*"
+
+      - name: Build koch
+        run: nim c -d:nimStrictMode --outdir:bin koch.nim
+
+      - name: Build all programs
+        run: bin/koch all -d:nimStrictMode -d:release

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# ignore build artifacts
+*.o
+*.a
+*.so
+*.exe
+*.lib
+*.dll
+
+# build artifact directories
+/build/
+/bin/
+
+# user-specific VSCode directories
+*.code-workspace
+*.vscode

--- a/koch.nim
+++ b/koch.nim
@@ -1,0 +1,115 @@
+## Tool for performing various build and testing related actions for the
+## repository. *Koch* is a German noun meaning *cook* or *chef* in English.
+
+import std/[sequtils, strutils, os, osproc, parseopt]
+
+const
+  HelpText = """
+Usage:
+  build [options] <command>
+
+Options:
+  --nim:path                  use the specified NimSkull compiler
+
+Commands:
+  all [args]                  builds all programs
+  single <name> [args]        builds the single program with the given name
+"""
+  Programs: seq[(string, string)] = @[]
+
+var
+  nimExe = findExe("nim")
+  verbose = true
+
+proc compile(file: sink string, name: string, extra: varargs[string]): bool =
+  ## Compiles the given NimSkull `file` into an exectuable located in the bin/
+  ## directory, using `name` as the name.
+  var args = @["c", "--nimcache:build/cache/" & name,
+               "-o:bin/" & addFileExt(name, ExeExt)]
+  args.add extra
+  args.add file
+  if verbose:
+    echo "run: ", nimExe, " ", args.join(" ")
+  let p = startProcess(nimExe, args=args, options={poParentStreams, poUsePath})
+  result = p.waitForExit(-1) == 0
+  p.close()
+
+proc saneSplit(s: string): seq[string] =
+  ## Compared to the normal split, returns an empty sequence for an empty
+  ## string.
+  let s = strip(s)
+  if s.len > 0: split(s, ' ')
+  else:         @[]
+
+# command implementations:
+
+proc buildSingle(args: string): bool =
+  ## Builds the single program specified by `args`.
+  var args = args.saneSplit()
+  if args.len == 0:
+    return false # not enough arguments, show the help
+
+  let progName = args[0]
+  args.delete(0)
+
+  result = true
+
+  for (name, path) in Programs.items:
+    if name == progName:
+      if not compile(getCurrentDir() / path, name, args):
+        echo "Failure"
+        quit(1)
+      return
+
+  # report a "not found" error
+  echo "no program with name: '", progName, "' exists. Candidates are:"
+  echo "  ", mapIt(Programs, it[0]).join(", ")
+  quit(1)
+
+proc buildAll(args: string): bool =
+  ## Builds all programs, passing `args` along to the compiler.
+  let extra = args.saneSplit()
+  for (name, path) in Programs.items:
+    echo extra
+    if not compile(getCurrentDir() / path, name, extra):
+      echo "Failure"
+      quit(1)
+
+  result = true
+
+proc showHelp(): bool =
+  ## Shows the help text.
+  echo HelpText
+  result = true
+
+# main command processing:
+var
+  opts = initOptParser(getExecArgs())
+  success = false
+
+while true:
+  opts.next()
+  case opts.kind
+  of cmdLongOption, cmdShortOption:
+    case normalize(opts.key)
+    of "nim":
+      nimExe = opts.val
+    else:
+      echo "Unknown option: ", normalize(opts.key)
+      break
+  of cmdArgument:
+    success =
+      case normalize(opts.key)
+      of "all":    buildAll(opts.cmdLineRest)
+      of "single": buildSingle(opts.cmdLineRest)
+      of "help":   showHelp()
+      else:
+        echo "Unknown command: ", normalize(opts.key)
+        false
+    break
+  of cmdEnd:
+    break
+
+if not success:
+  echo HelpText
+  quit(1)


### PR DESCRIPTION
## Summary

* implement a bare-bones `koch` build tool
* setup a basic CI pipeline

## Details

**Koch:**
* the tool and its functionality are inspired by the tool of the same
  name from NimSkull
* it only implements two very basic commands at the moment

**CI:**
* setup a basic CI pipeline that builds `koch` and runs the `all`
  command
* Linux, MacOS, MacOS (M1), and Windows are used as runner systems
* configure `dependabot`