### PR TITLE
vm: remove built-in closure support

### DIFF
--- a/vm/vm.nim
+++ b/vm/vm.nim
@@ -479,7 +479,7 @@ proc run*(c: var VmEnv, t: var VmThread, cl: RootRef): YieldReason {.raises: [].
     of opcRaise:
       eh.value = stack.pop()
       break exc # start exception handling
-    of opcCall, opcIndCall, opcIndCallCl:
+    of opcCall, opcIndCall:
       var
         (idx, args) = imm32_16()
         prc: ProcIndex
@@ -492,18 +492,6 @@ proc run*(c: var VmEnv, t: var VmThread, cl: RootRef): YieldReason {.raises: [].
         check tmp > 0 and tmp < c.procs.len.uint64, ecIllegalProc
         prc = ProcIndex(tmp - 1)
         check TypeId(idx) == c[prc].typ, ecTypeError
-      of opcIndCallCl:
-        let tmp = operand(1).uintVal
-        check tmp > 0 and tmp < c.procs.len.uint64, ecIllegalProc
-        prc = ProcIndex(tmp - 1)
-        check TypeId(idx) == c[prc].typ, ecTypeError
-        if c[prc].isClosure:
-          inc args
-          bias = 1
-        else:
-          bias = 2
-        # the proc and env cannot be popped right away, since the procedure might
-        # be a stub, in which case the VM yields
       else:
         unreachable()
 

--- a/vm/vmenv.nim
+++ b/vm/vmenv.nim
@@ -30,8 +30,6 @@ type
     ## Stores the various information about a procedure, such as the type,
     ## locals, body, etc.
     kind*: ProcKind
-    isClosure*: bool
-      ## whether the closure calling convention is used
     typ*: TypeId
       ## the procedure's type
     code*: Slice[PrgCtr]

--- a/vm/vmspec.nim
+++ b/vm/vmspec.nim
@@ -104,7 +104,6 @@ type
     opcRaise      ## val:int
     opcCall       ## callee:imm32 num:imm16
     opcIndCall    ## callee:int typ:imm32 num:imm16
-    opcIndCallCl  ## callee:int typ:imm32 num:imm16
     opcExcept     ## val:int
 
     # sub-routines

--- a/vm/vmvalidation.nim
+++ b/vm/vmvalidation.nim
@@ -296,7 +296,7 @@ proc run(ctx: var ValidationState, env: VmEnv, pos: PrgCtr, instr: Instr
     pop(vtInt)
     expectEmpty()
     ctx.active = false
-  of opcCall, opcIndCall, opcIndCallCl:
+  of opcCall, opcIndCall:
     let (idx, num) = imm32_16(instr)
     var typ: TypeId
 
@@ -307,11 +307,6 @@ proc run(ctx: var ValidationState, env: VmEnv, pos: PrgCtr, instr: Instr
       check checked(env.types.types, idx).kind == tkProc, errNotAProcType
       typ = TypeId idx
       pop(vtInt) # callee
-    of opcIndCallCl:
-      check checked(env.types.types, idx).kind == tkProc, errNotAProcType
-      typ = TypeId idx
-      pop(vtInt) # callee
-      pop(vtInt) # environment
     else:
       unreachable()
 


### PR DESCRIPTION
## Summary

* remove the `opcIndCallCl` (call closure) instruction
* remove the `isClosure` boolean flag from `ProcHeader`

## Details

The rationale is that the built-in closure support only really covers
contemporary NimSkull closures (where the environment is passed via a
single parameter), which is too narrow a use-case (that can also be
efficiently implemented without built-in VM support) for it to warrant
a dedicated instruction.