### PR TITLE
expand `tester`'s features

### DIFF
--- a/tools/tester.nim
+++ b/tools/tester.nim
@@ -30,6 +30,8 @@ type
   TestSpec = object
     ## A test specification. Contains information about a test and what to
     ## expect from it.
+    arguments: seq[string]
+      ## extra arguments to pass to the runner
     expected: seq[OutputSpec]
       ## the output(s) expected from the runner (if any)
     knownIssue: Option[string]
@@ -224,6 +226,8 @@ else:
           spec.expected.add:
             OutputSpec(fromFile: false,
                        output: strip(evt.value, leading=true, trailing=false))
+        of "arguments":
+          spec.arguments = split(evt.value, ' ')
         else:
           echo "unknown key: ", evt.key
           quit(1)
@@ -239,8 +243,11 @@ else:
   else:
     s.close()
 
+  var args = spec.arguments
+  args.add file
+
   # execute the runner and check the output:
-  var res = compare(exec(runner, [file]), spec)
+  var res = compare(exec(runner, args), spec)
 
   # handle the "known issue" specification:
   if spec.knownIssue.isSome:


### PR DESCRIPTION
## Summary

* support multiple runner output fragments
* support custom runner arguments (provided by `arguments`)
  specification

## Details

* prepare the tester for supporting an arbitrary number of runner
  output fragments
* output fragments are delimited by the `!BREAK!` substring in the
  runner's output
* more fragments than what the specification requires is not an error
* the `output` specification specifies what the *last* output fragment
  has to be
* a file with the `.expected` extension and the same name as the test
  specifies an additional output fragment

---

## Notes For Reviewers

Both features are a preparation for implementing bytecode output comparison for the `pass0` tests in #7. The idea is that the expected bytecode is provided by a `t0x_xxx.expected` file alongside the main test file.

The various expected output fragments could also be specified via the test specification (like how tests in NimSkull usually do it), but this tends to be awkward to read (i.e., the expected output comes *before* the actual test). Having the expected output be part of the test file but appear after the main test content could work, but using a separate file was somewhat simpler to implement.