### PR TITLE
implement a language with a blob type (`L1`)

### DIFF
--- a/passes/builders.nim
+++ b/passes/builders.nim
@@ -16,7 +16,7 @@ func initBuilder*[T](buf: sink seq[TreeNode[T]]): Builder[T] =
 func initBuilder*[T](): Builder[T] =
   Builder[T](parent: -1)
 
-template open*[T](bu: var Builder[T], k: T, body: untyped) =
+template subTree*[T](bu: var Builder[T], k: T, body: untyped) =
   ## Starts a new subtree of kind `k`.
   assert not isAtom(k)
   if bu.parent != -1:

--- a/passes/builders.nim
+++ b/passes/builders.nim
@@ -1,0 +1,40 @@
+## Implements an API for building a `PackedTree <builder.html#PackedTree>`_.
+
+import
+  passes/trees
+
+type
+  Builder*[T] = object
+    buf: seq[TreeNode[T]]
+    parent {.requiresInit.}: int
+      ## the index of the current subtree node to which to add new nodes to
+
+func initBuilder*[T](buf: sink seq[TreeNode[T]]): Builder[T] =
+  ## Sets up a builder with an initial buffer (`buf`).
+  Builder[T](buf: buf, parent: -1)
+
+func initBuilder*[T](): Builder[T] =
+  Builder[T](parent: -1)
+
+template open*[T](bu: var Builder[T], k: T, body: untyped) =
+  ## Starts a new subtree of kind `k`.
+  assert not isAtom(k)
+  if bu.parent != -1:
+    inc bu.buf[bu.parent].val
+
+  if true: # open a new scope but don't interfere with break statements
+    var parent = bu.buf.len
+    swap(bu.parent, parent)
+    bu.buf.add TreeNode[T](kind: k)
+    body
+    swap(bu.parent, parent)
+
+func add*[T](bu: var Builder[T], n: TreeNode[T]) =
+  ## Appends atomic node `n` to the current subtree.
+  assert isAtom(n.kind)
+  inc bu.buf[bu.parent].val
+  bu.buf.add n
+
+func finish*[T](bu: sink Builder[T]): seq[TreeNode[T]] =
+  ## Finishes building the tree and returns the node buffer.
+  result = bu.buf

--- a/passes/changesets.nim
+++ b/passes/changesets.nim
@@ -44,7 +44,7 @@ template replace*[T](c: var ChangeSet[T], n: NodeIndex, k: T,
       at = n # uphold the expected evaluation order
       start = c.nodes.len
     var bu {.inject.} = initBuilder(c.nodes)
-    bu.open(k): body
+    bu.subTree(k): body
     c.nodes = finish(bu)
 
     c.actions.add Action[T](at: at, kind: Replace,
@@ -72,7 +72,7 @@ template insert*[T](c: var ChangeSet[T], tree: PackedTree[T], n: NodeIndex,
       idx = i
       start = c.nodes.len
     var bu {.inject.} = initBuilder(c.nodes)
-    bu.open(k): body
+    bu.subTree(k): body
     c.nodes = finish(bu)
 
     c.actions.add Action[T](at: at, kind: ChangeLen, by: 1)

--- a/passes/changesets.nim
+++ b/passes/changesets.nim
@@ -1,0 +1,119 @@
+## Implements the `ChangeSet <#ChangeSet>`_ API, which provides an efficient
+## facility for modifying trees. The idea is to separate computation of what
+## to modify with actually performing the modification.
+
+import
+  std/algorithm,
+  passes/trees
+
+type
+  ActionKind = enum
+    ChangeKind ## change the kind of a node
+    ChangeLen  ## change the length of a subtree
+    Skip       ## skip over the subtree at the source cursor
+    Insert     ## insert a new tree; source cursor doesn't change
+    Replace    ## Insert + Skip
+
+  Action[T] = object
+    at: NodeIndex
+    case kind: ActionKind
+    of ChangeKind:
+      newKind: T
+    of ChangeLen:
+      by: uint32
+    of Insert, Replace:
+      slice: Slice[int] ## region from the temporary buffer
+    of Skip:
+      discard
+
+  ChangeSet*[T] = object
+    nodes: seq[TreeNode[T]]
+    actions: seq[Action[T]]
+
+func changeKind*[T](c: var ChangeSet[T], n: NodeIndex, kind: T) =
+  ## Records changing the kind of node `n` to `kind`.
+  c.actions.add Action[T](at: n, kind: ChangeKind, newKind: kind)
+
+template replace*[T](c: var ChangeSet[T], n: NodeIndex, k: T,
+                     body: untyped) =
+  ## Records replacing the node/subtree at `n` with a new tree of kind `k`. The
+  ## new tree is built by `body`, with a builder named ``bu`` injected into the
+  ## scope.
+  if true:
+    let
+      at = n # uphold the expected evaluation order
+      start = c.nodes.len
+    var bu {.inject.} = initBuilder(c.nodes)
+    bu.open(k): body
+    c.nodes = finish(bu)
+
+    c.actions.add Action[T](at: at, kind: Replace,
+                            slice: start .. c.nodes.high)
+
+func replace*[T](c: var ChangeSet[T], n: NodeIndex, with: TreeNode[T]) =
+  ## Records replacing the node/subtree at `n` with `with`.
+  c.actions.add Action[T](at: n, kind: Replace,
+                          slice: c.nodes.len .. c.nodes.len)
+  c.nodes.add with
+
+func remove*[T](c: var ChangeSet[T], tree: PackedTree[T], n: NodeIndex, i: int) =
+  ## Records the removal of the `i`-th node from `n`.
+  c.actions.add Action[T](at: n, kind: ChangeLen, by: 0xFFFF_FFFF'u32) # -1
+  c.actions.add Action[T](at: tree.child(n, i), kind: Skip)
+
+template insert*[T](c: var ChangeSet[T], tree: PackedTree[T], n: NodeIndex,
+                    i: int, k: T, body: untyped) =
+  ## Records the insertion of a new subtree at the `i`-th child node of `n`.
+  ## A builder named `bu` is injected into the scope `body` is evaluated
+  ## within.
+  if true:
+    let
+      at = n
+      idx = i
+      start = c.nodes.len
+    var bu {.inject.} = initBuilder(c.nodes)
+    bu.open(k): body
+    c.nodes = finish(bu)
+
+    c.actions.add Action[T](at: at, kind: ChangeLen, by: 1)
+    c.actions.add Action[T](at: tree.child(at, idx), kind: Insert,
+                            slice: start .. c.nodes.high)
+
+func apply*[T](tree: PackedTree[T], c: sink ChangeSet[T]): PackedTree[T] =
+  ## Applies the changeset `c` to `tree`.
+  # sort the actions by source position:
+  sort(c.actions, proc(a, b: auto): int =
+    a.at.int - b.at.int
+  )
+
+  var source = 0 ## cursor into the source node sequence
+  for it in c.actions.items:
+    if it.at.int > source:
+      result.nodes.add toOpenArray(tree.nodes, source, it.at.int - 1)
+      source = it.at.int # move to the action position
+
+    case it.kind
+    of ChangeKind:
+      var n = tree[it.at]
+      n.kind = it.newKind
+      result.nodes.add n
+      inc source
+    of ChangeLen:
+      # multiple "change length" actions per node are supported; only copy
+      # the target node once
+      if source <= it.at.int:
+        result.nodes.add tree[it.at]
+        inc source
+
+      result.nodes[^1].val += it.by
+    of Skip:
+      source = tree.next(it.at).int
+    of Insert:
+      result.nodes.add c.nodes.toOpenArray(it.slice.a, it.slice.b)
+    of Replace:
+      source = tree.next(it.at).int
+      result.nodes.add c.nodes.toOpenArray(it.slice.a, it.slice.b)
+
+  # copy the remaining nodes, if any:
+  if source < tree.nodes.len:
+    result.nodes.add toOpenArray(tree.nodes, source, tree.nodes.high)

--- a/passes/debugutils.nim
+++ b/passes/debugutils.nim
@@ -1,0 +1,27 @@
+## Implements routines and helpers for debugging and rendering packed trees.
+
+import
+  std/[strutils],
+  passes/[trees]
+
+proc render(t: PackedTree, i: NodeIndex, indent: int, result: var string) =
+  mixin isAtom
+  if i.int >= t.nodes.len:
+    # don't crash for malformed trees
+    return
+
+  var line = repeat("  ", indent) & $t[i].kind
+  if isAtom(t[i].kind):
+    line.add " "
+    line.addInt t[i].val
+    result.add line & '\n'
+  else:
+    result.add line & '\n'
+    # render all child nodes:
+    for it in t.items(i):
+      render(t, it, indent + 1, result)
+
+proc treeRepr*(t: PackedTree): string =
+  ## Returns a multi-line tree representation of `t`. The output is meant to be
+  ## usable as test output, and the format should thus stay stable.
+  render(t, NodeIndex(0), 0, result)

--- a/passes/debugutils.nim
+++ b/passes/debugutils.nim
@@ -2,6 +2,7 @@
 
 import
   std/[strutils],
+  experimental/[sexp],
   passes/[trees]
 
 proc render(t: PackedTree, i: NodeIndex, indent: int, result: var string) =
@@ -25,3 +26,41 @@ proc treeRepr*(t: PackedTree): string =
   ## Returns a multi-line tree representation of `t`. The output is meant to be
   ## usable as test output, and the format should thus stay stable.
   render(t, NodeIndex(0), 0, result)
+
+proc toPretty(result: var string, t: PackedTree, n: NodeIndex, indent: int) =
+  mixin isAtom
+  if isAtom(t[n].kind):
+    result.add $toSexp(t, n)
+  else:
+    result.add "("
+    result.add $t[n].kind
+
+    let L = t.len(n)
+    var
+      n = t.child(n, 0)
+      i = 0
+
+    # all simple nodes can be placed on the same line as the parenthesis
+    while i < L and (isAtom(t[n].kind) or t.len(n) == 0):
+      result.add(" ")
+      toPretty(result, t, n, indent)
+      inc i
+      n = t.next(n)
+
+    let isMultiLine = i < L
+    # the rest goes onto new lines:
+    while i < L:
+      result.add "\n"
+      result.add repeat("  ", indent + 1)
+      toPretty(result, t, n, indent + 1)
+      inc i
+      n = t.next(n)
+
+    if isMultiLine:
+      result.add "\n"
+      result.add repeat("  ", indent)
+    result.add ")"
+
+proc pretty*(t: PackedTree, n: NodeIndex): string =
+  ## Returns a multi-line textual S-expression representation of `t`.
+  toPretty(result, t, n, 0)

--- a/passes/lang1.md
+++ b/passes/lang1.md
@@ -10,7 +10,7 @@ Blob types describe arbitrarily-sized untyped binary data:
 type += (Blob size:<int>)
 ```
 
-The `Addr` operation takes applies to locals instead of address offsets. Only
+The `Addr` operation only applies to locals instead of address offsets. Only
 blob locals are allowed as `Addr` operands.
 
 ```grammar

--- a/passes/lang1.md
+++ b/passes/lang1.md
@@ -1,0 +1,35 @@
+## L1 Language
+
+```grammar
+.extends lang0
+```
+
+Blob types describe arbitrarily-sized untyped binary data:
+
+```grammar
+type += (Blob size:<int>)
+```
+
+The `Addr` operation takes applies to locals instead of address offsets. Only
+blob locals are allowed as `Addr` operands.
+
+```grammar
+rvalue -= (Addr (IntVal <int>))
+rvalue += (Addr <local>)
+```
+
+Each continuation names the locals alive for the duration of it:
+
+```grammar
+continuation -= (Continuation (Params) stack:<int> <stmt>* <exit>)
+              | (Subroutine (Params) stack:<int> <stmt>* <exit>)
+              | (Except <local> stack:<int> <stmt>* <exit>)
+
+continuation += (Continuation (Params) (Locals <local>*) <stmt>* <exit>)
+              | (Subroutine (Params) (Locals <local>*) <stmt>* <exit>)
+              | (Except <local> (Locals <local>*) <stmt>* <exit>)
+```
+
+*Rationale:* the lowering pass can focus stack allocation, without having to a
+perform control-flow analysis for computing the set of alive locals for each
+continuation.

--- a/passes/lang1.md
+++ b/passes/lang1.md
@@ -18,6 +18,11 @@ rvalue -= (Addr (IntVal <int>))
 rvalue += (Addr <local>)
 ```
 
+Locals of `Blob` type cannot be anywhere except for `Addr` operands. The `Blob`
+type is also disallowed for parameters or the return type of procedures.
+
+*Rationale:* keeps the pass simpler.
+
 Each continuation names the locals alive for the duration of it:
 
 ```grammar

--- a/passes/pass1.nim
+++ b/passes/pass1.nim
@@ -1,0 +1,80 @@
+## Lowers |L1| into |L0|. This means:
+## * turning locals of ``Blob`` type into local pointers
+## * computing the stack-space required for each continuation
+
+import
+  std/[tables],
+  passes/[builders, changesets, spec, trees]
+
+type
+  Node = TreeNode[NodeKind]
+
+using
+  tree: PackedTree[NodeKind]
+
+func typ(n: Node): int =
+  assert n.kind == Type
+  result = n.val.int
+
+func id(n: Node): int =
+  result = n.val.int
+
+proc lower(c: var ChangeSet[NodeKind], tree; n: NodeIndex) =
+  ## Computes the changeset representing the lowering for a procedure (`n`).
+  var locals = initTable[int, int]() ## local ID -> stack upper-bound
+
+  # compute the stack layout and the locals in stack memory and emit the
+  # address initialization
+  var stack = 0
+  for i, it in tree.pairs(tree.child(n, 1)):
+    let typ = tree.child(tree.child(0), tree[it].typ)
+    if tree[typ].kind == Blob:
+      # the blob local is turned into an address local storing the real
+      # address. The address is assigned at the very start of the
+      # procedure
+      # TODO: assign the address in the first continuation that uses the local.
+      #       This reduces run-time overhead when the local is not used
+      c.insert(tree, tree.child(tree.child(n, 2), 0), 2, Asgn):
+        bu.add Node(kind: Local, val: i.uint32)
+        bu.subTree(Addr):
+          bu.add Node(kind: IntVal, val: stack.uint32)
+
+      stack += tree[typ, 0].val.int
+      locals[i] = stack
+
+  # TODO: make the stack allocator smarter. Take into account which locals are
+  #       alive at the same time. For example, if two blob locals are never
+  #       alive concurrently, they can re-use the same memory region
+
+  for it in tree.items(tree.child(n, 2)):
+    if tree.len(it) > 1:
+      # compute the maximum amount of stack space required:
+      var maxStack = 0
+      for it in tree.items(tree.child(it, 1)):
+        maxStack = max(maxStack, locals.getOrDefault(tree[it].id, 0))
+
+      # replace the list of locals with the required stack space:
+      c.replace(tree.child(it, 1), Node(kind: Immediate, val: maxStack.uint32))
+
+      # ``(Addr (Local x))`` -> ``(Copy (Local x))``
+      for it in tree.flat(it):
+        if tree[it].kind == Addr:
+          c.replace(it, Copy):
+            bu.add tree[it, 0]
+
+proc lower*(tree; ptrSize: int): ChangeSet[NodeKind] =
+  ## Computes the changeset representing the lowering for a whole module
+  ## (`tree`). `ptrSize` is the size-in-bytes of a pointer value.
+
+  # lower the blob types. They're turned into pointer types
+  for it in tree.items(tree.child(0)):
+    if tree[it].kind == Blob:
+      # TODO: re-use a single pointer type, though this will require patching
+      #       all used types. It might be better to introduce a ``None`` type,
+      #       and leave mapping type IDs to ``pass0``
+      result.replace(it, UInt):
+        bu.add Node(kind: Immediate, val: uint32 ptrSize)
+
+  # lower the procedures:
+  for it in tree.items(tree.child(2)):
+    lower(result, tree, it)

--- a/passes/spec.nim
+++ b/passes/spec.nim
@@ -12,7 +12,7 @@ type
   NodeKind* = enum
     Immediate, IntVal, FloatVal, ProcVal, Proc, Type, Local, Global
 
-    Void, Int, UInt, Float, ProcTy
+    Void, Int, UInt, Float, ProcTy, Blob
 
     Copy, Asgn, Drop, Clear
 

--- a/passes/trees.nim
+++ b/passes/trees.nim
@@ -101,6 +101,19 @@ iterator pairs*(t: PackedTree, at: NodeIndex): (int, NodeIndex) =
     yield (i, n)
     n = t.next(n)
 
+iterator flat*(t: PackedTree, at: NodeIndex): NodeIndex =
+  ## Returns all nodes spanned by the tree node at `at`, including `at`
+  ## itself.
+  mixin isAtom
+  var
+    i = uint32(at)
+    last = i
+  while i <= last:
+    yield NodeIndex(i)
+    if not isAtom(t.nodes[i].kind):
+      last += t.nodes[i].val
+    inc i
+
 func pair*(tree: PackedTree, n: NodeIndex): (NodeIndex, NodeIndex) =
   ## Returns the index of the first and second subnode of `n`.
   result[0] = tree.child(n, 0)

--- a/passes/trees.nim
+++ b/passes/trees.nim
@@ -15,7 +15,7 @@ type
 
   PackedTree*[T] = object
     ## Stores a node tree packed together in a single sequence.
-    nodes: seq[TreeNode[T]]
+    nodes*: seq[TreeNode[T]]
     numbers: seq[uint64]
     # TODO: use a BiTable for the numbers
 

--- a/tests/pass1/runner.nim
+++ b/tests/pass1/runner.nim
@@ -1,0 +1,68 @@
+## The test runner for the pass1 tests.
+
+import
+  std/[
+    os,
+    streams,
+    strutils
+  ],
+  experimental/[
+    sexp
+  ],
+  passes/[
+    changesets,
+    debugutils,
+    pass0,
+    pass1,
+    spec,
+    trees
+  ],
+  vm/[
+    vm,
+    vmenv,
+    vmvalidation,
+  ]
+
+let
+  args = getExecArgs()
+  s    = openFileStream(args[^1], fmRead)
+
+# skip the test specification:
+if s.readLine() == "discard \"\"\"":
+  while not s.readLine().endsWith("\"\"\""):
+    discard
+else:
+  s.setPosition(0)
+
+var tree = fromSexp[NodeKind](parseSexp("(Module " & readAll(s) & ")"))
+s.close()
+
+let transformation = pass1.lower(tree, 8)
+tree = tree.apply(transformation)
+
+# output the lowered code:
+# TODO: output the *difference* (as an S-expression) instead; it's much easier
+#       to process for the human reader
+writeFile(changeFileExt(args[^1], "expected"), treeRepr(tree))
+stdout.write(treeRepr(tree))
+
+# translate to VM bytecode:
+var env = initVm(1024, 1024 * 1024)
+translate(tree, env)
+
+# make sure the environment is correct:
+let errors = validate(env)
+if errors.len > 0:
+  for it in errors.items:
+    echo it
+  echo "validation failure"
+  quit(1)
+
+var
+  thread = vm.initThread(env, env.procs.high.ProcIndex, 1024, @[])
+  res = run(env, thread, nil)
+env.dispose(move thread)
+
+if res.kind != yrkDone:
+  echo "expected successful execution, but got: ", res
+  quit(1)

--- a/tests/pass1/runner.nim
+++ b/tests/pass1/runner.nim
@@ -41,10 +41,12 @@ let transformation = pass1.lower(tree, 8)
 tree = tree.apply(transformation)
 
 # output the lowered code:
-# TODO: output the *difference* (as an S-expression) instead; it's much easier
-#       to process for the human reader
-writeFile(changeFileExt(args[^1], "expected"), treeRepr(tree))
-stdout.write(treeRepr(tree))
+# TODO: instead of the whole tree, only the *difference* (as an S-expression)
+#       should be returned, which would make it easier for a human reader to
+#       validate the output
+stdout.writeLine(pretty(tree, tree.child(0)))
+stdout.writeLine(pretty(tree, tree.child(1)))
+stdout.writeLine(pretty(tree, tree.child(2)))
 
 # translate to VM bytecode:
 var env = initVm(1024, 1024 * 1024)

--- a/tests/pass1/t01_basic.expected
+++ b/tests/pass1/t01_basic.expected
@@ -1,0 +1,27 @@
+Module
+  TypeDefs
+    UInt
+      Immediate 8
+    ProcTy
+      Void
+  GlobalDefs
+  ProcDefs
+    ProcDef
+      Type 1
+      Locals
+        Type 0
+      Continuations
+        Continuation
+          Params
+          Immediate 16
+          Asgn
+            Local 0
+            Addr
+              IntVal 0
+          Drop
+            Copy
+              Local 1
+          Continue
+            Immediate 1
+        Continuation
+          Params

--- a/tests/pass1/t01_basic.expected
+++ b/tests/pass1/t01_basic.expected
@@ -1,27 +1,22 @@
-Module
-  TypeDefs
-    UInt
-      Immediate 8
-    ProcTy
-      Void
-  GlobalDefs
-  ProcDefs
-    ProcDef
-      Type 1
-      Locals
-        Type 0
-      Continuations
-        Continuation
-          Params
-          Immediate 16
-          Asgn
-            Local 0
-            Addr
-              IntVal 0
-          Drop
-            Copy
-              Local 1
-          Continue
-            Immediate 1
-        Continuation
-          Params
+(TypeDefs
+  (UInt 8)
+  (ProcTy (Void))
+)
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Locals (Type 0))
+    (Continuations
+      (Continuation (Params) 16
+        (Asgn (Local 0)
+          (Addr (IntVal 0))
+        )
+        (Drop
+          (Copy (Local 1))
+        )
+        (Continue 1)
+      )
+      (Continuation (Params))
+    )
+  )
+)

--- a/tests/pass1/t01_basic.test
+++ b/tests/pass1/t01_basic.test
@@ -1,0 +1,22 @@
+discard """
+  description: "Test a single continuation with a single blob local"
+"""
+(TypeDefs
+  (Blob 16)
+  (ProcTy (Void))
+)
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Locals
+      (Type 0)
+    )
+    (Continuations
+      (Continuation (Params) (Locals (Local 0))
+        (Drop (Addr (Local 1)))
+        (Continue 1)
+      )
+      (Continuation (Params))
+    )
+  )
+)

--- a/tests/pass1/t02_multiple_locals.expected
+++ b/tests/pass1/t02_multiple_locals.expected
@@ -1,0 +1,29 @@
+Module
+  TypeDefs
+    UInt
+      Immediate 8
+    ProcTy
+      Void
+  GlobalDefs
+  ProcDefs
+    ProcDef
+      Type 1
+      Locals
+        Type 0
+        Type 0
+      Continuations
+        Continuation
+          Params
+          Immediate 32
+          Asgn
+            Local 0
+            Addr
+              IntVal 0
+          Asgn
+            Local 1
+            Addr
+              IntVal 16
+          Continue
+            Immediate 1
+        Continuation
+          Params

--- a/tests/pass1/t02_multiple_locals.expected
+++ b/tests/pass1/t02_multiple_locals.expected
@@ -1,29 +1,22 @@
-Module
-  TypeDefs
-    UInt
-      Immediate 8
-    ProcTy
-      Void
-  GlobalDefs
-  ProcDefs
-    ProcDef
-      Type 1
-      Locals
-        Type 0
-        Type 0
-      Continuations
-        Continuation
-          Params
-          Immediate 32
-          Asgn
-            Local 0
-            Addr
-              IntVal 0
-          Asgn
-            Local 1
-            Addr
-              IntVal 16
-          Continue
-            Immediate 1
-        Continuation
-          Params
+(TypeDefs
+  (UInt 8)
+  (ProcTy (Void))
+)
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Locals (Type 0) (Type 0))
+    (Continuations
+      (Continuation (Params) 32
+        (Asgn (Local 0)
+          (Addr (IntVal 0))
+        )
+        (Asgn (Local 1)
+          (Addr (IntVal 16))
+        )
+        (Continue 1)
+      )
+      (Continuation (Params))
+    )
+  )
+)

--- a/tests/pass1/t02_multiple_locals.test
+++ b/tests/pass1/t02_multiple_locals.test
@@ -1,0 +1,22 @@
+discard """
+  description: "Test a single continuation with more than one blob local"
+"""
+(TypeDefs
+  (Blob 16)
+  (ProcTy (Void))
+)
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Locals
+      (Type 0)
+      (Type 0)
+    )
+    (Continuations
+      (Continuation (Params) (Locals (Local 0) (Local 1))
+        (Continue 1)
+      )
+      (Continuation (Params))
+    )
+  )
+)

--- a/tests/pass1/t03_multiple_continuations.expected
+++ b/tests/pass1/t03_multiple_continuations.expected
@@ -1,39 +1,28 @@
-Module
-  TypeDefs
-    UInt
-      Immediate 8
-    ProcTy
-      Void
-  GlobalDefs
-  ProcDefs
-    ProcDef
-      Type 1
-      Locals
-        Type 0
-        Type 0
-      Continuations
-        Continuation
-          Params
-          Immediate 16
-          Asgn
-            Local 0
-            Addr
-              IntVal 0
-          Asgn
-            Local 1
-            Addr
-              IntVal 16
-          Continue
-            Immediate 1
-        Continuation
-          Params
-          Immediate 32
-          Continue
-            Immediate 2
-        Continuation
-          Params
-          Immediate 32
-          Continue
-            Immediate 3
-        Continuation
-          Params
+(TypeDefs
+  (UInt 8)
+  (ProcTy (Void))
+)
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Locals (Type 0) (Type 0))
+    (Continuations
+      (Continuation (Params) 16
+        (Asgn (Local 0)
+          (Addr (IntVal 0))
+        )
+        (Asgn (Local 1)
+          (Addr (IntVal 16))
+        )
+        (Continue 1)
+      )
+      (Continuation (Params) 32
+        (Continue 2)
+      )
+      (Continuation (Params) 32
+        (Continue 3)
+      )
+      (Continuation (Params))
+    )
+  )
+)

--- a/tests/pass1/t03_multiple_continuations.expected
+++ b/tests/pass1/t03_multiple_continuations.expected
@@ -1,0 +1,39 @@
+Module
+  TypeDefs
+    UInt
+      Immediate 8
+    ProcTy
+      Void
+  GlobalDefs
+  ProcDefs
+    ProcDef
+      Type 1
+      Locals
+        Type 0
+        Type 0
+      Continuations
+        Continuation
+          Params
+          Immediate 16
+          Asgn
+            Local 0
+            Addr
+              IntVal 0
+          Asgn
+            Local 1
+            Addr
+              IntVal 16
+          Continue
+            Immediate 1
+        Continuation
+          Params
+          Immediate 32
+          Continue
+            Immediate 2
+        Continuation
+          Params
+          Immediate 32
+          Continue
+            Immediate 3
+        Continuation
+          Params

--- a/tests/pass1/t03_multiple_continuations.test
+++ b/tests/pass1/t03_multiple_continuations.test
@@ -1,0 +1,30 @@
+discard """
+  description: "
+    Test a linear continuation sequence where there's more than one blob local
+  "
+"""
+(TypeDefs
+  (Blob 16)
+  (ProcTy (Void))
+)
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Locals
+      (Type 0)
+      (Type 0)
+    )
+    (Continuations
+      (Continuation (Params) (Locals (Local 0))
+        (Continue 1)
+      )
+      (Continuation (Params) (Locals (Local 0) (Local 1))
+        (Continue 2)
+      )
+      (Continuation (Params) (Locals (Local 1))
+        (Continue 3)
+      )
+      (Continuation (Params))
+    )
+  )
+)

--- a/tests/pass1/t04_split_control.expected
+++ b/tests/pass1/t04_split_control.expected
@@ -1,53 +1,37 @@
-Module
-  TypeDefs
-    UInt
-      Immediate 8
-    ProcTy
-      Void
-  GlobalDefs
-  ProcDefs
-    ProcDef
-      Type 1
-      Locals
-        Type 0
-        Type 0
-        Type 0
-      Continuations
-        Continuation
-          Params
-          Immediate 0
-          Asgn
-            Local 0
-            Addr
-              IntVal 0
-          Asgn
-            Local 1
-            Addr
-              IntVal 16
-          Asgn
-            Local 2
-            Addr
-              IntVal 32
-          SelectBool
-            IntVal 1
-            Continue
-              Immediate 1
-            Continue
-              Immediate 2
-        Continuation
-          Params
-          Immediate 16
-          Continue
-            Immediate 3
-        Continuation
-          Params
-          Immediate 32
-          Continue
-            Immediate 3
-        Continuation
-          Params
-          Immediate 48
-          Continue
-            Immediate 4
-        Continuation
-          Params
+(TypeDefs
+  (UInt 8)
+  (ProcTy (Void))
+)
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Locals (Type 0) (Type 0) (Type 0))
+    (Continuations
+      (Continuation (Params) 0
+        (Asgn (Local 0)
+          (Addr (IntVal 0))
+        )
+        (Asgn (Local 1)
+          (Addr (IntVal 16))
+        )
+        (Asgn (Local 2)
+          (Addr (IntVal 32))
+        )
+        (SelectBool (IntVal 1)
+          (Continue 1)
+          (Continue 2)
+        )
+      )
+      (Continuation (Params) 16
+        (Continue 3)
+      )
+      (Continuation (Params) 32
+        (Continue 3)
+      )
+      (Continuation (Params) 48
+        (Continue 4)
+      )
+      (Continuation (Params))
+    )
+  )
+)

--- a/tests/pass1/t04_split_control.expected
+++ b/tests/pass1/t04_split_control.expected
@@ -1,0 +1,53 @@
+Module
+  TypeDefs
+    UInt
+      Immediate 8
+    ProcTy
+      Void
+  GlobalDefs
+  ProcDefs
+    ProcDef
+      Type 1
+      Locals
+        Type 0
+        Type 0
+        Type 0
+      Continuations
+        Continuation
+          Params
+          Immediate 0
+          Asgn
+            Local 0
+            Addr
+              IntVal 0
+          Asgn
+            Local 1
+            Addr
+              IntVal 16
+          Asgn
+            Local 2
+            Addr
+              IntVal 32
+          SelectBool
+            IntVal 1
+            Continue
+              Immediate 1
+            Continue
+              Immediate 2
+        Continuation
+          Params
+          Immediate 16
+          Continue
+            Immediate 3
+        Continuation
+          Params
+          Immediate 32
+          Continue
+            Immediate 3
+        Continuation
+          Params
+          Immediate 48
+          Continue
+            Immediate 4
+        Continuation
+          Params

--- a/tests/pass1/t04_split_control.test
+++ b/tests/pass1/t04_split_control.test
@@ -1,0 +1,32 @@
+discard """
+  description: "Test with split control-flow paths"
+"""
+(TypeDefs
+  (Blob 16)
+  (ProcTy (Void))
+)
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Locals
+      (Type 0)
+      (Type 0)
+      (Type 0)
+    )
+    (Continuations
+      (Continuation (Params) (Locals)
+        (SelectBool (IntVal 1) (Continue 1) (Continue 2))
+      )
+      (Continuation (Params) (Locals (Local 0))
+        (Continue 3)
+      )
+      (Continuation (Params) (Locals (Local 1))
+        (Continue 3)
+      )
+      (Continuation (Params) (Locals (Local 2))
+        (Continue 4)
+      )
+      (Continuation (Params))
+    )
+  )
+)

--- a/tools/tester.nim
+++ b/tools/tester.nim
@@ -68,6 +68,9 @@ proc exec(cmd: string, args: openArray[string]): tuple[output: string,
       result.output.setLen(start + len)
       copyMem(addr result.output[start], addr buf[0], len)
 
+  # read the remaining output, if any:
+  result.output.add readAll(stream)
+
   result.code = p.peekExitCode()
   p.close()
 


### PR DESCRIPTION
## Summary

The `L1` language extends the lower-level `L0` language with an
arbitrarily-sized binary data type (`Blob` type).

## Details

Since languages are currently designed bottom-to-top (i.e., lower-level
to higher-level), the higher-level language extends the lower-level
language, rather than the other way around (i.e., how it is described
in the design document).

The L1 -> L0 lowering is intended to focus on stack layout and
allocation; the `Blob` is a generalization of all aggregate data-types,
of which the exact in-memory layout is irrelevant at this stage.

The current implementation of the lowering focuses only on correctness,
with the chosen stack layout being as simple as it gets.

### Misc

Fix a bug with the output stream draining in `tester`, which led to
the output returned from `exec` sometimes being cut off (and thus test
output comparisons to fail).