### PR TITLE
koch: remove `disasm` from program list

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -16,10 +16,7 @@ Commands:
   single <name> [args]        builds the single program with the given name
 """
   Programs: seq[(string, string)] = @[
-    ("tester", "tools/tester.nim"),
-    ("disasm", "vm/disasm.nim")
-    # XXX: ^^ not a real program; only here temporarily to make sure it
-    #      compiles
+    ("tester", "tools/tester.nim")
   ]
 
 var


### PR DESCRIPTION
It's not a tool, and making sure it compiles is done through the
`pass0` test runner (which imports the disassembler).