### PR TITLE
implement a tool for verifying language grammars

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -89,4 +89,4 @@ jobs:
 
       # run the passtool for the highest-level language:
       - name: "Check the grammar"
-        run: bin/passtool passes lang0
+        run: bin/passtool passes lang1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -65,3 +65,28 @@ jobs:
 
       - name: "Run tests"
         run: bin/tester
+
+  languages:
+    name: "Check and generate languages"
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: tree:0
+
+      # always use the most recent NimSkull version
+      - uses: nim-works/setup-nimskull@0.1.2
+        with:
+          nimskull-version: "*"
+
+      - name: Build koch
+        run: nim c -d:nimStrictMode --outdir:bin koch.nim
+
+      - name: Build passtool
+        run: bin/koch single passtool -d:nimStrictMode -d:release
+
+      # run the passtool for the highest-level language:
+      - name: "Check the grammar"
+        run: bin/passtool passes lang0

--- a/koch.nim
+++ b/koch.nim
@@ -17,9 +17,10 @@ Commands:
 """
   Programs: seq[(string, string)] = @[
     ("tester", "tools/tester.nim"),
-    ("disasm", "vm/disasm.nim")
+    ("disasm", "vm/disasm.nim"),
     # XXX: ^^ not a real program; only here temporarily to make sure it
     #      compiles
+    ("passtool", "tools/passtool/passtool.nim")
   ]
 
 var

--- a/passes/design.md
+++ b/passes/design.md
@@ -28,11 +28,11 @@ RuleCore ::= SexpMatcher | Reference | (Identifier ':' Rule)
 Rule ::= RuleCore ('*' | '+' | '?')?
 SexprRule ::= '(' Identifier Rule* ')'
 
-TopRule = Reference | SexprRule
+Production = Reference | SexprRule
 
-Def ::= Identifier '::=' TopMatcher ('|' TopMatcher)*
-Append ::= Identifier '+=' TopMatcher ('|' TopMatcher)*
-Remove ::= Identifier '-=' TopMatcher ('|' TopMatcher)*
+Def ::= Identifier '::=' Production ('|' Production)*
+Append ::= Identifier '+=' Production ('|' Production)*
+Remove ::= Identifier '-=' Production ('|' Production)*
 
 Top ::= ('.extends' Identifier)? (Def | Append | Remove)*
 ```

--- a/tools/passtool/grammar.nim
+++ b/tools/passtool/grammar.nim
@@ -1,0 +1,84 @@
+## Type definitions and associated helper procedures for the grammar IR.
+
+import
+  std/[tables, strutils]
+
+type
+  Repeat* = enum
+    rOnce
+    rZeroOrOne
+    rZeroOrMore
+    rOneOrMore
+
+  SourcePos* = tuple
+    file, line, col: uint16
+
+  Rule* = object
+    pos*: SourcePos
+      ## the source position
+    name*: string
+      ## an optional name for the rule
+    repeat*: Repeat
+      ## how many times the expression may repeat
+    expr*: Expr
+
+  Expr* = object
+    pos*: SourcePos
+    name*: string
+      ## name of the reference, or symbol of the S-expression
+    case isRef*: bool
+    of false:
+      rules*: seq[Rule]
+    of true:
+      discard
+
+  Production* = object
+    source*: string
+      ## name of the language the production comes from
+    expr*: Expr
+
+  Grammar* = OrderedTable[string, seq[Production]]
+
+proc `$`*(e: Expr): string
+
+proc `$`*(r: Rule): string =
+  if r.name.len > 0:
+    result.add r.name
+    result.add ":"
+
+  result.add $r.expr
+  case r.repeat
+  of rOnce:
+    discard "nothing to do"
+  of rOneOrMore:
+    result.add "+"
+  of rZeroOrOne:
+    result.add "?"
+  of rZeroOrMore:
+    result.add "*"
+
+proc `$`*(e: Expr): string =
+  case e.isRef
+  of false:
+    result.add '('
+    result.add e.name
+    for it in e.rules.items:
+      result.add ' '
+      result.add $it
+    result.add ')'
+  of true:
+    result.add '<'
+    result.add e.name
+    result.add '>'
+
+proc `$`*(g: Grammar): string =
+  for name, it in g.pairs:
+    result.add name
+    result.add " ::= "
+    let offset = name.len + 2
+    # format the productions in an easy-to-read way:
+    for i, rule in it.pairs:
+      if i > 0:
+        result.add "\n" & repeat(' ', offset) & "|  "
+      result.add $rule.expr
+    result.add "\n"

--- a/tools/passtool/parser.nim
+++ b/tools/passtool/parser.nim
@@ -1,0 +1,338 @@
+## Implements the lexer and parser for the rule grammar.
+
+import
+  std/[lexbase, streams, strformat, strutils]
+
+type
+  TokenKind = enum
+    tkError
+    tkEos # end-of-stream
+    tkNewline
+    tkSpace
+    tkParensLe, tkParensRi
+    tkDot
+    tkIdent
+    tkColon
+    tkEq
+    tkPlus
+    tkMinusEq
+    tkQMark
+    tkStar
+    tkSharpLe, tkSharpRi
+    tkSeparator
+
+  Token = object
+    line, col: int
+    case kind: TokenKind
+    of tkIdent, tkError:
+      str: string
+    else:
+      discard
+
+  Lexer* {.final.} = object of BaseLexer
+    curr: Token
+    currLine, currCol: int
+
+  ParserError = object of ValueError
+
+  RuleKind* = enum
+    Reference, SExpr
+    Named
+    ZeroOrMore, OneOrMore, Optional
+
+  ParsedRule* = object
+    line*: int
+    col*: int
+    kind*: RuleKind
+    # for simplicity, don't use a variant object
+    sym*: string
+    sub*: seq[ParsedRule]
+
+  ParsedKind* = enum
+    pkError
+    pkImport
+    pkDef
+    pkAppend
+    pkRemove
+
+  Parsed* = object
+    ## A parsed item.
+    line*: int
+    col*: int
+    kind*: ParsedKind
+    name*: string
+    prod*: seq[ParsedRule]
+
+proc seek(L: var Lexer): bool =
+  ## Seeks to the start of the next grammar section. Returns true if one was
+  ## found, false otherwise.
+  const Start = "```grammar"
+  while true:
+    case L.buf[L.bufpos]
+    of '\r':
+      L.bufpos = L.handleCR(L.bufpos)
+    of '\n':
+      L.bufpos = L.handleLF(L.bufpos)
+    of '\0':
+      return false # end of stream
+    of '`':
+      if L.bufpos + Start.len <= L.buf.len:
+        block compare:
+          for i in 1..<Start.len:
+            if L.buf[L.bufpos + i] != Start[i]:
+              break compare
+
+          inc L.bufpos, Start.len
+          return true # found a start
+
+      inc L.bufpos
+    else:
+      inc L.bufpos
+
+proc open*(L: var Lexer, stream: Stream) =
+  open(BaseLexer(L), stream)
+
+proc openWithMarkdown*(L: var Lexer, stream: Stream) =
+  ## Opens the lexer with the content of a Markdown file.
+  open(L, stream)
+  discard seek(L) # seek to the first section
+
+proc close*(L: sink Lexer) =
+  close(BaseLexer(L))
+
+proc sequence(L: var Lexer, kind: TokenKind, str: static string): Token =
+  if L.bufpos + str.len <= L.buf.len:
+    for i in 1..<str.len:
+      if L.buf[L.bufpos + i] != str[i]:
+        return Token(kind: tkError,
+                     str: "unexpected character: " & $L.buf[L.bufpos + i])
+
+    inc L.bufpos, str.len
+    result = Token(kind: kind)
+  else:
+    result = Token(kind: tkError,
+                   str: "unexpected character: " & $L.buf[L.bufpos + 1])
+
+proc getTok(L: var Lexer): TokenKind =
+  ## Produces the next token from the input stream and updates the current
+  ## token of `L`.
+  template single(k: TokenKind) =
+    inc L.bufpos
+    L.curr = Token(kind: k)
+
+  # update the current line/column before consuming the token:
+  L.currLine = L.lineNumber
+  L.currCol = BaseLexer(L).getColNumber(L.bufpos) + 1
+
+  case L.buf[L.bufpos]
+  of ' ', '\t': single(tkSpace)
+  of '<': single(tkSharpLe)
+  of '>': single(tkSharpRi)
+  of '|': single(tkSeparator)
+  of '?': single(tkQMark)
+  of '*': single(tkStar)
+  of '(': single(tkParensLe)
+  of ')': single(tkParensRi)
+  of '.': single(tkDot)
+  of '+': single(tkPlus)
+  of '=': single(tkEq)
+  of ':': single(tkColon)
+  of '-':
+    L.curr = sequence(L, tkMinusEq, "-=")
+  of '\n':
+    L.curr = Token(kind: tkNewline)
+    L.bufpos = L.handleLF(L.bufpos)
+  of '\r':
+    L.curr = Token(kind: tkNewline)
+    L.bufpos = L.handleCR(L.bufpos)
+  of '#':
+    # comments are treated as empty space for simplicity
+    inc L.bufpos
+    while L.buf[L.bufpos] notin {'\n', '\r', '\0'}:
+      inc L.bufpos
+    L.curr = Token(kind: tkSpace)
+  of 'a'..'z', 'A'..'Z':
+    var str = ""
+    str.add L.buf[L.bufpos]
+    inc L.bufpos
+    while L.buf[L.bufpos] in {'a'..'z', 'A'..'Z', '_', '0'..'9'}:
+      str.add L.buf[L.bufpos]
+      inc L.bufpos
+    L.curr = Token(kind: tkIdent, str: str)
+  of '\0':
+    L.curr = Token(kind: tkEos)
+  of '`':
+    # must be the end of the markdown code block
+    inc L.bufpos
+    if L.seek():
+      L.curr = Token(kind: tkNewline) # counts as a newline
+    else:
+      L.curr = Token(kind: tkEos)
+  else:
+    L.curr = Token(kind: tkError,
+                   str: "unexpected character: " & $L.buf[L.bufpos])
+
+  result = L.curr.kind
+
+proc space(L: var Lexer) =
+  while L.curr.kind == tkSpace:
+    discard L.getTok()
+
+proc error(L: Lexer, expected: TokenKind): ref ParserError =
+  ParserError.newException(fmt"expected {expected} but got {L.curr.kind}")
+
+proc consumeIdent(L: var Lexer): string =
+  result = move L.curr.str
+  discard L.getTok()
+
+proc expect(L: Lexer, kind: TokenKind) =
+  ## Expects the current token to be of `kind`, raising an error if that's
+  ## not the case.
+  if L.curr.kind != kind:
+    raise L.error(kind)
+
+proc skip(L: var Lexer, kind: TokenKind) =
+  ## Skips the current token if of `kind`; raises an error otherwise.
+  L.expect(kind)
+  discard L.getTok()
+
+proc expectNext(L: var Lexer, kind: TokenKind) =
+  if L.getTok() != kind:
+    raise L.error(kind)
+
+proc unexpected(L: Lexer) =
+  if L.curr.kind == tkError:
+    raise ParserError.newException(L.curr.str)
+  else:
+    raise ParserError.newException("unexpected token: " & $L.curr.kind)
+
+proc parseRuleCore(L: var Lexer): ParsedRule
+
+proc parseRule(L: var Lexer): ParsedRule =
+  result = parseRuleCore(L)
+  case L.curr.kind
+  of tkPlus:
+    discard L.getTok()
+    result = ParsedRule(kind: OneOrMore, sub: @[result])
+  of tkStar:
+    discard L.getTok()
+    result = ParsedRule(kind: ZeroOrMore, sub: @[result])
+  of tkQMark:
+    discard L.getTok()
+    result = ParsedRule(kind: Optional, sub: @[result])
+  else:
+    discard "okay, not part of the rule"
+
+proc parseRuleCore(L: var Lexer): ParsedRule =
+  result = ParsedRule(line: L.currLine, col: L.currCol)
+  case L.curr.kind
+  of tkSharpLe:
+    L.expectNext(tkIdent)
+    result.kind = Reference
+    result.sym = toLowerAscii L.consumeIdent()
+    L.skip(tkSharpRi)
+  of tkParensLe:
+    discard L.getTok()
+    L.space()
+    L.expect(tkIdent)
+    result.kind = SExpr
+    result.sym = L.consumeIdent()
+    L.space()
+    while L.curr.kind notin {tkParensRi, tkEos}:
+      result.sub.add parseRule(L)
+      L.space()
+    L.skip(tkParensRi)
+  of tkIdent:
+    result.kind = Named
+    result.sym = L.consumeIdent()
+    L.skip(tkColon)
+    result.sub.add parseRule(L)
+  else:
+    L.unexpected()
+
+proc makeParsed(L: Lexer, kind: ParsedKind, name: sink string): Parsed =
+  Parsed(line: L.currLine, col: L.currCol, kind: kind, name: name)
+
+proc parseNamedRule(L: var Lexer): Parsed =
+  L.space()
+  L.expect(tkIdent)
+  result = L.makeParsed(pkDef, toLowerAscii L.consumeIdent())
+  L.space()
+  case L.curr.kind
+  of tkColon:
+    L.expectNext(tkColon)
+    L.expectNext(tkEq)
+    result.kind = pkDef
+  of tkPlus:
+    L.expectNext(tkEq)
+    result.kind = pkAppend
+  of tkMinusEq:
+    result.kind = pkRemove
+  else:
+    L.unexpected()
+
+  discard L.getTok()
+
+  L.space()
+  while true:
+    result.prod.add parseRuleCore(L)
+    L.space()
+    # skip newlines. If there's a space following the newline, the next
+    # line is treated as a continuation of the current one
+    if L.curr.kind in {tkNewline, tkEos} and L.getTok() != tkSpace:
+      break
+
+    L.space()
+    L.skip(tkSeparator)
+    L.space()
+
+proc parseDirective(L: var Lexer): Parsed =
+  ## Parses a directive.
+  L.skip(tkDot)
+  L.expect(tkIdent)
+  # detect the directive in the parser already; it's simpler
+  let dir = L.consumeIdent()
+  case dir
+  of "extends":
+    L.space()
+    L.makeParsed(pkImport, L.consumeIdent())
+  else:
+    L.makeParsed(pkError, "unknown directive: " & dir)
+
+proc parseTopLevel(L: var Lexer): Parsed =
+  ## Parses a top-level item.
+  case L.curr.kind
+  of tkDot:
+    try:
+      L.parseDirective()
+    except ParserError as e:
+      L.makeParsed(pkError, e.msg)
+  of tkIdent:
+    try:
+      L.parseNamedRule()
+    except ParserError as e:
+      L.makeParsed(pkError, e.msg)
+  of tkError:
+    L.makeParsed(pkError, L.curr.str)
+  else:
+    L.makeParsed(pkError, "unexpected token: " & $L.curr.kind)
+
+iterator parse*(L: var Lexer): Parsed =
+  ## Produces and parses the tokens from `L` until an error is encounted or
+  ## the end of stream is reached. The parsed items are returned.
+  discard L.getTok()
+  # skip empty space:
+  while L.curr.kind in {tkNewline, tkSpace}:
+    discard L.getTok()
+
+  var stop = false
+  while L.curr.kind != tkEos and not stop:
+    L.space()
+    let parsed = parseTopLevel(L)
+    # stop after an error:
+    stop = parsed.kind == pkError
+    yield parsed
+
+    # skip empty space:
+    while L.curr.kind in {tkNewline, tkSpace}:
+      discard L.getTok()

--- a/tools/passtool/parser.nim
+++ b/tools/passtool/parser.nim
@@ -18,7 +18,7 @@ type
     tkMinusEq
     tkQMark
     tkStar
-    tkSharpLe, tkSharpRi
+    tkAngleLe, tkAngleRi
     tkSeparator
 
   Token = object
@@ -126,8 +126,8 @@ proc getTok(L: var Lexer): TokenKind =
 
   case L.buf[L.bufpos]
   of ' ', '\t': single(tkSpace)
-  of '<': single(tkSharpLe)
-  of '>': single(tkSharpRi)
+  of '<': single(tkAngleLe)
+  of '>': single(tkAngleRi)
   of '|': single(tkSeparator)
   of '?': single(tkQMark)
   of '*': single(tkStar)
@@ -226,11 +226,11 @@ proc parseRule(L: var Lexer): ParsedRule =
 proc parseRuleCore(L: var Lexer): ParsedRule =
   result = ParsedRule(line: L.currLine, col: L.currCol)
   case L.curr.kind
-  of tkSharpLe:
+  of tkAngleLe:
     L.expectNext(tkIdent)
     result.kind = Reference
     result.sym = toLowerAscii L.consumeIdent()
-    L.skip(tkSharpRi)
+    L.skip(tkAngleRi)
   of tkParensLe:
     discard L.getTok()
     L.space()

--- a/tools/passtool/passtool.nim
+++ b/tools/passtool/passtool.nim
@@ -1,0 +1,31 @@
+## A tool that extracts the language grammars from Markdown files, verifies
+## that the grammar and diffs are sound, and generates the run-time
+## verification logic and type definitions (if requested).
+
+import
+  std/[os],
+  experimental/[colortext],
+  sem
+
+proc main(args: openArray[string]) =
+  if args.len != 2:
+    echo "usage: passtool <dir> <langname>"
+    quit(1)
+
+  var
+    langs: Languages
+    errors: Errors
+
+  # parse and analyse the provided file:
+  sem(args[1], args[0], langs, errors)
+
+  if errors.hasErrors:
+    for source, it in errors.items:
+      echo source, " [Error] " + fgRed, it
+
+    quit(1)
+
+  # TODO: implement the rest of the passtool's features, such as the code
+  #       generation mentioned above
+
+main(getExecArgs())

--- a/tools/passtool/sem.nim
+++ b/tools/passtool/sem.nim
@@ -1,0 +1,217 @@
+## Implements the semantic analysis for the parsed rules.
+
+import
+  std/[os, streams, tables],
+  grammar,
+  parser
+
+type
+  Errors* = object
+    ## Accumulates errors during analysis of grammar.
+    files: seq[string]
+      ## list of file paths; indexed into by SourcePos
+    errors: seq[tuple[pos: SourcePos, str: string]]
+
+    currFile: uint16
+      ## index of the current file
+
+  Languages* = Table[string, Grammar]
+
+proc emit(e: var Errors, pos: SourcePos, str: sink string) =
+  e.errors.add (pos, str)
+
+proc emit(e: var Errors, line, col: int, str: sink string) =
+  e.errors.add ((e.currFile, line.uint16, col.uint16), str)
+
+proc hasErrors*(e: Errors): bool =
+  ## Returns whether there were any errors.
+  e.errors.len > 0
+
+iterator items*(e: Errors): tuple[file, val: string] =
+  ## Returns all errors recorded with `e`.
+  for it in e.errors.items:
+    yield (e.files[it.pos.file] & "(" & $it.pos.line & ", " & $it.pos.col & ")",
+           it.str)
+
+proc semExpr(e: ParsedRule, errors: var Errors): Expr
+
+proc semRule(rule: var Rule, e: ParsedRule, errors: var Errors) =
+  case e.kind
+  of SExpr, Reference:
+    rule.expr = semExpr(e, errors)
+  of OneOrMore:
+    rule.repeat = rOneOrMore
+    rule.expr = semExpr(e.sub[0], errors)
+  of ZeroOrMore:
+    rule.repeat = rZeroOrMore
+    rule.expr = semExpr(e.sub[0], errors)
+  of Optional:
+    rule.repeat = rZeroOrOne
+    rule.expr = semExpr(e.sub[0], errors)
+  of Named:
+    errors.emit(e.line, e.col, "named expressions not allowed here")
+
+proc semExpr(e: ParsedRule, errors: var Errors): Expr =
+  case e.kind
+  of SExpr:
+    result = Expr(isRef: false, name: e.sym)
+    for it in e.sub.items:
+      var rule: Rule
+      if it.kind == Named:
+        rule.name = it.sym
+        semRule(rule, it.sub[0], errors)
+      else:
+        semRule(rule, it, errors)
+
+      result.rules.add rule
+  of Reference:
+    result = Expr(isRef: true, name: e.sym)
+    # forward references are allowed, so whether a rule with the given name
+    # exists cannot be checked here
+  else:
+    errors.emit(e.line, e.col, "unexpected: " & $e.kind)
+
+  result.pos = (errors.currFile, e.line.uint16, e.col.uint16)
+
+proc verify(lang: Grammar, e: Expr, errors: var Errors) =
+  ## Makes sure all references name existing rules, emitting errors for those
+  ## that don't.
+  case e.isRef
+  of true:
+    if e.name notin lang and e.name notin ["int", "float"]:
+      errors.emit(e.pos, "no rule with name " & e.name & " exists")
+  of false:
+    for it in e.rules.items:
+      verify(lang, it.expr, errors)
+
+proc isEqual(a, b: Expr, strict: bool): bool =
+  ## Compares two expressions for structural equality. If `strict` is true,
+  ## the names (if any) assigned to rule expressions also have to match.
+  if a.isRef != b.isRef or a.name != b.name:
+    return false
+
+  case a.isRef
+  of true:
+    result = true
+  of false:
+    if a.rules.len == b.rules.len:
+      for i, it in a.rules.pairs:
+        let o = b.rules[i]
+        # a sub-expression doesn't match -> the expressions are not equal
+        if (strict and it.name != o.name) or it.repeat != o.repeat or
+           not isEqual(it.expr, o.expr, strict):
+          return false
+
+      result = true
+    else:
+      result = false
+
+proc find(p: seq[Production], e: Expr): int =
+  ## Returns the index of a production that's equal to `e`, or -1, if none is
+  ## found.
+  for i, it in p.pairs:
+    # ignore the names of expressions when comparing expressions:
+    if isEqual(it.expr, e, strict=false):
+      return i
+
+  result = -1
+
+proc remove(p: var seq[Production], e: Expr, errors: var Errors) =
+  ## Subtracts `e` from the set of `p`. If no matching production exists,
+  ## an error is emitted.
+  let i = find(p, e)
+  if i != -1:
+    p.delete(i)
+  else:
+    errors.emit(e.pos, "missing rule: " & $e)
+
+proc add(p: var seq[Production], e: sink Production, errors: var Errors) =
+  ## Adds `e` to the set of productions `p`, reporting an error if this would
+  ## result in a duplicate.
+  let i = find(p, e.expr)
+  # TODO: also make sure that the production does not lead to ambiguity
+  if i == -1:
+    p.add e
+  else:
+    errors.emit(e.expr.pos):
+      "production '" & $e.expr & "' already exists, registered by " &
+      p[i].source
+
+proc sem*(name, dir: string, langs: var Languages, errors: var Errors)
+
+proc sem(parsed: seq[Parsed], name, dir: string, langs: var Languages,
+         errors: var Errors) =
+  ## Analyses the parsed items, which means checking the parsed rules and
+  ## productions for semantic errors and translating them into the grammar IR.
+  var lang = default(Grammar)
+
+  for it in parsed.items:
+    case it.kind
+    of pkDef:
+      if it.name in lang:
+        errors.emit(it.line, it.col, "redefinition of " & it.name)
+      elif it.name in ["int", "float"]:
+        errors.emit(it.line, it.col):
+          it.name & " is already the name of a built-in rule"
+      else:
+        var p: seq[Production]
+        for r in it.prod.items:
+          add(p, Production(source: name, expr: semExpr(r, errors)), errors)
+
+        lang[it.name] = p
+    of pkAppend:
+      if it.name in lang:
+        # append the given productions to the existing rule:
+        for r in it.prod.items:
+          let e = Production(source: name, expr: semExpr(r, errors))
+          add(lang[it.name], e, errors)
+      else:
+        errors.emit(it.line, it.col, "no rule with name: " & it.name)
+    of pkRemove:
+      if it.name in lang:
+        # remove the given productions from the existing rule:
+        for r in it.prod.items:
+          remove(lang[it.name], semExpr(r, errors), errors)
+      else:
+        errors.emit(it.line, it.col, "no rule with name: " & it.name)
+    of pkError:
+      errors.emit(it.line, it.col, "parser error: " & it.name)
+    of pkImport:
+      sem(it.name, dir, langs, errors)
+      if lang.len > 0:
+        errors.emit(it.line, it.col):
+          "cannot extend language when there's already rules defined"
+      else:
+        # inherit the full grammar:
+        lang = langs[it.name]
+
+  for it in lang.values:
+    for e in it.items:
+      verify(lang, e.expr, errors)
+
+  # add the language grammar to the table:
+  langs[name] = lang
+
+proc parseAll(file: string): seq[Parsed] =
+  ## Opens the given ``.md`` file and extracts and parses all ``grammar``
+  ## sections.
+  var f = openFileStream(file, fmRead)
+  var L = Lexer()
+  openWithMarkdown(L, f)
+  for p in L.parse():
+    result.add p
+  close(L)
+
+proc sem*(name, dir: string, langs: var Languages, errors: var Errors) =
+  ## Parses the file containing the grammar for the language with the given
+  ## `name`, analyzes the result, and registers the language in `langs`. Errors
+  ## are recorded to `errors`.
+  let
+    file = changeFileExt(dir / name, ".md")
+    parsed = parseAll(file)
+
+  # register the file:
+  errors.currFile = errors.files.len.uint16
+  errors.files.add file
+
+  sem(parsed, name, dir, langs, errors)


### PR DESCRIPTION
The `passtool` currently only performs some basic checks (i.e., whether
all references name existing rules and that no duplicate productions
are introduced).

In the future, it'll also provide code-generation facilities for
automating the creation of validation layers for languages. The idea is
to reduced the overhead of removing, changing, or adding new
intermediate languages as much as possible.

The tool is ran as part of CI to make sure all language grammars are
valid.