### PR TITLE
add string support for grammars and `PackedTree`

### DIFF
--- a/passes/changesets.nim
+++ b/passes/changesets.nim
@@ -129,4 +129,4 @@ func apply*[T](tree: PackedTree[T], c: sink ChangeSet[T]): PackedTree[T] =
   if source < tree.nodes.len:
     nodes.add toOpenArray(tree.nodes, source, tree.nodes.high)
 
-  result = initTree(nodes, tree.numbers)
+  result = initTree(nodes, tree.literals)

--- a/passes/design.md
+++ b/passes/design.md
@@ -39,8 +39,9 @@ Top ::= ('.extends' Identifier)? (Def | Append | Remove)*
 
 A `Def` defines a named rule, an `Append` appends to an existing named rule,
 and a `Remove` removes the given rule(s) from the named rule. A `Reference`
-is a reference to another named rule. There are two special references: `<int>`
-and `<float>`. They refer to a literal integer and float value, respectively.
+is a reference to another named rule. There are three special references:
+`<int>`, `<float>`, and `<string>`. They refer to literal integer, float, and
+string values, respectively.
 
 The idea is to use S-expressions as the serialization format (it's both human
 readable and writable); basing the language definition on S-expressions

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -84,4 +84,4 @@ proc exprToIL*(t: InTree): (TypeKind, PackedTree[NodeKind]) =
             bu.subTree Params:
               bu.add Node(kind: Type, val: 0)
 
-  result = (typ, initTree(bu.finish(), t.numbers))
+  result = (typ, initTree(bu.finish(), t.literals))

--- a/tools/passtool/sem.nim
+++ b/tools/passtool/sem.nim
@@ -78,7 +78,7 @@ proc verify(lang: Grammar, e: Expr, errors: var Errors) =
   ## that don't.
   case e.isRef
   of true:
-    if e.name notin lang and e.name notin ["int", "float"]:
+    if e.name notin lang and e.name notin ["int", "float", "string"]:
       errors.emit(e.pos, "no rule with name " & e.name & " exists")
   of false:
     for it in e.rules.items:
@@ -150,7 +150,7 @@ proc sem(parsed: seq[Parsed], name, dir: string, langs: var Languages,
     of pkDef:
       if it.name in lang:
         errors.emit(it.line, it.col, "redefinition of " & it.name)
-      elif it.name in ["int", "float"]:
+      elif it.name in ["int", "float", "string"]:
         errors.emit(it.line, it.col):
           it.name & " is already the name of a built-in rule"
       else:


### PR DESCRIPTION
## Summary

* add the built-in `<string>` matcher for language grammars
* support `PackedTree` storing `string` values

---

## Note For Reviewers
* a prerequisite for more progress on the source language (e.g., strings are needed for identifiers)