### PR TITLE
lang: add integer/float subtraction and addition

### DIFF
--- a/passes/builders.nim
+++ b/passes/builders.nim
@@ -16,6 +16,10 @@ func initBuilder*[T](buf: sink seq[TreeNode[T]]): Builder[T] =
 func initBuilder*[T](): Builder[T] =
   Builder[T](parent: -1)
 
+func initBuilder*[T](nk: T): Builder[T] =
+  assert not isAtom(nk)
+  Builder[T](buf: @[TreeNode[T](kind: nk)], parent: 0)
+
 template subTree*[T](bu: var Builder[T], k: T, body: untyped) =
   ## Starts a new subtree of kind `k`.
   assert not isAtom(k)
@@ -32,8 +36,17 @@ template subTree*[T](bu: var Builder[T], k: T, body: untyped) =
 func add*[T](bu: var Builder[T], n: TreeNode[T]) =
   ## Appends atomic node `n` to the current subtree.
   assert isAtom(n.kind)
-  inc bu.buf[bu.parent].val
+  if bu.parent != -1:
+    inc bu.buf[bu.parent].val
   bu.buf.add n
+
+func add*[T](bu: var Builder[T], nodes: openArray[TreeNode[T]]) =
+  ## Appends all `nodes` to the current sub-tree. The nodes must either
+  ## represent a single atomic node, or a complete subtree.
+  assert nodes.len > 0
+  if bu.parent != -1:
+    inc bu.buf[bu.parent].val
+  bu.buf.add nodes
 
 func copyFrom*[T](bu: var Builder[T], tree: PackedTree[T], n: NodeIndex) =
   ## Inserts the whole subtree from `tree` at `n` at the current buffer

--- a/passes/lang_source.md
+++ b/passes/lang_source.md
@@ -5,6 +5,9 @@ of the parse-tree, not the grammar of the textual representation (i.e., how
 the parse-tree is constructed from tokens).
 
 ```grammar
+ident ::= (Ident <string>)
+
 expr ::= (IntVal <int>)
       |  (FloatVal <float>)
+      |  (Call <ident> <expr>*)
 ```

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -10,21 +10,41 @@ import
   passes/[builders, spec, trees],
   vm/[utils]
 
-from passes/spec_source import nil
+import passes/spec_source except NodeKind
 
 type
   SourceKind = spec_source.NodeKind
   InTree     = PackedTree[SourceKind]
   Node       = TreeNode[NodeKind]
+  NodeSeq    = seq[Node]
 
   TypeKind* = enum
+    tkError
     tkInt
     tkFloat
 
+  Context = object
+    types: Builder[NodeKind]
+      ## the in-progress type section
+    numTypes: int
+
 using
+  c: var Context
   bu: var Builder[NodeKind]
 
-proc exprToIL(t: InTree, n: NodeIndex, bu): TypeKind =
+template addType(c; kind: NodeKind, body: untyped): uint32 =
+  c.types.subTree kind:
+    body
+  (let r = c.numTypes; inc c.numTypes; r.uint32)
+
+proc exprToIL(c; t: InTree, n: NodeIndex, bu): TypeKind
+
+proc exprToIL(c; t: InTree, n: NodeIndex): (NodeSeq, TypeKind) =
+  var bu = initBuilder[NodeKind]()
+  result[1] = exprToIL(c, t, n, bu)
+  result[0] = finish(bu)
+
+proc exprToIL(c; t: InTree, n: NodeIndex, bu): TypeKind =
   case t[n].kind
   of SourceKind.IntVal:
     bu.add Node(kind: IntVal, val: t[n].val)
@@ -32,44 +52,74 @@ proc exprToIL(t: InTree, n: NodeIndex, bu): TypeKind =
   of SourceKind.FloatVal:
     bu.add Node(kind: FloatVal, val: t[n].val)
     result = tkFloat
-  of spec_source.AllNodes - spec_source.ExprNodes:
+  of SourceKind.Call:
+    if t.len(n) == 3:
+      # only binary operations are supported at the moment
+      let (name, a, b) = triplet(t, n)
+      var op: NodeKind
+      case t.getString(name)
+      of "+": op = Add
+      of "-": op = Sub
+      else:
+        # TODO: proper error reporting is missing
+        bu.add Node(kind: IntVal, val: 0) # add at least something
+        return tkError
+
+      let
+        (eA, typA) = exprToIL(c, t, a)
+        (eB, typB) = exprToIL(c, t, b)
+
+      if typA == typB and typA != tkError:
+        let typ =
+          if typA == tkInt:
+            c.addType Int:
+              c.types.add Node(kind: Immediate, val: 8)
+          else:
+            c.addType Float:
+              c.types.add Node(kind: Immediate, val: 8)
+
+        bu.subTree op:
+          bu.add Node(kind: Type, val: typ)
+          bu.add eA
+          bu.add eB
+
+        result = typA
+      else:
+        bu.add Node(kind: IntVal, val: 0) # add at least something
+        result = tkError
+    else:
+      bu.add Node(kind: IntVal, val: 0) # add at least something
+      result = tkError
+  of AllNodes - ExprNodes:
     unreachable()
 
 proc exprToIL*(t: InTree): (TypeKind, PackedTree[NodeKind]) =
   ## Translates the given source language expression to the highest-level IL.
   ## Also returns the type of the expression.
-  var typ: TypeKind
-  block:
-    # we need to know the type of the expression, so we translate the
-    # expression using a temporary builder first
-    var bu = initBuilder[NodeKind]()
-    bu.subTree Module:
-      typ = exprToIL(t, NodeIndex(0), bu)
-    # XXX: this is bad. The Changeset/Builder API needs to support
-    #      placeholders, where one can insert placeholders, with the
-    #      actual subtree being created separately
+  var c = Context(types: initBuilder[NodeKind](TypeDefs))
+
+  let
+    (e, typ) = exprToIL(c, t, NodeIndex(0))
+    typId =
+      case typ
+      of tkInt, tkError:
+        c.addType Int: c.types.add(Node(kind: Immediate, val: 8))
+      of tkFloat:
+        c.addType Float: c.types.add(Node(kind: Immediate, val: 8))
+
+    ptypId = c.addType ProcTy:
+      c.types.add Node(kind: Type, val: typId)
 
   var bu = initBuilder[NodeKind]()
-
   bu.subTree Module:
-    bu.subTree TypeDefs:
-      case typ
-      of tkInt:
-        bu.subTree Int:
-          bu.add Node(kind: Immediate, val: 8)
-      else:
-        bu.subTree Float:
-          bu.add Node(kind: Immediate, val: 8)
-
-      bu.subTree ProcTy:
-        bu.add Node(kind: Type, val: 0)
+    bu.add finish(move c.types)
 
     bu.subTree GlobalDefs:
       discard
 
     bu.subTree ProcDefs:
       bu.subTree ProcDef:
-        bu.add Node(kind: Type, val: 1)
+        bu.add Node(kind: Type, val: ptypId)
         bu.subTree Locals: discard
         bu.subTree Continuations:
           bu.subTree Continuation:
@@ -77,11 +127,11 @@ proc exprToIL*(t: InTree): (TypeKind, PackedTree[NodeKind]) =
             bu.subTree Locals: discard
             bu.subTree Continue:
               bu.add Node(kind: Immediate, val: 1)
-              # the actual expression is placed as a parameter to the Continue:
-              discard exprToIL(t, NodeIndex(0), bu)
+              # the expression is placed as an argument to the Continue:
+              bu.add e
 
           bu.subTree Continuation:
             bu.subTree Params:
-              bu.add Node(kind: Type, val: 0)
+              bu.add Node(kind: Type, val: typId)
 
   result = (typ, initTree(bu.finish(), t.literals))

--- a/passes/spec.nim
+++ b/passes/spec.nim
@@ -49,11 +49,12 @@ proc fromSexp*(tree: var PackedTree[NodeKind], kind: NodeKind,
   else:
     unreachable()
 
-proc toSexp*(n: TreeNode[NodeKind]): SexpNode =
+proc toSexp*(tree: PackedTree[NodeKind], idx: NodeIndex,
+             n: TreeNode[NodeKind]): SexpNode =
   case n.kind
   of Immediate: sexp(n.val.int)
-  of IntVal:    sexp([newSSymbol("IntVal"), sexp n.val.int])
-  of FloatVal:  sexp([newSSymbol("FloatVal"), sexp n.val.int])
+  of IntVal:    sexp([newSSymbol("IntVal"), sexp tree.getInt(idx)])
+  of FloatVal:  sexp([newSSymbol("FloatVal"), sexp tree.getFloat(idx)])
   of ProcVal:   sexp([newSSymbol("ProcVal"), sexp n.val.int])
   of Proc:      sexp([newSSymbol("Proc"), sexp n.val.int])
   of Type:      sexp([newSSymbol("Type"), sexp n.val.int])

--- a/passes/spec_source.nim
+++ b/passes/spec_source.nim
@@ -28,11 +28,12 @@ proc fromSexp*(tree: var PackedTree[NodeKind], kind: NodeKind,
   else:
     unreachable()
 
-proc toSexp*(n: TreeNode[NodeKind]): SexpNode =
+proc toSexp*(tree: PackedTree[NodeKind], idx: NodeIndex,
+             n: TreeNode[NodeKind]): SexpNode =
   case n.kind
   of Immediate: sexp(n.val.int)
-  of IntVal:    sexp([newSSymbol("IntVal"), sexp n.val.int])
-  of FloatVal:  sexp([newSSymbol("FloatVal"), sexp n.val.int])
+  of IntVal:    sexp([newSSymbol("IntVal"), sexp tree.getInt(idx)])
+  of FloatVal:  sexp([newSSymbol("FloatVal"), sexp tree.getFloat(idx)])
 
 proc fromSexp*(i: BiggestInt): TreeNode[NodeKind] =
   TreeNode[NodeKind](kind: Immediate, val: i.uint32)

--- a/passes/spec_source.nim
+++ b/passes/spec_source.nim
@@ -10,13 +10,15 @@ import
 type
   NodeKind* {.pure.} = enum
     Immediate, IntVal, FloatVal
+    Ident
+    Call
 
 const
-  ExprNodes* = {IntVal, FloatVal}
+  ExprNodes* = {IntVal, FloatVal, Call}
   AllNodes* = {low(NodeKind) .. high(NodeKind)}
 
 template isAtom*(x: NodeKind): bool =
-  ord(x) <= ord(FloatVal)
+  ord(x) <= ord(Ident)
 
 proc fromSexp*(tree: var PackedTree[NodeKind], kind: NodeKind,
                n: SexpNode): TreeNode[NodeKind] =
@@ -25,6 +27,8 @@ proc fromSexp*(tree: var PackedTree[NodeKind], kind: NodeKind,
     TreeNode[NodeKind](kind: kind, val: tree.pack(n[1].num))
   of FloatVal:
     TreeNode[NodeKind](kind: FloatVal, val: tree.pack(n[1].fnum))
+  of Ident:
+    TreeNode[NodeKind](kind: Ident, val: tree.pack(n[1].str))
   else:
     unreachable()
 
@@ -34,6 +38,8 @@ proc toSexp*(tree: PackedTree[NodeKind], idx: NodeIndex,
   of Immediate: sexp(n.val.int)
   of IntVal:    sexp([newSSymbol("IntVal"), sexp tree.getInt(idx)])
   of FloatVal:  sexp([newSSymbol("FloatVal"), sexp tree.getFloat(idx)])
+  of Ident:     sexp([newSSymbol("Ident"), sexp tree.getString(idx)])
+  else:         unreachable()
 
 proc fromSexp*(i: BiggestInt): TreeNode[NodeKind] =
   TreeNode[NodeKind](kind: Immediate, val: i.uint32)

--- a/passes/trees.nim
+++ b/passes/trees.nim
@@ -185,7 +185,7 @@ func literals*(tree: PackedTree): lent Literals {.inline.} =
 proc toSexp*[T](tree: PackedTree[T], at: NodeIndex): SexpNode =
   mixin isAtom, toSexp
   if isAtom(tree[at].kind):
-    result = toSexp(tree[at])
+    result = toSexp(tree, at, tree[at])
   else:
     result = newSList()
     result.add newSSymbol($tree[at].kind)

--- a/tests/expr/runner.nim
+++ b/tests/expr/runner.nim
@@ -18,6 +18,7 @@ import
     trees
   ],
   vm/[
+    utils,
     vm,
     vmenv,
     vmvalidation
@@ -36,6 +37,10 @@ else:
 
 # parse the S-expression and translate the source language to the L1:
 var (typ, tree) = exprToIL(fromSexp[NodeKind](parseSexp(readAll(s))))
+# don't continue if there was an error:
+if typ == tkError:
+  quit(0)
+
 # lower to the L0 language:
 tree = tree.apply(pass1.lower(tree, 8))
 
@@ -67,3 +72,5 @@ of tkInt:
   stdout.write($res.result.intVal & ": int")
 of tkFloat:
   stdout.write($res.result.floatVal & ": float")
+of tkError:
+  unreachable()

--- a/tests/expr/runner.nim
+++ b/tests/expr/runner.nim
@@ -39,7 +39,8 @@ else:
 var (typ, tree) = exprToIL(fromSexp[NodeKind](parseSexp(readAll(s))))
 # don't continue if there was an error:
 if typ == tkError:
-  quit(0)
+  echo "exprToIL failed"
+  quit(1)
 
 # lower to the L0 language:
 tree = tree.apply(pass1.lower(tree, 8))

--- a/tests/expr/t02_add_float_values.test
+++ b/tests/expr/t02_add_float_values.test
@@ -1,0 +1,4 @@
+discard """
+  output: "4.0: float"
+"""
+(Call (Ident "+") (FloatVal 1.5) (FloatVal 2.5))

--- a/tests/expr/t02_add_integer_values.test
+++ b/tests/expr/t02_add_integer_values.test
@@ -1,0 +1,4 @@
+discard """
+  output: "3: int"
+"""
+(Call (Ident "+") (IntVal 1) (IntVal 2))

--- a/tests/expr/t02_sub_float_values.test
+++ b/tests/expr/t02_sub_float_values.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-1.0: float"
+"""
+(Call (Ident "-") (FloatVal 1.5) (FloatVal 2.5))

--- a/tests/expr/t02_sub_integer_values.test
+++ b/tests/expr/t02_sub_integer_values.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-1: int"
+"""
+(Call (Ident "-") (IntVal 1) (IntVal 2))

--- a/tests/expr/t03_nested_calls.test
+++ b/tests/expr/t03_nested_calls.test
@@ -1,0 +1,6 @@
+discard """
+  output: "10: int"
+"""
+(Call (Ident "+")
+  (Call (Ident "+") (IntVal 1) (IntVal 2))
+  (Call (Ident "+") (IntVal 3) (IntVal 4)))


### PR DESCRIPTION
## Summary

* add grammar for calls and identifiers to the source language
* add addition and subtraction for integers and floats

## Details

### Source2IL

* implement support for `+` and `-` calls; the names are currently
  hard-coded
* add very basic error handling/propagation via `tkError`
* replace the double translation of expressions with using a temporary
  buffer; it's simpler, faster, and more convenient

### Builder

* extend with `add` overload for appending raw node sequences
* support adding leaf nodes without there being an enclosing sub-tree

### Misc

* support packed integers and floats for S-expression serialization
