### PR TITLE
tester: support S-expr output comparison

### DIFF
--- a/tests/pass1/t01_basic.expected
+++ b/tests/pass1/t01_basic.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (UInt 8)
   (ProcTy (Void))

--- a/tests/pass1/t02_multiple_locals.expected
+++ b/tests/pass1/t02_multiple_locals.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (UInt 8)
   (ProcTy (Void))

--- a/tests/pass1/t03_multiple_continuations.expected
+++ b/tests/pass1/t03_multiple_continuations.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (UInt 8)
   (ProcTy (Void))

--- a/tests/pass1/t04_split_control.expected
+++ b/tests/pass1/t04_split_control.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (UInt 8)
   (ProcTy (Void))

--- a/tests/pass3/t01_array_type.expected
+++ b/tests/pass3/t01_array_type.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 4)
   (Blob 8)

--- a/tests/pass3/t01_record_type.expected
+++ b/tests/pass3/t01_record_type.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 4)
   (Blob 16)

--- a/tests/pass3/t02_addr_of_at.expected
+++ b/tests/pass3/t02_addr_of_at.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 4)
   (Blob 8)

--- a/tests/pass3/t02_addr_of_field.expected
+++ b/tests/pass3/t02_addr_of_field.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 4)
   (Blob 8)

--- a/tests/pass3/t02_asgn_with_at.expected
+++ b/tests/pass3/t02_asgn_with_at.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 4)
   (Blob 8)

--- a/tests/pass3/t02_asgn_with_field.expected
+++ b/tests/pass3/t02_asgn_with_field.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 4)
   (Blob 8)

--- a/tests/pass3/t02_load_with_at.expected
+++ b/tests/pass3/t02_load_with_at.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 4)
   (Blob 8)

--- a/tests/pass3/t02_load_with_field.expected
+++ b/tests/pass3/t02_load_with_field.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 4)
   (Blob 8)

--- a/tests/pass3/t03_at_indirect.expected
+++ b/tests/pass3/t03_at_indirect.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 4)
   (Blob 8)

--- a/tests/pass3/t03_field_indirect.expected
+++ b/tests/pass3/t03_field_indirect.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 4)
   (Blob 8)

--- a/tests/pass4/t01_spawn.expected
+++ b/tests/pass4/t01_spawn.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void))

--- a/tests/pass4/t02_different_types.expected
+++ b/tests/pass4/t02_different_types.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (UInt 8)

--- a/tests/pass4/t02_move.expected
+++ b/tests/pass4/t02_move.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void))

--- a/tests/pass4/t02_proc_parameters.expected
+++ b/tests/pass4/t02_proc_parameters.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void) (Type 0) (Type 0))

--- a/tests/pass4/t02_rename_simple.expected
+++ b/tests/pass4/t02_rename_simple.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void))

--- a/tests/pass4/t02_return_local.expected
+++ b/tests/pass4/t02_return_local.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Type 0))

--- a/tests/pass4/t03_checked_call_asgn.expected
+++ b/tests/pass4/t03_checked_call_asgn.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Type 0))

--- a/tests/pass4/t03_continue_with_value.expected
+++ b/tests/pass4/t03_continue_with_value.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void))

--- a/tests/pass4/t03_join.expected
+++ b/tests/pass4/t03_join.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void))

--- a/tests/pass4/t03_join_cross.expected
+++ b/tests/pass4/t03_join_cross.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void))

--- a/tests/pass4/t03_join_multi.expected
+++ b/tests/pass4/t03_join_multi.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void))

--- a/tests/pass4/t03_join_same.expected
+++ b/tests/pass4/t03_join_same.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void))

--- a/tests/pass4/t03_rename.expected
+++ b/tests/pass4/t03_rename.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void))

--- a/tests/pass4/t03_shared_local.expected
+++ b/tests/pass4/t03_shared_local.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void))

--- a/tests/pass4/t04_checked_call_asgn_and_move.expected
+++ b/tests/pass4/t04_checked_call_asgn_and_move.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Type 0))

--- a/tests/pass4/t04_checked_call_asgn_self.expected
+++ b/tests/pass4/t04_checked_call_asgn_self.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Type 0) (Type 0))

--- a/tests/pass4/t04_continue_with_value_and_move.expected
+++ b/tests/pass4/t04_continue_with_value_and_move.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void))

--- a/tests/pass4/t05_checked_call_asgn_and_copy.expected
+++ b/tests/pass4/t05_checked_call_asgn_and_copy.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Type 0))

--- a/tests/pass4/t05_loop_disjoint_locals.expected
+++ b/tests/pass4/t05_loop_disjoint_locals.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void))

--- a/tests/pass4/t06_loop_with_copy.expected
+++ b/tests/pass4/t06_loop_with_copy.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void))

--- a/tests/pass4/t07_checked_call_except.expected
+++ b/tests/pass4/t07_checked_call_except.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void))

--- a/tests/pass4/t07_raise_except.expected
+++ b/tests/pass4/t07_raise_except.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void))

--- a/tests/pass4/t08_checked_call_except_and_move.expected
+++ b/tests/pass4/t08_checked_call_except_and_move.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void))

--- a/tests/pass4/t08_raise_except_and_move.expected
+++ b/tests/pass4/t08_raise_except_and_move.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Void))

--- a/tests/pass4/t09_raise_except_and_copy.expected
+++ b/tests/pass4/t09_raise_except_and_copy.expected
@@ -1,3 +1,4 @@
+;$sexp
 (TypeDefs
   (Int 8)
   (ProcTy (Type 0))


### PR DESCRIPTION
## Summary

* support S-expression output comparison for the tester
* the first line of an `.expected` file being `;$sexp` marks it as
  containing S-expressions

## Details

While parsing and comparing S-expression is less efficient than a pure
string comparison, it does improve ergonomics of writing tests, as the
formatting of `.expected` files becomes irrelevant.

The `;$sexp` prefix was chosen because it's something that's unlikely
to ever appears at the start of a runner's output. Since
`sexp.parseSexp` doesn't support parsing more than one S-expression
from a stream, a custom parser based on `SexpParser` has to be used.

The existing `.expected` files containing S-expressions are marked as
such.