### PR TITLE
passtool: report unused production rules

### DIFF
--- a/passes/lang0.md
+++ b/passes/lang0.md
@@ -100,5 +100,6 @@ top-level node, in dedicated sections, to allow for easy and fast access to
 them.
 
 ```grammar
-top ::= (Module (TypeDefs <type>*) (GlobalDefs <type_id>*) (ProcDefs <procdef>*))
+module ::= (Module (TypeDefs <type>*) (GlobalDefs <type_id>*) (ProcDefs <procdef>*))
+top ::= <module>
 ```

--- a/passes/lang0.md
+++ b/passes/lang0.md
@@ -100,5 +100,5 @@ top-level node, in dedicated sections, to allow for easy and fast access to
 them.
 
 ```grammar
-module ::= (Module (TypeDefs <type>*) (GlobalDefs <type_id>*) (ProcDefs <procdef>*))
+top ::= (Module (TypeDefs <type>*) (GlobalDefs <type_id>*) (ProcDefs <procdef>*))
 ```

--- a/passes/lang_source.md
+++ b/passes/lang_source.md
@@ -10,4 +10,6 @@ ident ::= (Ident <string>)
 expr ::= (IntVal <int>)
       |  (FloatVal <float>)
       |  (Call <ident> <expr>*)
+
+top ::= <expr>
 ```

--- a/tools/passtool/passtool.nim
+++ b/tools/passtool/passtool.nim
@@ -18,6 +18,7 @@ proc main(args: openArray[string]) =
 
   # parse and analyse the provided file:
   sem(args[1], args[0], langs, errors)
+  trim(langs, errors)
 
   if errors.hasErrors:
     for source, it in errors.items:

--- a/tools/passtool/sem.nim
+++ b/tools/passtool/sem.nim
@@ -1,7 +1,7 @@
 ## Implements the semantic analysis for the parsed rules.
 
 import
-  std/[os, streams, tables],
+  std/[os, sets, streams, tables],
   grammar,
   parser
 
@@ -215,3 +215,45 @@ proc sem*(name, dir: string, langs: var Languages, errors: var Errors) =
   errors.files.add file
 
   sem(parsed, name, dir, langs, errors)
+
+proc mark(e: Expr, marker: var HashSet[string], next: var seq[string]) =
+  ## Registers all references in `e` with `marker`, adding them to `next` if
+  ## not seen prior.
+  if e.isRef:
+    if e.name notin ["int", "float", "string"]:
+      if not marker.containsOrIncl(e.name):
+        next.add e.name
+  else:
+    for it in e.rules.items:
+      mark(it.expr, marker, next)
+
+proc trim*(langs: var Languages, errors: var Errors) =
+  ## Removes unused production rules, producing errors for unused rules that
+  ## were introduced specifically for the grammar they're unused in.
+  var next: seq[string] # re-use across loops
+
+  for name, it in langs.mpairs:
+    var marker: HashSet[string]
+
+    if "top" in it:
+      marker.incl "top"
+      next.add "top"
+
+    # mark everything reachable from the top rule:
+    while next.len > 0:
+      let n = next.pop()
+      for rule in it[n].items:
+        mark(rule.expr, marker, next)
+
+    var remove: seq[string]
+    # register for removal everything that wasn't marked:
+    for pname, prods in it.pairs:
+      if pname notin marker:
+        remove.add pname
+
+        for prod in prods.items:
+          if prod.source == name:
+            errors.emit(prod.expr.pos, "unused production")
+
+    for r in remove.items:
+      it.del(r)


### PR DESCRIPTION
## Summary

`passtool` now reports errors for unused production rules. The
motivation is preventing mistakes and to ensure that the grammars
don't accumulate garbage.

## Details

* `trim` implements the trimming, and also handles the unused
  production rule reporting
* the top-level rule must be named `top`; `lang_source.md` and
  `lang0.md` are adjusted accordingly
