### PR TITLE
passtool: fix incorrect error positions

### DIFF
--- a/tools/passtool/sem.nim
+++ b/tools/passtool/sem.nim
@@ -209,9 +209,13 @@ proc sem*(name, dir: string, langs: var Languages, errors: var Errors) =
   let
     file = changeFileExt(dir / name, ".md")
     parsed = parseAll(file)
+    prev = errors.currFile
 
   # register the file:
   errors.currFile = errors.files.len.uint16
   errors.files.add file
 
   sem(parsed, name, dir, langs, errors)
+
+  # restore previous context:
+  errors.currFile = prev


### PR DESCRIPTION
All errors pointed to the file of the innermost language, due to
`currFile` not being restored after parsing/analyzing an `.md` file.