### PR TITLE
source2il: target `L4`

### DIFF
--- a/passes/pass3.nim
+++ b/passes/pass3.nim
@@ -249,7 +249,7 @@ proc lowerType(tree; n; changes) =
     # turn into a blob type:
     changes.replace(n, Blob):
       bu.add tree[n, 0] # copy the size
-  of ProcTy, Int, UInt:
+  of ProcTy, Int, UInt, Float:
     discard "nothing to do"
   else:
     unreachable()

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -190,17 +190,7 @@ proc exprToIL*(t: InTree): (TypeKind, PackedTree[NodeKind]) =
       bu.subTree ProcDef:
         bu.add Node(kind: Type, val: ptypId)
         bu.subTree Locals: discard
-        bu.subTree Continuations:
-          bu.subTree Continuation:
-            bu.subTree Params: discard
-            bu.subTree Locals: discard
-            bu.subTree Continue:
-              bu.add Node(kind: Immediate, val: 1)
-              # the expression is placed as an argument to the Continue:
-              bu.add e
-
-          bu.subTree Continuation:
-            bu.subTree Params:
-              bu.add Node(kind: Type, val: typId)
+        bu.subTree Return:
+          bu.add e
 
   result = (typ, initTree(bu.finish(), t.literals))

--- a/tests/expr/runner.nim
+++ b/tests/expr/runner.nim
@@ -13,6 +13,9 @@ import
     changesets,
     pass0,
     pass1,
+    pass3,
+    pass4,
+    pass10,
     source2il,
     spec_source,
     trees
@@ -43,6 +46,9 @@ if typ == tkError:
   quit(1)
 
 # lower to the L0 language:
+tree = tree.apply(pass10.lower(tree))
+tree = tree.apply(pass4.lower(tree))
+tree = tree.apply(pass3.lower(tree, 8))
 tree = tree.apply(pass1.lower(tree, 8))
 
 # generate the bytecode:


### PR DESCRIPTION
## Summary

Target the `L4` with `source2il`, so that further development of the
source language is made easier.

## Details

* adjust the generation of procedure wrapper for expressions
* apply the necessary lowerings in the `expr` test runner
* fix a bug with `pass3`, where the `Float` type wasn't considered
  during type lowering
