### PR TITLE
source2il: separate `Context` creation

### DIFF
--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -24,7 +24,7 @@ type
     tkInt
     tkFloat
 
-  Context* = object
+  ModuleCtx* = object
     ## The translation/analysis context for a single module.
     literals: Literals
     types: Builder[NodeKind]
@@ -33,7 +33,7 @@ type
     procs: Builder[NodeKind]
 
 using
-  c: var Context
+  c: var ModuleCtx
   t: InTree
   bu: var Builder[NodeKind]
 
@@ -170,12 +170,12 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu): TypeKind =
   of AllNodes - ExprNodes:
     unreachable()
 
-proc open*(): Context =
+proc open*(): ModuleCtx =
   ## Creates a new empty module translation/analysis context.
-  Context(types: initBuilder[NodeKind](TypeDefs),
-          procs: initBuilder[NodeKind](ProcDefs))
+  ModuleCtx(types: initBuilder[NodeKind](TypeDefs),
+            procs: initBuilder[NodeKind](ProcDefs))
 
-proc close*(c: sink Context): PackedTree[NodeKind] =
+proc close*(c: sink ModuleCtx): PackedTree[NodeKind] =
   ## Closes the module context and returns the accumulated translated code.
   var bu = initBuilder[NodeKind]()
   bu.subTree Module:

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -189,10 +189,12 @@ proc close*(c: sink Context): PackedTree[NodeKind] =
 proc exprToIL*(c; t): TypeKind =
   ## Translates the given source language expression to the highest-level IL
   ## and turns it into a procedure. Also returns the type of the expression.
-  let
-    (e, typ) = exprToIL(c, t, NodeIndex(0))
-    typId = c.typeToIL(typ)
+  let (e, typ) = exprToIL(c, t, NodeIndex(0))
+  if typ == tkError:
+    return tkError # don't create any procedure
 
+  let
+    typeId = c.typeToIL(typ)
     ptypId = c.addType ProcTy:
       c.types.add Node(kind: Type, val: typId)
 

--- a/passes/trees.nim
+++ b/passes/trees.nim
@@ -185,26 +185,38 @@ proc getString*(tree: PackedTree, n: NodeIndex): lent string =
   ## Returns the string value stored by `n`.
   tree.literals.strings[tree[n].val]
 
-proc pack*(tree: var PackedTree, i: int64): uint32 =
-  ## Packs `i` into an ``uint32`` value that can be stored in a ``TreeNode``.
+proc pack*(db: var Literals, i: int64): uint32 =
+  ## Packs `i` into a ``uint32`` value that can be stored in a ``TreeNode``.
   if i >= 0 and i < int64(ExternalFlag):
     result = uint32(i) # fits into a uint32
   else:
-    result = tree.literals.numbers.len.uint32 or ExternalFlag
-    tree.literals.numbers.add(cast[uint64](i))
+    result = db.numbers.len.uint32 or ExternalFlag
+    db.numbers.add(cast[uint64](i))
 
-proc pack*(tree: var PackedTree, f: float64): uint32 =
-  ## Packs `f` into an ``uint32`` value that can be stored in a ``TreeNode``.
-  result = tree.literals.numbers.len.uint32
-  tree.literals.numbers.add(cast[uint64](f))
+proc pack*(db: var Literals, f: float64): uint32 =
+  ## Packs `f` into a ``uint32`` value that can be stored in a ``TreeNode``.
+  result = db.numbers.len.uint32
+  db.numbers.add(cast[uint64](f))
 
-proc pack*(tree: var PackedTree, s: sink string): uint32 =
-  result = tree.literals.strings.len.uint32
-  tree.literals.strings.add(s)
+proc pack*(db: var Literals, s: sink string): uint32 =
+  result = db.strings.len.uint32
+  db.strings.add(s)
 
 func literals*(tree: PackedTree): lent Literals {.inline.} =
   ## Returns the storage for the literal data.
   tree.literals
+
+proc pack*(tree: var PackedTree, i: int64): uint32 {.inline.} =
+  ## Packs `i` into a ``uint32`` value that can be stored in a ``TreeNode``.
+  pack(tree.literals, i)
+
+proc pack*(tree: var PackedTree, f: float64): uint32 {.inline.} =
+  ## Packs `f` into a ``uint32`` value that can be stored in a ``TreeNode``.
+  pack(tree.literals, f)
+
+proc pack*(tree: var PackedTree, s: sink string): uint32 {.inline.} =
+  ## Packs `s` into a ``uint32`` value that can be stored in a ``TreeNode``.
+  pack(tree.literals, s)
 
 # TODO: move the S-expression serialization/deserialization elsewhere
 

--- a/tests/expr/runner.nim
+++ b/tests/expr/runner.nim
@@ -39,13 +39,15 @@ if s.readLine() == "discard \"\"\"":
 else:
   s.setPosition(0)
 
+var ctx = source2il.open()
 # parse the S-expression and translate the source language to the L1:
-var (typ, tree) = exprToIL(fromSexp[NodeKind](parseSexp(readAll(s))))
+let typ = ctx.exprToIL(fromSexp[NodeKind](parseSexp(readAll(s))))
 # don't continue if there was an error:
 if typ == tkError:
   echo "exprToIL failed"
   quit(1)
 
+var tree = close(ctx)
 # lower to the L0 language:
 tree = tree.apply(pass10.lower(tree))
 tree = tree.apply(pass4.lower(tree))

--- a/tools/repl.nim
+++ b/tools/repl.nim
@@ -84,7 +84,7 @@ iterator parse(stream: Stream): tuple[n: SexpNode, depth: int] {.closure.} =
       # we're done
       return (nil, 0)
 
-proc process(ctx: var Context, tree: PackedTree[NodeKind]) =
+proc process(ctx: var ModuleCtx, tree: PackedTree[NodeKind]) =
   case tree[NodeIndex(0)].kind
   of ExprNodes:
     let typ = ctx.exprToIL(tree)


### PR DESCRIPTION
## Summary

Separate `Context` creation from translation (`exprToIL`). This is a
prerequisite for incremental processing of modules.

## Details

* rename `Context` to `ModuleCtx`
* the new `open` procedure creates a new `ModuleCtx`
* the new `close` procedures finishes the `ModuleCtx` and yields the
  produced IL code
* `exprToIL` appends a proc to `Context` and only returns the type  
* `Literals` can now be appended to directly, without a `PackedTree` 
* `Context` now accumulates its own `Literals` DB, instead of re-using
  that of the input tree(s)

---

## Notes For Reviewers
* part of the work of introducing modules and procedure declarations
