### PR TITLE
vm: add `Unreachable` opcode

### DIFF
--- a/passes/pass0.nim
+++ b/passes/pass0.nim
@@ -480,7 +480,7 @@ proc genExit(c; tree; exit: NodeIndex) =
     c.instr(opcPopLocal, tree[exit, 1].id)
     c.jump(opcJmp, tree[tree.child(exit, ^2), 0].imm)
   of Unreachable:
-    discard "a no-op"
+    c.instr(opcUnreachable)
   else:
     unreachable()
 

--- a/tests/pass0/t03_unreachable.expected
+++ b/tests/pass0/t03_unreachable.expected
@@ -1,4 +1,4 @@
 .type t0 (Proc (Void))
 .start t0 p0
-  Ret
+  Unreachable
 .end

--- a/tests/pass0/t03_unreachable.test
+++ b/tests/pass0/t03_unreachable.test
@@ -1,6 +1,5 @@
 discard """
-  description: "An Unreachable exit translates to nothing"
-  output: "(Done)"
+  output: "(Error ecUnreachable)"
 """
 (TypeDefs
   (ProcTy (Void))
@@ -11,6 +10,5 @@ discard """
     (Continuation (Params) 0
       (Unreachable)
     )
-    (Continuation (Params))
   ))
 )

--- a/vm/assembler.nim
+++ b/vm/assembler.nim
@@ -239,7 +239,7 @@ proc parseOp(s: Stream, op: Opcode, a: var AssemblerState): Instr =
      opcSubFloat, opcMulFloat, opcDivFloat, opcNegFloat, opcEqInt, opcLtInt,
      opcLeInt, opcLtu, opcLeu, opcEqFloat, opcLtFloat, opcLeFloat, opcNot,
      opcReinterpF32, opcReinterpF64, opcReinterpI32, opcReinterpI64,
-     opcExcept, opcRaise, opcMemCopy, opcMemClear, opcGrow:
+     opcExcept, opcUnreachable, opcRaise, opcMemCopy, opcMemClear, opcGrow:
     Instr(op) # instruction with no immediate operands
   of opcAddImm, opcLdConst, opcLdImmInt, opcOffset,
      opcLdInt8, opcLdInt16, opcLdInt32, opcLdInt64, opcLdFlt32, opcLdFlt64,

--- a/vm/vm.nim
+++ b/vm/vm.nim
@@ -19,6 +19,7 @@ type
     ecIllegalGrow    ## improper grow operation
     ecTypeError      ## type error
     ecCallbackError  ## a fatal error ocurred within a callback
+    ecUnreachable    ## an 'unreachable' instruction was executed
 
   YieldReasonKind* = enum
     yrkDone
@@ -428,6 +429,8 @@ proc run*(c: var VmEnv, t: var VmThread, cl: RootRef): YieldReason {.raises: [].
 
     of opcExcept:
       unreachable() # never executed
+    of opcUnreachable:
+      return YieldReason(kind: yrkError, error: ecUnreachable)
 
     of opcStackAlloc:
       let next = t.sp + cast[uint32](imm32())

--- a/vm/vmspec.nim
+++ b/vm/vmspec.nim
@@ -105,6 +105,7 @@ type
     opcCall       ## callee:imm32 num:imm16
     opcIndCall    ## callee:int typ:imm32 num:imm16
     opcExcept     ## val:int
+    opcUnreachable
 
     # memory management
     opcStackAlloc ## size:imm32

--- a/vm/vmvalidation.nim
+++ b/vm/vmvalidation.nim
@@ -240,6 +240,8 @@ proc run(ctx: var ValidationState, env: VmEnv, pos: PrgCtr, instr: Instr
     check not ctx.active, "control-flow reaches 'opcExcept'"
     push(vtInt)
     ctx.active = true
+  of opcUnreachable:
+    ctx.active = false
   of opcStackAlloc:
     push(vtInt)
   of opcStackFree, opcGrow:


### PR DESCRIPTION
When executing an `Unreachable` instruction, the VM unconditionally
exits with an error of the L0 language.

The opcode is added for the convenience of the code generator / higher-
level passes: a procedure ending in an `Unreachable` statement now no
longer requires an (unnecessary) exit continuation in order to result
in well-formed bytecode.

While `pass0` could relatively easily insert a `Ret` instruction to
make the bytecode well-formed, the dedicated instruction has the
benefit that it aborts execution.

---

## Notes For Reviewers
* part of implementing `Unreachable` for the source language