### PR TITLE
lang: add `Unreachable` and `void` procedures

### DIFF
--- a/passes/spec_source.nim
+++ b/passes/spec_source.nim
@@ -11,15 +11,16 @@ type
   NodeKind* {.pure.} = enum
     Immediate, IntVal, FloatVal
     Ident,
-    UnitTy, BoolTy, IntTy, FloatTy
+    VoidTy, UnitTy, BoolTy, IntTy, FloatTy
     Call
     Return
-    Params,
-    ProcDecl,
+    Unreachable
+    Params
+    ProcDecl
     Module
 
 const
-  ExprNodes* = {IntVal, FloatVal, Ident, Call, Return}
+  ExprNodes* = {IntVal, FloatVal, Ident, Call, Return, Unreachable}
   DeclNodes* = {ProcDecl}
   AllNodes* = {low(NodeKind) .. high(NodeKind)}
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -74,7 +74,7 @@ expr += (IntVal <int>)
 
 The `IntVal` expression always has type `int`, `FloatVal` always type `float`.
 
-#### `return`
+#### `Return`
 
 ```grammar
 expr += (Return res:<expr>?)
@@ -88,6 +88,23 @@ is reported if:
 
 The type of the `Return` expression is `void`. It returns control from the
 current procedure to its caller.
+
+#### `Unreachable`
+
+```grammar
+expr += (Unreachable)
+```
+
+Marks a control-flow path as unreachable. In case program execution does reach
+the `Unreachable` expression, the program immediately terminates. A compiler
+*may* report an error if it can statically detect that control-flow can reach
+an `Unreachable` expression within a procedure.
+
+> TODO: consider lifting the requirement that the program must terminate, in
+> order to allow for the compiler optimizing the affected control-flow paths
+> away
+
+The type of the `Unreachable` expression is `void`.
 
 #### Calls
 
@@ -119,7 +136,8 @@ After evaluating the arguments (if any), control is passed to the callee.
 #### Type Expression
 
 ```grammar
-type_expr ::= (UnitTy)  # unit
+type_expr ::= (VoidTy)  # void
+           |  (UnitTy)  # unit
            |  (BoolTy)  # bool
            |  (IntTy)   # int
            |  (FloatTy) # float

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -100,10 +100,6 @@ the `Unreachable` expression, the program immediately terminates. A compiler
 *may* report an error if it can statically detect that control-flow can reach
 an `Unreachable` expression within a procedure.
 
-> TODO: consider lifting the requirement that the program must terminate, in
-> order to allow for the compiler optimizing the affected control-flow paths
-> away
-
 The type of the `Unreachable` expression is `void`.
 
 #### Calls

--- a/tests/expr/t02_unreachable.test
+++ b/tests/expr/t02_unreachable.test
@@ -1,0 +1,4 @@
+discard """
+  output: "runtime error: ecUnreachable"
+"""
+(Unreachable)

--- a/tests/expr/t05_return_operand_cannot_be_void.test
+++ b/tests/expr/t05_return_operand_cannot_be_void.test
@@ -1,0 +1,8 @@
+discard """
+  description: "
+    Ensure that a void expression cannot be used as a Return operand
+  "
+  reject: true
+"""
+(ProcDecl (Ident "a") (VoidTy) (Params)
+  (Return (Unreachable)))

--- a/tests/expr/t05_unreachable_is_void.test
+++ b/tests/expr/t05_unreachable_is_void.test
@@ -1,0 +1,6 @@
+discard """
+  description: "Ensure that `Unreachable` is a void expression"
+  output: "runtime error: ecUnreachable"
+"""
+(ProcDecl (Ident "a") (VoidTy) (Params)
+  (Unreachable))

--- a/tests/expr/t06_call_proc_with_void_return_type.test
+++ b/tests/expr/t06_call_proc_with_void_return_type.test
@@ -1,0 +1,8 @@
+discard """
+  output: "runtime error: ecUnreachable"
+"""
+(Module
+  (ProcDecl (Ident "a") (VoidTy) (Params)
+    (Unreachable))
+  (ProcDecl (Ident "main") (VoidTy) (Params)
+    (Call (Ident "a"))))


### PR DESCRIPTION
## Summary

* add the `Unreachable` expression
* add the `VoidTy` type expressions
* support procedures with a `void` return type

## Details

`Unreachable` is intended to mark control-flow paths as dead. Future
progress on the language might render it obsolete again, but for now,
it fills a hole in the language and, in the absence of a `raise`-like
construct, makes `void`-return procedures (and thus `void` call
expressions) possible.

---

## Notes For Reviewers
* depends on #34
