### PR TITLE
lang: add tuple types and tuples

### DIFF
--- a/common/vmexec.nim
+++ b/common/vmexec.nim
@@ -2,8 +2,8 @@
 ## runners.
 
 import
-  passes/[
-    source2il
+  phy/[
+    types
   ],
   vm/[
     vmenv,

--- a/common/vmexec.nim
+++ b/common/vmexec.nim
@@ -11,7 +11,7 @@ import
     utils
   ]
 
-proc run*(env: var VmEnv, prc: ProcIndex, typ: TypeKind): string =
+proc run*(env: var VmEnv, prc: ProcIndex, typ: SemType): string =
   ## Runs the nullary procedure with index `prc`, and returns the result
   ## rendered as a string. `typ` is the type of the resulting value.
   var
@@ -21,7 +21,7 @@ proc run*(env: var VmEnv, prc: ProcIndex, typ: TypeKind): string =
 
   case res.kind
   of yrkDone:
-    case typ
+    case typ.kind
     of tkVoid:
       # this is nonsense ('void' has no value), but it's allowed for
       # convenience

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -356,7 +356,7 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): SemType =
         elems[i] = e.typ
 
         if e.typ.kind in {tkError, tkVoid}:
-          return e.typ
+          return errorType()
 
         stmts.add e.stmts
         # add an assignment for the field:

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -185,7 +185,7 @@ proc inline(bu; e: sink Expr; stmts) =
   stmts.add e.stmts
   bu.add e.expr
 
-proc capture(c; e: sink Expr; bu; stmts): Node =
+proc capture(c; e: sink Expr; stmts): Node =
   ## Commits expression `e` to a fresh temporary. This is part of the
   ## expression-list lowering machinery.
   let tmp = c.newTemp(e.typ)
@@ -225,15 +225,11 @@ proc binaryArithToIL(c; t; n: NodeIndex, name: string, bu, stmts): SemType =
     else:   unreachable()
 
   if eA.typ == eB.typ and eA.typ.kind in {tkInt, tkFloat}:
-    let
-      typ = c.typeToIL(eA.typ)
-      a = c.capture(eA, bu, stmts)
-      b = c.capture(eB, bu, stmts)
 
     bu.subTree op:
-      bu.add Node(kind: Type, val: typ)
-      bu.add a
-      bu.add b
+      bu.add Node(kind: Type, val: c.typeToIL(eA.typ))
+      bu.add c.capture(eA, stmts)
+      bu.add c.capture(eB, stmts)
 
     result = eA.typ
   else:
@@ -257,14 +253,10 @@ proc relToIL(c; t; n: NodeIndex, name: string, bu; stmts): SemType =
     else:   unreachable()
 
   if eA.typ == eB.typ and eA.typ.kind in valid:
-    let
-      a = c.capture(eA, bu, stmts)
-      b = c.capture(eB, bu, stmts)
-
     bu.subTree op:
       bu.add Node(kind: Type, val: c.typeToIL(eA.typ))
-      bu.add a
-      bu.add b
+      bu.add c.capture(eA, stmts)
+      bu.add c.capture(eB, stmts)
 
     result = prim(tkBool)
   else:

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -9,6 +9,7 @@
 import
   std/[tables],
   passes/[builders, spec, trees],
+  phy/[types],
   vm/[utils]
 
 import passes/spec_source except NodeKind
@@ -18,14 +19,6 @@ type
   InTree     = PackedTree[SourceKind]
   Node       = TreeNode[NodeKind]
   NodeSeq    = seq[Node]
-
-  TypeKind* = enum
-    tkError
-    tkVoid
-    tkUnit
-    tkBool
-    tkInt
-    tkFloat
 
   ProcInfo = object
     id: int

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -89,6 +89,16 @@ proc typeToIL(c; typ: SemType): uint32 =
     c.addType Int: c.types.add(Node(kind: Immediate, val: 8))
   of tkFloat:
     c.addType Float: c.types.add(Node(kind: Immediate, val: 8))
+  of tkTuple:
+    let args = mapIt(typ.elems, c.typeToIL(it))
+    c.addType Record:
+      c.types.add Node(kind: Immediate, val: size(typ).uint32)
+      var off = 0 ## the current field offset
+      for i, it in args.pairs:
+        c.types.subTree Field:
+          c.types.add Node(kind: Immediate, val: off.uint32)
+          c.types.add Node(kind: Type, val: it)
+        off += size(typ.elems[i])
 
 proc genProcType(c; ret: SemType): uint32 =
   ## Generates a proc type with `ret` as the return type and adds it to `c`.

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -40,11 +40,24 @@ type
 
     # procedure context:
     retType: SemType
+    returnParam: uint32
+      ## the index of the out parameter, if one is required
+    locals: seq[SemType]
+      ## all locals part of the procedure
+
+  Expr = object
+    # XXX: the target IL doesn't support expression lists (yet), so we have
+    #      to apply the necessary lowering here, for now. Efficiency doesn't
+    #      matter
+    stmts: seq[NodeSeq] # can be empty
+    expr: NodeSeq
+    typ: SemType
 
 using
   c: var ModuleCtx
   t: InTree
   bu: var Builder[NodeKind]
+  stmts: var seq[NodeSeq]
 
 template addType(c; kind: NodeKind, body: untyped): uint32 =
   c.types.subTree kind:
@@ -108,17 +121,86 @@ proc genProcType(c; ret: SemType): uint32 =
   of tkVoid:
     c.addType ProcTy:
       c.types.subTree Void: discard
+  of ComplexTypes:
+    # non-primitive types are passed via an out parameter.
+    # ``() -> T`` becomes ``(int) -> unit``
+    let
+      ret = c.typeToIL(prim(tkUnit))
+      arg = c.typeToIL(prim(tkInt))
+    c.addType ProcTy:
+      c.types.add Node(kind: Type, val: ret)
+      c.types.add Node(kind: Type, val: arg)
   else:
     let typId = c.typeToIL(ret)
     c.addType ProcTy:
       c.types.add Node(kind: Type, val: typId)
 
-proc exprToIL(c; t: InTree, n: NodeIndex, bu): SemType
+template buildTree(kind: NodeKind, body: untyped): NodeSeq =
+  ## Makes a builder available to `body`, evaluates `body`, and returns the
+  ## generated tree.
+  var res: NodeSeq
+  if true: # open a new scope
+    var bu {.inject.} = initBuilder[NodeKind](kind)
+    body
+    res = finish(bu)
+  res
 
-proc exprToIL(c; t: InTree, n: NodeIndex): (NodeSeq, SemType) =
+template addStmt(stmts: var seq[NodeSeq], body: untyped) =
+  if true: # open a new scope
+    var bu {.inject.} = initBuilder[NodeKind]()
+    body
+    stmts.add finish(bu)
+
+template addStmt(stmts: var seq[NodeSeq], kind: NodeKind, body: untyped) =
+  stmts.add buildTree(kind, body)
+
+proc resetProcContext(c) =
+  c.locals.setLen(0) # re-use the memory
+
+proc newTemp(c; typ: SemType): uint32 =
+  ## Allocates a new temporary of `typ` type.
+  result = c.locals.len.uint32
+  c.locals.add typ
+
+proc genAsgn(c; a: Node|NodeSeq, b: NodeSeq, typ: SemType, bu) =
+  ## Emits an ``a = b`` assignment to `bu`.
+  case typ.kind
+  of tkTuple:
+    # record types don't support assignments in the target IL, so a ``Copy``
+    # has to be used
+    # XXX: this will happen as part of a lowering pass, eventually
+    bu.subTree Copy:
+      bu.subTree Addr:
+        bu.add a
+      bu.subTree Addr:
+        bu.add b
+      bu.add Node(kind: IntVal, val: c.literals.pack(size(typ)))
+  else:
+    bu.subTree Asgn:
+      bu.add a
+      bu.add b
+
+proc inline(bu; e: sink Expr; stmts) =
+  ## Appends the trailing expression directly to `bu`.
+  stmts.add e.stmts
+  bu.add e.expr
+
+proc capture(c; e: sink Expr; bu; stmts): Node =
+  ## Commits expression `e` to a fresh temporary. This is part of the
+  ## expression-list lowering machinery.
+  let tmp = c.newTemp(e.typ)
+  result = Node(kind: Local, val: tmp)
+
+  stmts.add e.stmts
+  stmts.addStmt:
+    c.genAsgn(result, e.expr, e.typ, bu)
+
+proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): SemType
+
+proc exprToIL(c; t: InTree, n: NodeIndex): Expr =
   var bu = initBuilder[NodeKind]()
-  result[1] = exprToIL(c, t, n, bu)
-  result[0] = finish(bu)
+  result.typ = exprToIL(c, t, n, bu, result.stmts)
+  result.expr = finish(bu)
 
 template lenCheck(t; n: NodeIndex, bu; expected: int) =
   ## Exits the current analysis procedure with an error, if `n` doesn't have
@@ -127,14 +209,14 @@ template lenCheck(t; n: NodeIndex, bu; expected: int) =
     bu.add Node(kind: IntVal)
     return errorType()
 
-proc binaryArithToIL(c; t; n: NodeIndex, name: string, bu): SemType =
+proc binaryArithToIL(c; t; n: NodeIndex, name: string, bu, stmts): SemType =
   ## Analyzes and emits the IL for a binary arithmetic operation.
   lenCheck(t, n, bu, 3)
 
   let
     (_, a, b)  = t.triplet(n)
-    (eA, typA) = exprToIL(c, t, a)
-    (eB, typB) = exprToIL(c, t, b)
+    eA = exprToIL(c, t, a)
+    eB = exprToIL(c, t, b)
 
   let op =
     case name
@@ -142,27 +224,30 @@ proc binaryArithToIL(c; t; n: NodeIndex, name: string, bu): SemType =
     of "-": Sub
     else:   unreachable()
 
-  if typA == typB and typA.kind in {tkInt, tkFloat}:
-    let typ = c.typeToIL(typA)
+  if eA.typ == eB.typ and eA.typ.kind in {tkInt, tkFloat}:
+    let
+      typ = c.typeToIL(eA.typ)
+      a = c.capture(eA, bu, stmts)
+      b = c.capture(eB, bu, stmts)
 
     bu.subTree op:
       bu.add Node(kind: Type, val: typ)
-      bu.add eA
-      bu.add eB
+      bu.add a
+      bu.add b
 
-    result = typA
+    result = eA.typ
   else:
     bu.add Node(kind: IntVal)
     result = errorType()
 
-proc relToIL(c; t; n: NodeIndex, name: string, bu): SemType =
+proc relToIL(c; t; n: NodeIndex, name: string, bu; stmts): SemType =
   ## Analyzes and emits the IL for a relational operation.
   lenCheck(t, n, bu, 3)
 
   let
     (_, a, b)  = t.triplet(n)
-    (eA, typA) = exprToIL(c, t, a)
-    (eB, typB) = exprToIL(c, t, b)
+    eA = exprToIL(c, t, a)
+    eB = exprToIL(c, t, b)
 
   let (op, valid) =
     case name
@@ -171,39 +256,44 @@ proc relToIL(c; t; n: NodeIndex, name: string, bu): SemType =
     of "<=": (Le, {tkInt, tkFloat})
     else:   unreachable()
 
-  if typA == typB and typA.kind in valid:
+  if eA.typ == eB.typ and eA.typ.kind in valid:
+    let
+      a = c.capture(eA, bu, stmts)
+      b = c.capture(eB, bu, stmts)
+
     bu.subTree op:
-      bu.add Node(kind: Type, val: c.typeToIL(typA))
-      bu.add eA
-      bu.add eB
+      bu.add Node(kind: Type, val: c.typeToIL(eA.typ))
+      bu.add a
+      bu.add b
 
     result = prim(tkBool)
   else:
     bu.add Node(kind: IntVal)
     result = errorType()
 
-proc notToIL(c; t; n: NodeIndex, bu): SemType =
+proc notToIL(c; t; n: NodeIndex, bu; stmts): SemType =
   lenCheck(t, n, bu, 2)
 
-  let (arg, typ) = exprToIL(c, t, t.child(n, 1))
+  let arg = exprToIL(c, t, t.child(n, 1))
 
-  if typ.kind == tkBool:
+  if arg.typ.kind == tkBool:
+    # a single argument, so no capture is necessary
     bu.subTree Not:
-      bu.add arg
+      bu.inline(arg, stmts)
     result = prim(tkBool)
   else:
     bu.add Node(kind: IntVal)
     result = errorType()
 
-proc callToIL(c; t; n: NodeIndex, bu): SemType =
+proc callToIL(c; t; n: NodeIndex, bu; stmts): SemType =
   let name = t.getString(t.child(n, 0))
   case name
   of "+", "-":
-    result = binaryArithToIL(c, t, n, name, bu)
+    result = binaryArithToIL(c, t, n, name, bu, stmts)
   of "==", "<", "<=":
-    result = relToIL(c, t, n, name, bu)
+    result = relToIL(c, t, n, name, bu, stmts)
   of "not":
-    result = notToIL(c, t, n, bu)
+    result = notToIL(c, t, n, bu, stmts)
   elif name in c.scope:
     # it's a user-defined procedure
     let prc {.cursor.} = c.scope[name]
@@ -211,12 +301,21 @@ proc callToIL(c; t; n: NodeIndex, bu): SemType =
       # procedure arity is currently always 0
       case prc.result.kind
       of tkVoid:
-        bu.subTree Stmts:
-          bu.subTree Call:
-            bu.add Node(kind: Proc, val: prc.id.uint32)
-          # mark the normal control-flow path as dead:
-          bu.subTree Unreachable:
-            discard
+        stmts.addStmt Call:
+          bu.add Node(kind: Proc, val: prc.id.uint32)
+        # mark the normal control-flow path as dead:
+        bu.subTree Unreachable:
+          discard
+      of ComplexTypes:
+        # the value is not returned normally, but passed via an out parameter
+        let tmp = c.newTemp(prc.result)
+        stmts.addStmt Call:
+          bu.add Node(kind: Proc, val: prc.id.uint32)
+          bu.subTree Addr:
+            bu.add Node(kind: Local, val: tmp)
+
+        # return the temporary as the expression
+        bu.add Node(kind: Local, val: tmp)
       else:
         bu.subTree Call:
           bu.add Node(kind: Proc, val: prc.id.uint32)
@@ -229,7 +328,7 @@ proc callToIL(c; t; n: NodeIndex, bu): SemType =
     bu.add Node(kind: IntVal)
     result = errorType()
 
-proc exprToIL(c; t: InTree, n: NodeIndex, bu): SemType =
+proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): SemType =
   case t[n].kind
   of SourceKind.IntVal:
     bu.add Node(kind: IntVal, val: c.literals.pack(t.getInt(n)))
@@ -249,20 +348,41 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu): SemType =
       bu.add Node(kind: IntVal)
       result = prim(tkError)
   of SourceKind.Call:
-    result = callToIL(c, t, n, bu)
+    result = callToIL(c, t, n, bu, stmts)
   of SourceKind.Return:
     var typ: SemType
     bu.subTree Return:
-      typ =
-        case t.len(n)
-        of 0:
-          # as long as it's an 8-bit integer, the exact value doesn't matter
-          bu.add Node(kind: IntVal)
-          prim(tkUnit)
-        of 1: exprToIL(c, t, t.child(n, 0), bu)
-        else: unreachable() # syntax error
+      case t.len(n)
+      of 0:
+        # as long as it's an 8-bit integer, the exact value doesn't matter
+        bu.add Node(kind: IntVal)
+        typ = prim(tkUnit)
+      of 1:
+        let e = c.exprToIL(t, t.child(n, 0))
+        typ = e.typ
+        stmts.add e.stmts
 
-    if typ.kind notin {tkError, tkVoid} and typ == c.retType:
+        if e.typ.kind == tkError:
+          return e.typ
+
+        case e.typ.kind
+        of ComplexTypes:
+          # special handling for complex types; do a memcopy through the out
+          # parameter
+          stmts.addStmt Copy:
+            bu.subTree Copy:
+              bu.add Node(kind: Local, val: c.returnParam)
+            bu.subTree Addr:
+              bu.add e.expr
+            bu.add Node(kind: IntVal, val: c.literals.pack(size(typ)))
+
+          bu.add Node(kind: IntVal) # return the unitary value
+        else:
+          bu.add e.expr
+      else:
+        unreachable() # syntax error
+
+    if typ.kind != tkVoid and typ == c.retType:
       result = prim(tkVoid)
     else:
       # TODO: use proper error correction; a return expression is always of
@@ -295,26 +415,52 @@ proc close*(c: sink ModuleCtx): PackedTree[NodeKind] =
 proc exprToIL*(c; t): SemType =
   ## Translates the given source language expression to the highest-level IL
   ## and turns it into a procedure. Also returns the type of the expression.
-  let (e, typ) = exprToIL(c, t, NodeIndex(0))
-  if typ.kind == tkError:
-    return typ # don't create any procedure
+  var e = exprToIL(c, t, NodeIndex(0))
+  result = e.typ
 
-  let procTy = c.genProcType(typ)
+  if e.typ.kind in ComplexTypes:
+    # XXX: to properly handle non-primitive returns, the expression is
+    #      currently analysed twice
+    c.resetProcContext() # undo the effects
+    c.locals.add prim(tkInt) # add the pointer parameter
+    c.returnParam = 0
+    c.retType = e.typ
+    # crudely wrap the expression in a Return:
+    let t =
+      initTree(@[TreeNode[SourceKind](kind: SourceKind.Return, val: 1)] & t.nodes,
+               t.literals)
+    # analyse again:
+    e = c.exprToIL(t, NodeIndex(0))
+
+  defer:
+    c.resetProcContext()
+
+  if result.kind == tkError:
+    return # don't create any procedure
+
+  let procTy = c.genProcType(result)
 
   template bu: untyped = c.procs
 
   bu.subTree ProcDef:
     bu.add Node(kind: Type, val: procTy)
-    bu.subTree Locals: discard
-    case typ.kind
-    of tkVoid:
-      bu.add e
-    else:
-      bu.subTree Return:
-        bu.add e
+    bu.subTree Locals:
+      for it in c.locals.items:
+        bu.add Node(kind: Type, val: c.typeToIL(it))
+    bu.subTree Stmts:
+      # first emit all statements:
+      for it in e.stmts.items:
+        bu.add it
+
+      # then the expression:
+      case e.typ.kind
+      of tkVoid:
+        bu.add e.expr
+      else:
+        bu.subTree Return:
+          bu.add e.expr
 
   inc c.numProcs
-  result = typ
 
 proc declToIL*(c; t; n: NodeIndex): SemType =
   ## Translates the given source language declaration to the target IL.
@@ -331,21 +477,33 @@ proc declToIL*(c; t; n: NodeIndex): SemType =
 
     let procTy = c.genProcType(c.retType)
 
-    var bu = initBuilder[NodeKind](ProcDef)
-    bu.add Node(kind: Type, val: procTy)
-    bu.subTree Locals:
-      discard
+    if c.retType.kind in ComplexTypes:
+      # needs an extra pointer parameter
+      c.locals.add prim(tkInt)
+      c.returnParam = uint32(c.locals.len - 1)
+
+    defer:
+      c.resetProcContext() # clear the context again
 
     # register the proc before analysing/translating the body
     c.scope[name] = ProcInfo(id: c.numProcs, result: c.retType)
 
-    let (e, eTyp) = c.exprToIL(t, t.child(n, 3))
-    if eTyp.kind == tkVoid:
-      # the expression must always be a void expression
-      bu.add e
-    else:
+    let e = c.exprToIL(t, t.child(n, 3))
+    # the body expression must always be a void expression
+    if e.typ.kind != tkVoid:
       c.scope.del(name) # remove again
       return errorType()
+
+    var bu = initBuilder[NodeKind](ProcDef)
+    bu.add Node(kind: Type, val: procTy)
+    bu.subTree Locals:
+      for it in c.locals.items:
+        bu.add Node(kind: Type, val: c.typeToIL(it))
+    # add the body:
+    bu.subTree Stmts:
+      for it in e.stmts.items:
+        bu.add it
+      bu.add e.expr
 
     c.procs.add finish(bu)
     inc c.numProcs

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -305,10 +305,11 @@ proc callToIL(c; t; n: NodeIndex, bu; stmts): SemType =
       of ComplexTypes:
         # the value is not returned normally, but passed via an out parameter
         let tmp = c.newTemp(prc.result)
-        stmts.addStmt Call:
-          bu.add Node(kind: Proc, val: prc.id.uint32)
-          bu.subTree Addr:
-            bu.add Node(kind: Local, val: tmp)
+        stmts.addStmt Drop:
+          bu.subTree Call:
+            bu.add Node(kind: Proc, val: prc.id.uint32)
+            bu.subTree Addr:
+              bu.add Node(kind: Local, val: tmp)
 
         # return the temporary as the expression
         bu.add Node(kind: Local, val: tmp)

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -228,8 +228,10 @@ proc binaryArithToIL(c; t; n: NodeIndex, name: string, bu, stmts): SemType =
 
     bu.subTree op:
       bu.add Node(kind: Type, val: c.typeToIL(eA.typ))
-      bu.add c.capture(eA, stmts)
-      bu.add c.capture(eB, stmts)
+      bu.subTree Copy:
+        bu.add c.capture(eA, stmts)
+      bu.subTree Copy:
+        bu.add c.capture(eB, stmts)
 
     result = eA.typ
   else:
@@ -255,8 +257,10 @@ proc relToIL(c; t; n: NodeIndex, name: string, bu; stmts): SemType =
   if eA.typ == eB.typ and eA.typ.kind in valid:
     bu.subTree op:
       bu.add Node(kind: Type, val: c.typeToIL(eA.typ))
-      bu.add c.capture(eA, stmts)
-      bu.add c.capture(eB, stmts)
+      bu.subTree Copy:
+        bu.add c.capture(eA, stmts)
+      bu.subTree Copy:
+        bu.add c.capture(eB, stmts)
 
     result = prim(tkBool)
   else:

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -165,8 +165,8 @@ proc newTemp(c; typ: SemType): uint32 =
 proc genAsgn(c; a: Node|NodeSeq, b: NodeSeq, typ: SemType, bu) =
   ## Emits an ``a = b`` assignment to `bu`.
   case typ.kind
-  of tkTuple:
-    # record types don't support assignments in the target IL, so a ``Copy``
+  of ComplexTypes:
+    # complex types don't support assignments in the target IL, so a ``Copy``
     # has to be used
     # XXX: this will happen as part of a lowering pass, eventually
     bu.subTree Copy:

--- a/passes/spec_source.nim
+++ b/passes/spec_source.nim
@@ -11,8 +11,9 @@ type
   NodeKind* {.pure.} = enum
     Immediate, IntVal, FloatVal
     Ident,
-    VoidTy, UnitTy, BoolTy, IntTy, FloatTy
+    VoidTy, UnitTy, BoolTy, IntTy, FloatTy, TupleTy
     Call
+    TupleCons
     Return
     Unreachable
     Params
@@ -20,7 +21,7 @@ type
     Module
 
 const
-  ExprNodes* = {IntVal, FloatVal, Ident, Call, Return, Unreachable}
+  ExprNodes* = {IntVal, FloatVal, Ident, Call, TupleCons, Return, Unreachable}
   DeclNodes* = {ProcDecl}
   AllNodes* = {low(NodeKind) .. high(NodeKind)}
 

--- a/phy/types.nim
+++ b/phy/types.nim
@@ -9,3 +9,15 @@ type
     tkBool
     tkInt
     tkFloat
+
+  SemType* = object
+    ## Represent a source-language type. The "Sem" prefix is to not have it
+    ## name conflicts with other types named `Type`.
+    kind*: TypeKind
+
+proc errorType*(): SemType {.inline.} =
+  SemType(kind: tkError)
+
+proc prim*(kind: TypeKind): SemType {.inline.} =
+  ## Returns the primitive type with the given kind.
+  SemType(kind: kind)

--- a/phy/types.nim
+++ b/phy/types.nim
@@ -1,0 +1,11 @@
+## Implements types and procedures for representing and working with the
+## source-language types.
+
+type
+  TypeKind* = enum
+    tkError
+    tkVoid
+    tkUnit
+    tkBool
+    tkInt
+    tkFloat

--- a/phy/types.nim
+++ b/phy/types.nim
@@ -33,6 +33,11 @@ type
     of tkTuple:
       elems*: seq[SemType]
 
+const
+  ComplexTypes* = {tkTuple}
+    ## types that can currently not be used as procedure return or parameter
+    ## types in the target IL
+
 proc errorType*(): SemType {.inline.} =
   SemType(kind: tkError)
 

--- a/phy/types.nim
+++ b/phy/types.nim
@@ -54,16 +54,7 @@ proc `==`*(a, b: SemType): bool =
   of tkError, tkVoid, tkUnit, tkBool, tkInt, tkFloat:
     result = true
   of tkTuple:
-    # equal if both have the same number of elements, and the same element
-    # types
-    if a.elems.len != b.elems.len:
-      return false
-
-    for i in 0..<a.elems.len:
-      if a.elems[i] != b.elems[i]:
-        return
-
-    result = true
+    result = a.elems == b.elems
 
 proc size*(t: SemType): int =
   ## Computes the size-in-bytes that an instance of `t` occupies in memory.

--- a/phy/types.nim
+++ b/phy/types.nim
@@ -59,3 +59,15 @@ proc `==`*(a, b: SemType): bool =
         return
 
     result = true
+
+proc size*(t: SemType): int =
+  ## Computes the size-in-bytes that an instance of `t` occupies in memory.
+  case t.kind
+  of tkError, tkVoid: unreachable()
+  of tkUnit, tkBool: 1
+  of tkInt, tkFloat: 8
+  of tkTuple:
+    var s = 0
+    for it in t.elems.items:
+      s += size(it)
+    s

--- a/phy/types.nim
+++ b/phy/types.nim
@@ -2,12 +2,13 @@
 ## source-language types.
 
 # XXX: the idea of ``SemType`` is misguided. Instead of using a custom IR, it
-#      would be simpler *and* more efficient to use ouput ``PackedTree`` as
+#      would be simpler *and* more efficient to use the ouput ``PackedTree`` as
 #      the type IR. There's no ``SemType``-to-tree translation step then, and
 #      instead of copying around ``SemType``s (which is costly), only a
-#      ``NodeIndex`` (referring to the type) would be copied around.
-#      If types are de-duplicated on creation, this would reduce type equality
-#      to an integer comparison
+#      ``NodeIndex`` (referring to the type) would have to be copied around.
+#
+#      If types are de-duplicated on creation, this would also reduce testing
+#      types for equality to an integer comparison
 
 import
   vm/[
@@ -25,7 +26,7 @@ type
     tkTuple
 
   SemType* = object
-    ## Represent a source-language type. The "Sem" prefix is to not have it
+    ## Represents a source-language type. The "Sem" prefix is there to prevent
     ## name conflicts with other types named `Type`.
     case kind*: TypeKind
     of tkError, tkVoid, tkUnit, tkBool, tkInt, tkFloat:

--- a/phy/types.nim
+++ b/phy/types.nim
@@ -1,6 +1,19 @@
 ## Implements types and procedures for representing and working with the
 ## source-language types.
 
+# XXX: the idea of ``SemType`` is misguided. Instead of using a custom IR, it
+#      would be simpler *and* more efficient to use ouput ``PackedTree`` as
+#      the type IR. There's no ``SemType``-to-tree translation step then, and
+#      instead of copying around ``SemType``s (which is costly), only a
+#      ``NodeIndex`` (referring to the type) would be copied around.
+#      If types are de-duplicated on creation, this would reduce type equality
+#      to an integer comparison
+
+import
+  vm/[
+    utils
+  ]
+
 type
   TypeKind* = enum
     tkError
@@ -9,11 +22,16 @@ type
     tkBool
     tkInt
     tkFloat
+    tkTuple
 
   SemType* = object
     ## Represent a source-language type. The "Sem" prefix is to not have it
     ## name conflicts with other types named `Type`.
-    kind*: TypeKind
+    case kind*: TypeKind
+    of tkError, tkVoid, tkUnit, tkBool, tkInt, tkFloat:
+      discard
+    of tkTuple:
+      elems*: seq[SemType]
 
 proc errorType*(): SemType {.inline.} =
   SemType(kind: tkError)
@@ -21,3 +39,23 @@ proc errorType*(): SemType {.inline.} =
 proc prim*(kind: TypeKind): SemType {.inline.} =
   ## Returns the primitive type with the given kind.
   SemType(kind: kind)
+
+proc `==`*(a, b: SemType): bool =
+  ## Compares two types for equality.
+  if a.kind != b.kind:
+    return false
+
+  case a.kind
+  of tkError, tkVoid, tkUnit, tkBool, tkInt, tkFloat:
+    result = true
+  of tkTuple:
+    # equal if both have the same number of elements, and the same element
+    # types
+    if a.elems.len != b.elems.len:
+      return false
+
+    for i in 0..<a.elems.len:
+      if a.elems[i] != b.elems[i]:
+        return
+
+    result = true

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -175,8 +175,8 @@ type_expr += (TupleTy)              # first form
 
 The first form of the `TupleTy` operator produces the `unit` type.
 
-> TODO: this behaviour makes sense, but it renders `UnitTy` obsolete. Consider
-> removing the latter.
+> TODO: this behaviour makes sense, but it renders `UnitTy` redundant. Consider
+> removing the latter, or at least making it an alias for `(TupleTy)`.
 
 The second form constructs a `tuple` type with from the given type. Allowed
 operand type kinds are: `unit`, `int`, `float`, and `tuple`. An error is

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -178,7 +178,7 @@ The first form of the `TupleTy` operator produces the `unit` type.
 > TODO: this behaviour makes sense, but it renders `UnitTy` redundant. Consider
 > removing the latter, or at least making it an alias for `(TupleTy)`.
 
-The second form constructs a `tuple` type with from the given type. Allowed
+The second form constructs a `tuple` type from the given types. Allowed
 operand type kinds are: `unit`, `int`, `float`, and `tuple`. An error is
 reported for any other type.
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -19,7 +19,7 @@ A *statement* is a computation without a type.
 
 ### Types
 
-The built-in types (also referred to as "primitive types") are:
+The primitive types are:
 * `void`
 * `unit`
 * `bool`
@@ -38,6 +38,18 @@ dependent.
 
 `float` is the type of floating point values, where the size is target-
 dependent.
+
+#### Composite Types
+
+Types can be combined into *composite types*.
+
+The `tuple(T1, ..., Tn)` type constructor constructs a *product type* (i.e., a
+type that is the product of the `T1`..`Tn` types). The operand order is
+significant, meaning that `tuple(int, float)` does not construct the same type
+as `tuple(float, int)`.
+
+`tuple()` (i.e., the product of no types) is a special case, and is equal to
+the `unit` type.
 
 ### Lookup
 
@@ -129,7 +141,22 @@ After evaluating the arguments (if any), control is passed to the callee.
 
 > TODO: specification for the built-in operations is missing
 
-#### Type Expression
+#### Tuple Constructors
+
+```grammar
+expr += (TupleCons)         # first form
+      | (TupleCons <expr>+) # second form
+```
+
+The first form constructs a value of type `unit`.
+
+The second form construct a value of type `tuple(T1..Tn)`, where `T1` is the
+type of the first expression, `T2` the type of the second expression (if any),
+and so on.
+
+An error is reported if any `Tx` is `void`.
+
+### Type Expressions
 
 ```grammar
 type_expr ::= (VoidTy)  # void
@@ -138,6 +165,22 @@ type_expr ::= (VoidTy)  # void
            |  (IntTy)   # int
            |  (FloatTy) # float
 ```
+
+#### Tuple Type Constructors
+
+```gramm
+type_expr += (TupleTy)              # first form
+          |  (TupleTy <type_expr>+) # second form
+```
+
+The first form of the `TupleTy` operator produces the `unit` type.
+
+> TODO: this behaviour makes sense, but it renders `UnitTy` obsolete. Consider
+> removing the latter.
+
+The second form constructs a `tuple` type with from the given type. Allowed
+operand type kinds are: `unit`, `int`, `float`, and `tuple`. An error is
+reported for any other type.
 
 ### Declarations
 

--- a/tests/expr/runner.nim
+++ b/tests/expr/runner.nim
@@ -49,7 +49,7 @@ s.close()
 # translate the input
 
 var ctx = source2il.open()
-var typ: TypeKind
+var typ: SemType
 
 case input[NodeIndex(0)].kind
 of DeclNodes:
@@ -62,19 +62,19 @@ of Module:
   # it's a full module. Translate all declarations
   for it in input.items(NodeIndex(0)):
     typ = ctx.declToIL(input, it)
-    if typ == tkError:
+    if typ.kind == tkError:
       break
 
   # the last procedure is the one that will be executed
 
   if input.len(NodeIndex(0)) == 0:
-    typ = tkVoid # set to something that's not ``tkError``
+    typ = prim(tkVoid) # set to something that's not ``tkError``
 else:
   echo "unexpected node: ", input[NodeIndex(0)].kind
   quit(1)
 
 # don't continue if there was an error:
-if typ == tkError:
+if typ.kind == tkError:
   echo "semantic analysis failed"
   quit(2)
 

--- a/tests/expr/runner.nim
+++ b/tests/expr/runner.nim
@@ -20,6 +20,9 @@ import
     spec_source,
     trees
   ],
+  phy/[
+    types
+  ],
   common/[
     vmexec
   ],

--- a/tests/expr/t02_tuple_constructor_1.test
+++ b/tests/expr/t02_tuple_constructor_1.test
@@ -1,0 +1,4 @@
+discard """
+  output: "(100,): (int,)"
+"""
+(TupleCons (IntVal 100))

--- a/tests/expr/t02_tuple_constructor_2.test
+++ b/tests/expr/t02_tuple_constructor_2.test
@@ -1,0 +1,4 @@
+discard """
+  output: "(100, 100): (int, int)"
+"""
+(TupleCons (IntVal 100) (IntVal 100))

--- a/tests/expr/t02_tuple_constructor_3.test
+++ b/tests/expr/t02_tuple_constructor_3.test
@@ -1,0 +1,4 @@
+discard """
+  output: "(100, (100,)): (int, (int,))"
+"""
+(TupleCons (IntVal 100) (TupleCons (IntVal 100)))

--- a/tests/expr/t02_unit_constructor.test
+++ b/tests/expr/t02_unit_constructor.test
@@ -1,0 +1,4 @@
+discard """
+  output: "(): unit"
+"""
+(TupleCons)

--- a/tests/expr/t03_unit_in_tuple.test
+++ b/tests/expr/t03_unit_in_tuple.test
@@ -1,0 +1,4 @@
+discard """
+  output: "((),): (unit,)"
+"""
+(TupleCons (TupleCons))

--- a/tests/expr/t03_void_in_tuple.test
+++ b/tests/expr/t03_void_in_tuple.test
@@ -1,0 +1,4 @@
+discard """
+  reject: true
+"""
+(TupleCons (Unreachable))

--- a/tests/expr/t04_proc_declaration.test
+++ b/tests/expr/t04_proc_declaration.test
@@ -1,5 +1,5 @@
 discard """
-  output: "unit"
+  output: "(): unit"
 """
 (ProcDecl (Ident "a") (UnitTy) (Params)
   (Return))

--- a/tests/expr/t06_call_proc_with_tuple_return_type.test
+++ b/tests/expr/t06_call_proc_with_tuple_return_type.test
@@ -1,0 +1,8 @@
+discard """
+  output: "(100, 200): (int, int)"
+"""
+(Module
+  (ProcDecl (Ident "a") (TupleTy (IntTy) (IntTy)) (Params)
+    (Return (TupleCons (IntVal 100) (IntVal 200))))
+  (ProcDecl (Ident "main") (TupleTy (IntTy) (IntTy)) (Params)
+    (Return (Call (Ident "a")))))

--- a/tests/expr/t06_call_proc_with_unit_return_type.test
+++ b/tests/expr/t06_call_proc_with_unit_return_type.test
@@ -1,5 +1,5 @@
 discard """
-  output: "unit"
+  output: "(): unit"
 """
 (Module
   (ProcDecl (Ident "a") (UnitTy) (Params)

--- a/tools/repl.nim
+++ b/tools/repl.nim
@@ -20,6 +20,9 @@ import
     spec_source,
     trees,
   ],
+  phy/[
+    types
+  ],
   common/[
     vmexec
   ],

--- a/tools/repl.nim
+++ b/tools/repl.nim
@@ -90,14 +90,14 @@ iterator parse(stream: Stream): tuple[n: SexpNode, depth: int] {.closure.} =
 proc process(ctx: var ModuleCtx, tree: PackedTree[NodeKind]) =
   case tree[NodeIndex(0)].kind
   of DeclNodes:
-    if ctx.declToIL(tree, NodeIndex(0)) == TypeKind.tkError:
+    if ctx.declToIL(tree, NodeIndex(0)).kind == TypeKind.tkError:
       echo "error in declaration"
 
   of ExprNodes:
     let typ = ctx.exprToIL(tree)
 
     # don't continue if there was an error:
-    if typ == TypeKind.tkError:
+    if typ.kind == TypeKind.tkError:
       echo "expression has an error"
       return
 

--- a/vm/vm.nim
+++ b/vm/vm.nim
@@ -455,16 +455,23 @@ when not defined(debug):
 
 # ------- VmThread API
 
-proc initThread*(c: VmEnv, prc: ProcIndex, stack: uint,
+proc initThread*(c: VmEnv, prc: ProcIndex, stack: HOslice[uint],
                  params: sink seq[Value]): VmThread =
   ## Creates a new VM thread, with `prc` as the starting procedure and `params`
-  ## as the initial operand stack. `stack` denotes the maximum number of stack
-  ## memory the thread can use.
+  ## as the initial operand stack. `stack` is the memory region to use for the
+  ## stack of the thread.
   VmThread(pc: c[prc].code.a,
-           stackEnd: stack,
+           sp: stack.a,
+           stackEnd: stack.b,
            stack: params,
            locals: newSeq[Value](c[prc].locals.len),
            frames: @[Frame(prc: prc)])
+
+proc initThread*(c: VmEnv, prc: ProcIndex, stack: uint,
+                 params: sink seq[Value]): VmThread =
+  ## Convenience wrapper around
+  ## `initThread <#initThread,VmEnv,ProcIndex,HOslice[uint],sinkseq[Value]>`_.
+  initThread(c, prc, hoSlice(0'u, stack), params)
 
 proc dispose*(c: var VmEnv, t: sink VmThread) =
   ## Cleans up and frees all VM data owned by `t`.


### PR DESCRIPTION
## Summary

* implement tuple type constructors
* implement tuple constructors
* implement general support for aggregate/complex types for `source2il`
  and the tester

## Details

### Restructuring

* since types can be more complex now, they're represented by the new
  `SemType` type
* move the type representation and corresponding query routines to the
  new `types` module

### Source2IL

* implement tuple and tuple type constructor support
* implement support for returning aggregate/complex types from
  procedures. They currently need to be returned via an out parameter
* implement expression-list lowering. They're needed for the out
  parameter handling, but the `L10` doesn't support them yet

### VM

* support setting the start of the stack with `initThread`
* implement support for aggregate return values for `vmexec.run` 