### PR TITLE
pass4: fix locals not being processed

### DIFF
--- a/passes/pass4.nim
+++ b/passes/pass4.nim
@@ -447,7 +447,7 @@ proc lowerCont(c; tree; gr; cont: Cont, self: int, changes) =
     if tree.len(exit) == 3:
       let g = cont.groups.a
       if isExit(tree, gr.conts[gr.groups[g].target].n):
-        lowerExpr(tree, tree.child(exit, 0), active, changes)
+        lowerExpr(tree, tree.child(exit, 1), active, changes)
       else:
         let dst = c.getDest(gr, cont, g)
         active.addUnique(dst)

--- a/tests/pass4/t04_continue_with_local_return.expected
+++ b/tests/pass4/t04_continue_with_local_return.expected
@@ -1,0 +1,25 @@
+;$sexp
+(TypeDefs
+  (Int 8)
+  (ProcTy (Type 0)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Locals (Type 0) (Type 0))
+    (Continuations
+      (Continuation (Params)
+        (Locals (Local 0))
+        (Asgn (Local 0) (IntVal 100))
+        (Continue 1))
+      (Continuation (Params)
+        (Locals (Local 0) (Local 1))
+        (Asgn (Local 1) (IntVal 200))
+        (Continue 2))
+      (Continuation (Params)
+        (Locals (Local 1) (Local 0))
+        (Continue 3
+          (Add (Type 0)
+            (Copy (Local 1))
+            (Copy (Local 0)))))
+      (Continuation
+        (Params (Type 0))))))

--- a/tests/pass4/t04_continue_with_local_return.test
+++ b/tests/pass4/t04_continue_with_local_return.test
@@ -1,0 +1,30 @@
+discard """
+  description: "
+    Ensure the expression in a `Continue` targeting the exit is processed
+    properly (i.e., that the locals within use the correct IDs)
+  "
+"""
+(TypeDefs
+  (Int 8)
+  (ProcTy (Type 0))
+)
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1) (Continuations
+    (Continuation (Params) (Locals)
+      (Continue 1 (IntVal 100) (List))
+    )
+    (Continuation (Params (Type 0)) (Locals)
+      (Continue 2 (IntVal 200)
+        (List (Move (Local 0))))
+    )
+    (Continuation (Params (Type 0) (Type 0)) (Locals)
+      (Continue 3
+        (Add (Type 0)
+          (Copy (Local 0))
+          (Copy (Local 1)))
+        (List))
+    )
+    (Continuation (Params (Type 0))))
+  )
+)


### PR DESCRIPTION
## Summary

Fix a bug with `pass4` where references to locals within a `Continue`'s
expression were not patched, leading to code generation failures or
incorrect behaviour at run-time.

## Details

Instead of the expression's index, the node index of the continuation
ID was passed to `lowerExpr`. A test is added to make sure the lowering
works properly now.

---

## Notes For Reviewers
* discovered as part of #36