### PR TITLE
implement a reporting system

### DIFF
--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -29,9 +29,8 @@ type
   ModuleCtx* = object
     ## The translation/analysis context for a single module.
     reporter: ref ReportContext[string]
-    # XXX: strings being used for messages is a temporary measure. Eventually,
-    #      a dedicated message type that offloads message formating to message
-    #      rendering will be used
+    # XXX: strings being used for diagnostics is a temporary measure. Message
+    #      formatting should eventually be separated from diagnostic emission
 
     literals: Literals
     types: Builder[NodeKind]

--- a/phy/default_reporting.nim
+++ b/phy/default_reporting.nim
@@ -3,7 +3,7 @@ import
 
 type
   DefaultReporter*[T] = object of ReportContext[T]
-    ## A report context that only accumulates messages, but doesn't do
+    ## A report context that only accumulates diagnostics, but doesn't do
     ## anything with them.
     reports: seq[T]
 
@@ -15,11 +15,11 @@ type
 proc initDefaultReporter*[T](): ref DefaultReporter[T] =
   ## Sets up a default reporter.
   new(result)
-  result.sendPrc = proc(self: ref ReportContext[T], rep: sink T) =
+  result.errorPrc = proc(self: ref ReportContext[T], rep: sink T) =
     (ref DefaultReporter[T])(self).reports.add rep
   result.fatalPrc = proc(self: ref ReportContext[T], rep: sink T) =
     raise (ref FatalError[T])(rep: rep)
 
 proc retrieve*[T](r: var DefaultReporter[T]): seq[T] =
-  ## Takes all accumulated reports from `r`.
+  ## Takes all accumulated error diagnostics from `r`.
   result = move r.reports

--- a/phy/default_reporting.nim
+++ b/phy/default_reporting.nim
@@ -1,0 +1,25 @@
+import
+  phy/reporting
+
+type
+  DefaultReporter*[T] = object of ReportContext[T]
+    ## A report context that only accumulates messages, but doesn't do
+    ## anything with them.
+    reports: seq[T]
+
+  FatalError*[T] = object of CatchableError
+    ## Represents some error that was fatal to whoever reported it, but that
+    ## can still be recovered from.
+    rep*: T
+
+proc initDefaultReporter*[T](): ref DefaultReporter[T] =
+  ## Sets up a default reporter.
+  new(result)
+  result.sendPrc = proc(self: ref ReportContext[T], rep: sink T) =
+    (ref DefaultReporter[T])(self).reports.add rep
+  result.fatalPrc = proc(self: ref ReportContext[T], rep: sink T) =
+    raise (ref FatalError[T])(rep: rep)
+
+proc retrieve*[T](r: var DefaultReporter[T]): seq[T] =
+  ## Takes all accumulated reports from `r`.
+  result = move r.reports

--- a/phy/reporting.nim
+++ b/phy/reporting.nim
@@ -1,0 +1,25 @@
+## Implements the generic reporting architecture. Everything that wants to
+## report hints, warnings, or errors needs access to a ``ReportContext``-
+## derived type.
+
+import
+  vm/utils
+
+type
+  ReportContext*[T] = object of RootObj
+    ## The base type that all report context types must be derived from.
+    sendPrc*: proc(c: ref ReportContext[T], rep: sink T)
+      ## called when a message is sent to the context
+    fatalPrc*: proc(c: ref ReportContext[T], rep: sink T)
+      ## called when a fatal message is sent to the context. The procedure
+      ## must not return normally
+
+proc report*[T](c: ref ReportContext[T], rep: sink T) =
+  ## Sends `rep` to the report context.
+  c.sendPrc(c, rep)
+
+proc fatal*[T](c: ref ReportContext[T], rep: sink T) {.noreturn.} =
+  ## Sends `rep` to the report context, which is guaranteed to result in the
+  ## current control-flow path to terminate.
+  c.fatalPrc(rep)
+  unreachable()

--- a/phy/reporting.nim
+++ b/phy/reporting.nim
@@ -8,18 +8,44 @@ import
 type
   ReportContext*[T] = object of RootObj
     ## The base type that all report context types must be derived from.
-    sendPrc*: proc(c: ref ReportContext[T], rep: sink T)
-      ## called when a message is sent to the context
-    fatalPrc*: proc(c: ref ReportContext[T], rep: sink T)
-      ## called when a fatal message is sent to the context. The procedure
+    debugPrc*: proc(c: ref ReportContext[T], diag: sink T)
+      ## may be nil
+    hintPrc*: proc(c: ref ReportContext[T], diag: sink T)
+      ## may be nil
+    warnPrc*: proc(c: ref ReportContext[T], diag: sink T)
+      ## may be nil
+    errorPrc*: proc(c: ref ReportContext[T], diag: sink T)
+      ## called when an error diagnostic is sent to the context. The procedure
+      ## is not required to return normally
+    fatalPrc*: proc(c: ref ReportContext[T], diag: sink T)
+      ## called when a fatal diagnostic is sent to the context. The procedure
       ## must not return normally
 
-proc report*[T](c: ref ReportContext[T], rep: sink T) =
-  ## Sends `rep` to the report context.
-  c.sendPrc(c, rep)
+proc debug*[T](c: ref ReportContext[T], diag: sink T) =
+  ## Sends the debug diagnostic `diag` to the report context.
+  if c.debugPrc != nil:
+    c.debugPrc(c, diag)
 
-proc fatal*[T](c: ref ReportContext[T], rep: sink T) {.noreturn.} =
-  ## Sends `rep` to the report context, which is guaranteed to result in the
-  ## current control-flow path to terminate.
-  c.fatalPrc(rep)
+proc hint*[T](c: ref ReportContext[T], diag: sink T) =
+  ## Sends the hint diagnostic `diag` to the report context. This is meant
+  ## for user-facing hints (about some input, like code).
+  if c.hintPrc != nil:
+    c.hintPrc(c, diag)
+
+proc warn*[T](c: ref ReportContext[T], diag: sink T) =
+  ## Sends the error diagnostic `diag` to the report context. This is meant
+  ## for user-facing warnings (about some input, like code).
+  if c.warnPrc != nil:
+    c.warnPrc(c, diag)
+
+proc error*[T](c: ref ReportContext[T], diag: sink T) =
+  ## Sends the error diagnostic `diag` to the report context. This is meant
+  ## for user-facing errors. The callsite has to assume that ``error`` returns
+  ## normally.
+  c.errorPrc(c, diag)
+
+proc fatal*[T](c: ref ReportContext[T], diag: sink T) {.noreturn.} =
+  ## Sends the error diagnostic `diag` to the report context, which is
+  ## guaranteed to result in the current control-flow path to terminate.
+  c.fatalPrc(diag)
   unreachable()

--- a/tests/expr/runner.nim
+++ b/tests/expr/runner.nim
@@ -21,6 +21,7 @@ import
     trees
   ],
   phy/[
+    default_reporting,
     types
   ],
   common/[
@@ -48,7 +49,8 @@ s.close()
 # -------------------
 # translate the input
 
-var ctx = source2il.open()
+var reporter = initDefaultReporter[string]()
+var ctx = source2il.open(reporter)
 var typ: SemType
 
 case input[NodeIndex(0)].kind
@@ -62,8 +64,6 @@ of Module:
   # it's a full module. Translate all declarations
   for it in input.items(NodeIndex(0)):
     typ = ctx.declToIL(input, it)
-    if typ.kind == tkError:
-      break
 
   # the last procedure is the one that will be executed
 
@@ -74,8 +74,10 @@ else:
   quit(1)
 
 # don't continue if there was an error:
-if typ.kind == tkError:
-  echo "semantic analysis failed"
+let messages = reporter[].retrieve()
+if messages.len > 0:
+  for it in messages.items:
+    echo "Error: ", it
   quit(2)
 
 # ---------------


### PR DESCRIPTION
## Summary

* implement a generic reporting system (`ReportContext`), intended for
  use by the compiler
* integrate `ReportContext` into `source2il`
* the REPL and the `expr` test runner now report a text message for
  each error

## Details

* add the `reporting` and `default_reporting`, containing the
  `ReportContext` type and a simple implementation thereof,
  respectively
* require an `ReportContext` instance when creating a `ModuleCtx`
* in `source2il`, report an error message whenever detecting an error
* adjust the tester runner and the REPL to the new error reporting.
  Whether an error occurred is now indicated by there being an
  unprocessed message in the report context

The error messages are currently formatted in-place, but the idea is to
eventually send dedicated message objects (which store all necessary
information for rendering the message to text) to the `ReportContext`.
