### PR TITLE
lang: add tuple access

### DIFF
--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -405,6 +405,37 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): SemType =
       # it's a unit value
       bu.add Node(kind: IntVal)
       result = prim(tkUnit)
+  of SourceKind.TupleAccess:
+    let
+      (a, b) = t.pair(n)
+      tup = c.exprToIL(t, a)
+    case tup.typ.kind
+    of tkTuple:
+      let idx = t.getInt(b)
+      if idx >= 0 and idx < tup.typ.elems.len:
+        result = tup.typ.elems[idx]
+
+        case result.kind
+        of ComplexTypes:
+          bu.subTree Field:
+            bu.inline(tup, stmts)
+            bu.add Node(kind: Immediate, val: idx.uint32)
+        else:
+          # TODO: wrapping the expression in a Copy operation needs to happen
+          #       at the callsite (because only the consumer knows whether to
+          #       copy or not)
+          bu.subTree Copy:
+            bu.subTree Field:
+              bu.inline(tup, stmts)
+              bu.add Node(kind: Immediate, val: idx.uint32)
+      else:
+        c.error("tuple has no element with index " & $idx)
+        result = errorType()
+    of tkError:
+      result = tup.typ
+    else:
+      c.error("expected 'tuple' value")
+      result = errorType()
   of SourceKind.Return:
     var typ: SemType
     bu.subTree Return:

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -405,7 +405,7 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): SemType =
       # it's a unit value
       bu.add Node(kind: IntVal)
       result = prim(tkUnit)
-  of SourceKind.TupleAccess:
+  of SourceKind.FieldAccess:
     let
       (a, b) = t.pair(n)
       tup = c.exprToIL(t, a)

--- a/passes/spec_source.nim
+++ b/passes/spec_source.nim
@@ -14,7 +14,7 @@ type
     VoidTy, UnitTy, BoolTy, IntTy, FloatTy, TupleTy
     Call
     TupleCons
-    TupleAccess
+    FieldAccess
     Return
     Unreachable
     Params
@@ -22,7 +22,7 @@ type
     Module
 
 const
-  ExprNodes* = {IntVal, FloatVal, Ident, Call, TupleCons, TupleAccess, Return,
+  ExprNodes* = {IntVal, FloatVal, Ident, Call, TupleCons, FieldAccess, Return,
                 Unreachable}
   DeclNodes* = {ProcDecl}
   AllNodes* = {low(NodeKind) .. high(NodeKind)}

--- a/passes/spec_source.nim
+++ b/passes/spec_source.nim
@@ -14,6 +14,7 @@ type
     VoidTy, UnitTy, BoolTy, IntTy, FloatTy, TupleTy
     Call
     TupleCons
+    TupleAccess
     Return
     Unreachable
     Params
@@ -21,7 +22,8 @@ type
     Module
 
 const
-  ExprNodes* = {IntVal, FloatVal, Ident, Call, TupleCons, Return, Unreachable}
+  ExprNodes* = {IntVal, FloatVal, Ident, Call, TupleCons, TupleAccess, Return,
+                Unreachable}
   DeclNodes* = {ProcDecl}
   AllNodes* = {low(NodeKind) .. high(NodeKind)}
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -80,7 +80,8 @@ Otherwise, an error is reported.
 #### Literals
 
 ```grammar
-expr += (IntVal <int>)
+int_val ::= (IntVal <int>)
+expr += <int_val>
       | (FloatVal <float>)
 ```
 
@@ -155,6 +156,21 @@ type of the first expression, `T2` the type of the second expression (if any),
 and so on.
 
 An error is reported if any `Tx` is `void`.
+
+### Tuple Elimination
+
+```grammar
+expr += (TupleAccess tup:<expr> index:<int_val>)
+```
+
+Retrieves the value from the `index`-th position of the tuple.
+
+Let `T` be the type of `tup`. If `T` is not a `tuple` type, an error is
+reported. If `index` is an integer value less than 0, or greater than or equal
+to the number of types in the tuple type `T`, an error is reported.
+
+Given type `tuple(T[0], .., T[n])` for `T`, the type of the expression is
+`T[index]`.
 
 ### Type Expressions
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -160,7 +160,7 @@ An error is reported if any `Tx` is `void`.
 ### Tuple Elimination
 
 ```grammar
-expr += (TupleAccess tup:<expr> index:<int_val>)
+expr += (FieldAccess tup:<expr> index:<int_val>)
 ```
 
 Retrieves the value from the `index`-th position of the tuple.

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -167,7 +167,7 @@ Retrieves the value from the `index`-th position of the tuple.
 
 Let `T` be the type of `tup`. If `T` is not a `tuple` type, an error is
 reported. If `index` is an integer value less than 0, or greater than or equal
-to the number of types in the tuple type `T`, an error is reported.
+to the number of positions in the tuple type `T`, an error is reported.
 
 Given type `tuple(T[0], .., T[n])` for `T`, the type of the expression is
 `T[index]`.

--- a/tests/expr/t03_tuple_access_1.test
+++ b/tests/expr/t03_tuple_access_1.test
@@ -1,6 +1,6 @@
 discard """
   output: "100: int"
 """
-(TupleAccess
+(FieldAccess
   (TupleCons (IntVal 100))
   (IntVal 0))

--- a/tests/expr/t03_tuple_access_1.test
+++ b/tests/expr/t03_tuple_access_1.test
@@ -1,0 +1,6 @@
+discard """
+  output: "100: int"
+"""
+(TupleAccess
+  (TupleCons (IntVal 100))
+  (IntVal 0))

--- a/tests/expr/t03_tuple_access_2.test
+++ b/tests/expr/t03_tuple_access_2.test
@@ -1,0 +1,6 @@
+discard """
+  output: "10.5: float"
+"""
+(TupleAccess
+  (TupleCons (IntVal 100) (FloatVal 10.5))
+  (IntVal 1))

--- a/tests/expr/t03_tuple_access_2.test
+++ b/tests/expr/t03_tuple_access_2.test
@@ -1,6 +1,6 @@
 discard """
   output: "10.5: float"
 """
-(TupleAccess
+(FieldAccess
   (TupleCons (IntVal 100) (FloatVal 10.5))
   (IntVal 1))

--- a/tests/expr/t03_tuple_access_3.test
+++ b/tests/expr/t03_tuple_access_3.test
@@ -1,7 +1,7 @@
 discard """
   output: "(100,): (int,)"
 """
-(TupleAccess
+(FieldAccess
   (TupleCons
     (TupleCons (IntVal 100)))
   (IntVal 0))

--- a/tests/expr/t03_tuple_access_3.test
+++ b/tests/expr/t03_tuple_access_3.test
@@ -1,0 +1,7 @@
+discard """
+  output: "(100,): (int,)"
+"""
+(TupleAccess
+  (TupleCons
+    (TupleCons (IntVal 100)))
+  (IntVal 0))

--- a/tests/expr/t03_tuple_access_out_of_bounds_1.test
+++ b/tests/expr/t03_tuple_access_out_of_bounds_1.test
@@ -1,0 +1,6 @@
+discard """
+  reject: true
+"""
+(TupleAccess
+  (TupleCons (IntVal 100))
+  (IntVal 1))

--- a/tests/expr/t03_tuple_access_out_of_bounds_1.test
+++ b/tests/expr/t03_tuple_access_out_of_bounds_1.test
@@ -1,6 +1,6 @@
 discard """
   reject: true
 """
-(TupleAccess
+(FieldAccess
   (TupleCons (IntVal 100))
   (IntVal 1))

--- a/tests/expr/t03_tuple_access_out_of_bounds_2.test
+++ b/tests/expr/t03_tuple_access_out_of_bounds_2.test
@@ -1,6 +1,6 @@
 discard """
   reject: true
 """
-(TupleAccess
+(FieldAccess
   (TupleCons (IntVal 100))
   (IntVal -1))

--- a/tests/expr/t03_tuple_access_out_of_bounds_2.test
+++ b/tests/expr/t03_tuple_access_out_of_bounds_2.test
@@ -1,0 +1,6 @@
+discard """
+  reject: true
+"""
+(TupleAccess
+  (TupleCons (IntVal 100))
+  (IntVal -1))


### PR DESCRIPTION
Extend the source language with the `FieldAccess` operator, for
retrieving values from a tuple. Only static indexing with immediate
integer values is supported at the moment.