### PR TITLE
vm: fix load and store for floats

### DIFF
--- a/tests/vm/t04_float_local.test
+++ b/tests/vm/t04_float_local.test
@@ -1,0 +1,11 @@
+discard """
+  output: "(Done 0.5)"
+"""
+.type P1 (Proc (Float))
+.start P1 main
+.local tmp float
+LdImmFloat 0.5
+PopLocal tmp
+GetLocal tmp
+Ret
+.end

--- a/tests/vm/t04_float_local_set.test
+++ b/tests/vm/t04_float_local_set.test
@@ -1,0 +1,10 @@
+discard """
+  output: "(Done 0.5)"
+"""
+.type P1 (Proc (Float))
+.start P1 main
+.local tmp float
+LdImmFloat 0.5
+SetLocal tmp
+Ret
+.end

--- a/tests/vm/t04_int_local copy.test
+++ b/tests/vm/t04_int_local copy.test
@@ -1,0 +1,10 @@
+discard """
+  output: "(Done 1)"
+"""
+.type P1 (Proc (Int))
+.start P1 main
+.local tmp int
+LdImmInt 1
+SetLocal tmp
+Ret
+.end

--- a/tests/vm/t04_int_local.test
+++ b/tests/vm/t04_int_local.test
@@ -1,0 +1,11 @@
+discard """
+  output: "(Done 1)"
+"""
+.type P1 (Proc (Int))
+.start P1 main
+.local tmp int
+LdImmInt 1
+PopLocal tmp
+GetLocal tmp
+Ret
+.end

--- a/tests/vm/t04_stack_alloc.test
+++ b/tests/vm/t04_stack_alloc.test
@@ -1,0 +1,8 @@
+discard """
+  output: "(Done 4096)"
+"""
+.type P1 (Proc (Int))
+.start P1 main
+StackAlloc 8
+Ret
+.end

--- a/tests/vm/t05_read_write_float32.test
+++ b/tests/vm/t05_read_write_float32.test
@@ -1,0 +1,14 @@
+discard """
+  output: "(Done 1.5)"
+"""
+.type P1 (Proc (Float))
+.start P1 main
+.local tmp Int
+StackAlloc 4
+SetLocal tmp
+LdImmFloat 1.5
+WrFlt32 0
+GetLocal tmp
+LdFlt32 0
+Ret
+.end

--- a/tests/vm/t05_read_write_float64.test
+++ b/tests/vm/t05_read_write_float64.test
@@ -1,0 +1,14 @@
+discard """
+  output: "(Done 1.5)"
+"""
+.type P1 (Proc (Float))
+.start P1 main
+.local tmp Int
+StackAlloc 8
+SetLocal tmp
+LdImmFloat 1.5
+WrFlt64 0
+GetLocal tmp
+LdFlt64 0
+Ret
+.end

--- a/vm/vmvalidation.nim
+++ b/vm/vmvalidation.nim
@@ -181,8 +181,8 @@ proc run(ctx: var ValidationState, env: VmEnv, pos: PrgCtr, instr: Instr
     pop(vtInt)
     pop(vtInt)
   of opcWrFlt32, opcWrFlt64:
-    pop(vtInt)
     pop(vtFloat)
+    pop(vtInt)
   of opcWrRef:
     pop(vtInt)
     pop(vtRef)


### PR DESCRIPTION
## Summary

* fix `WrFlt32` and `LdFlt32` not working correctly
* fix a validator bug with `WrFlt32` and `WrFlt64`, where valid code
  was treated as invalid

## Details

The implementation of `LdFlt32` and `WrFlt64` didn't consider that
there are only 64-bit float registers, *casting* (not converting)
between 64-bit values and 32-bit floats and thus producing bogus
results.

The 64-bit float value is now *converted* to or from a 32-bit float
when doing a 32-bit load or store, respectively, fixing the issue.

Finally, tests for float load and store instructions are added.
Since the assembler/VM features they depend on weren't tested yet,
tests are added for those too.

---

## Note For Reviewers
* discovered as part of #39