### PR TITLE
lang3: support aggregate assignments

### DIFF
--- a/passes/lang3.md
+++ b/passes/lang3.md
@@ -46,7 +46,5 @@ value += (Copy <path>)
 stmt += (Asgn <path> <value>)
 ```
 
-Storing, loading, or assigning full aggregate values is not supported at
-this level.
-
-*Note: this might be subject to change.*
+Discarding an aggregate value (e.g., via `(Drop (Copy (Local 0)))`) is not
+supported at this level.

--- a/tests/pass3/t04_asgn_aggregate.expected
+++ b/tests/pass3/t04_asgn_aggregate.expected
@@ -1,0 +1,19 @@
+;$sexp
+(TypeDefs
+  (Int 8)
+  (Blob 8)
+  (ProcTy (Void))
+  (UInt 8))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 2)
+    (Locals (Type 1) (Type 1))
+    (Continuations
+      (Continuation (Params)
+        (Locals (Local 0) (Local 1))
+        (Copy
+          (Addr (Local 0))
+          (Addr (Local 1))
+          (IntVal 8))
+        (Continue 1))
+      (Continuation (Params)))))

--- a/tests/pass3/t04_asgn_aggregate.test
+++ b/tests/pass3/t04_asgn_aggregate.test
@@ -1,0 +1,16 @@
+(TypeDefs
+  (Int 8)
+  (Record 8
+    (Field 0 (Type 0)))
+  (ProcTy (Void)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 2)
+    (Locals (Type 1) (Type 1))
+    (Continuations
+      (Continuation (Params) (Locals (Local 0) (Local 1))
+        (Asgn (Local 0)
+          (Copy (Local 1)))
+        (Continue 1)
+      )
+      (Continuation (Params)))))

--- a/tests/pass3/t04_asgn_sub_aggregate.expected
+++ b/tests/pass3/t04_asgn_sub_aggregate.expected
@@ -1,0 +1,22 @@
+;$sexp
+(TypeDefs
+  (Int 8)
+  (Blob 8)
+  (Blob 8)
+  (ProcTy (Void))
+  (UInt 8))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 3)
+    (Locals (Type 2) (Type 1))
+    (Continuations
+      (Continuation (Params)
+        (Locals (Local 0) (Local 1))
+        (Copy
+          (Add (Type 4)
+            (Addr (Local 0))
+            (IntVal 0))
+          (Addr (Local 1))
+          (IntVal 8))
+        (Continue 1))
+      (Continuation (Params)))))

--- a/tests/pass3/t04_asgn_sub_aggregate.test
+++ b/tests/pass3/t04_asgn_sub_aggregate.test
@@ -1,0 +1,18 @@
+(TypeDefs
+  (Int 8)
+  (Record 8
+    (Field 0 (Type 0)))
+  (Record 8
+    (Field 0 (Type 1)))
+  (ProcTy (Void)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 3)
+    (Locals (Type 2) (Type 1))
+    (Continuations
+      (Continuation (Params) (Locals (Local 0) (Local 1))
+        (Asgn
+          (Field (Local 0) 0)
+          (Copy (Local 1)))
+        (Continue 1))
+      (Continuation (Params)))))

--- a/tests/pass3/t04_load_aggregate.expected
+++ b/tests/pass3/t04_load_aggregate.expected
@@ -1,0 +1,19 @@
+;$sexp
+(TypeDefs
+  (Int 8)
+  (Blob 8)
+  (ProcTy (Void))
+  (UInt 8))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 2)
+    (Locals (Type 1))
+    (Continuations
+      (Continuation (Params)
+        (Locals (Local 0))
+        (Copy
+          (Addr (Local 0))
+          (IntVal 0)
+          (IntVal 8))
+        (Continue 1))
+      (Continuation (Params)))))

--- a/tests/pass3/t04_load_aggregate.test
+++ b/tests/pass3/t04_load_aggregate.test
@@ -1,0 +1,19 @@
+discard """
+  output: "(Error)"
+"""
+(TypeDefs
+  (Int 8)
+  (Record 8
+    (Field 0 (Type 0)))
+  (ProcTy (Void)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 2)
+    (Locals (Type 1))
+    (Continuations
+      (Continuation (Params) (Locals (Local 0))
+        (Asgn (Local 0)
+          (Load (Type 1)
+            (IntVal 0)))
+        (Continue 1))
+      (Continuation (Params)))))

--- a/tests/pass3/t04_store_aggregate.expected
+++ b/tests/pass3/t04_store_aggregate.expected
@@ -1,0 +1,18 @@
+;$sexp
+(TypeDefs
+  (Int 8)
+  (Blob 8)
+  (ProcTy (Void))
+  (UInt 8))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 2)
+    (Locals (Type 1))
+    (Continuations
+      (Continuation (Params)
+        (Locals (Local 0))
+        (Copy (IntVal 0)
+          (Addr (Local 0))
+          (IntVal 8))
+        (Continue 1))
+      (Continuation (Params)))))

--- a/tests/pass3/t04_store_aggregate.test
+++ b/tests/pass3/t04_store_aggregate.test
@@ -1,0 +1,19 @@
+discard """
+  output: "(Error)"
+"""
+(TypeDefs
+  (Int 8)
+  (Record 8
+    (Field 0 (Type 0)))
+  (ProcTy (Void)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 2)
+    (Locals (Type 1))
+    (Continuations
+      (Continuation (Params) (Locals (Local 0))
+        (Store (Type 1)
+          (IntVal 0)
+          (Copy (Local 0)))
+        (Continue 1))
+      (Continuation (Params)))))


### PR DESCRIPTION
## Summary

Add support for assigning, storing, and loading aggregate values to
`L3`, and thus to all higher-level languages extending it. This is a
prerequisite for removing the assignment lowering from `source2il`. 

## Details

Assignments and stores of aggregate values are lowered into memory
copies (`Copy`) by `pass3`. `pass3` is currently the best pass to
implement this lowering in, since it also does the lowering of other
aggregate-related operations.

---

## Notes For Reviewers
* removing the assignment lowering from `source2il` will remove some conditional
  logic and complexity from the latter