### PR TITLE
pass10: fix propagation of needed locals

### DIFF
--- a/passes/pass10.nim
+++ b/passes/pass10.nim
@@ -446,7 +446,7 @@ proc lowerProc(c: var PassCtx, tree; n; changes) =
           c.bblocks[o].has.incl it.needs * c.pinned
 
       if inLoop and it.term == termLoop and it.outgoing[0] == loopStart:
-        # got back to the start of the loop
+        # end of the loop reached; jump back to the start of it
         swap(i, loopStart) # prevent inner loops from being repeated
         inLoop = false
       else:
@@ -479,8 +479,8 @@ proc lowerProc(c: var PassCtx, tree; n; changes) =
       for param in it.params.items:
         it.needs.excl param
 
-      if i == loopStart and inLoop:
-        # jump back to the end of the loop
+      if inLoop and c.bblocks[loopStart].outgoing[0] == i:
+        # start of the loop reached; jump back to the end of it
         swap(i, loopStart)
         inLoop = false
       else:

--- a/tests/pass10/t03_ssa_loop_3.expected
+++ b/tests/pass10/t03_ssa_loop_3.expected
@@ -1,0 +1,46 @@
+;$sexp
+(TypeDefs
+  (Int 8)
+  (ProcTy (Void)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Continuations
+      (Continuation (Params)
+        (Locals)
+        (Continue 1 (IntVal 200) (List)))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (Continue 2
+          (List
+            (Move (Local 0)))))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (SelectBool (IntVal 1)
+          (Continue 4
+            (List
+              (Move (Local 0))))
+          (Continue 3
+            (List
+              (Move (Local 0))))))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (Continue 5
+          (List
+            (Move (Local 0)))))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (Loop 2
+          (List
+            (Move (Local 0)))))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (Drop
+          (Copy (Local 0)))
+        (Continue 6 (List)))
+      (Continuation (Params)))))

--- a/tests/pass10/t03_ssa_loop_3.test
+++ b/tests/pass10/t03_ssa_loop_3.test
@@ -1,0 +1,17 @@
+discard """
+  description: "Test case: local assigned and used *outside* the loop"
+"""
+(TypeDefs
+  (Int 8)
+  (ProcTy (Void)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Locals (Type 0))
+    (Stmts
+      (Asgn (Local 0) (IntVal 200))
+      (Loop
+        (If (IntVal 1)
+          (Break 1)))
+      (Drop (Copy (Local 0)))
+      (Return))))


### PR DESCRIPTION
## Summary

Fix a bug with propagation of needed locals in `pass10` that resulted
in crashes for locals needed across a loop edge.

## Details

The test for detecting the loop start during backward propagation
was wrong. It triggered immediately for the basic-block ending in
the loop edge, thus disabling reiteration for the rest of the loop's
basic-blocks, which resulted in incorrect `needs` sets.

The condition is corrected and a test case for reproducing the issue is
added.