### PR TITLE
source2il: simpler `Expr` rules

### DIFF
--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -549,6 +549,11 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): SemType =
       of 1: c.exprToIL(t, t.child(n, 0))
       else: unreachable() # syntax error
 
+    if e.typ.kind == tkVoid:
+      c.error("cannot return 'void' expression")
+      e.expr = @[Node(kind: IntVal)] # add a placholder
+      e.typ = prim(tkError)
+
     # apply the necessary to-supertype conversions:
     e = c.fitExpr(e, c.retType)
 
@@ -557,8 +562,6 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): SemType =
       case e.typ.kind
       of tkError:
         discard "do nothing"
-      of tkVoid:
-        c.error("cannot return 'void' expression")
       of ComplexTypes:
         # special handling for complex types: store through the out parameter
         stmts.addStmt Store:

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -251,10 +251,12 @@ proc genUse(a: NodeSeq, bu) =
     bu.add a
 
 proc genAsgn(c; a: Node|NodeSeq, b: NodeSeq, typ: SemType, bu) =
-  ## Emits an ``a = b`` assignment to `bu`.
-  bu.subTree Asgn:
-    bu.add a
-    genUse(b, bu)
+  ## Emits an ``a = b`` assignment to `bu`. For convenience, if `typ` is a
+  ## ``tkVoid``, no assignment is emitted.
+  if typ.kind != tkVoid:
+    bu.subTree Asgn:
+      bu.add a
+      genUse(b, bu)
 
 proc inline(bu; e: sink Expr; stmts) =
   ## Appends the trailing expression directly to `bu`.


### PR DESCRIPTION
## Summary

Remove the special case of the trailing statement in a void expression
having to be placed in the `Expr.expr` part, simplifying the `exprToIL`
post-conditions.

## Details

* require the `expr` part of `Expr` to be empty for `void`
  expressions and non-empty for non-`void` expressions (except
  `tkError` ones)
* add assertions to verify that the post-conditions are satisfied
* adjust the IL generation logic accordingly
* move the `Return` void check to before expression fitting

In addition, `genAsgn` now ignores void expressions, so that one can
write
```nim
c.genAsgn(..., e.expr, e.typ, bu)
```
instead of
```nim
if e.typ.kind != tkVoid:
  c.genAsgn(..., e.expr, e.typ, bu)
```