### PR TITLE
source2il: disallow using built-in name for declaration

### DIFF
--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -21,7 +21,7 @@ type
   NodeSeq    = seq[Node]
 
   EntityKind = enum
-    ekNone        ## non existent
+    ekNone        ## signals "non-existent"
     ekBuiltin     ## some built-in special entity
     ekBuiltinProc ## some built-in special
     ekProc
@@ -95,8 +95,6 @@ proc error(c; message: sink string) =
 func lookup(c: ModuleCtx, name: string): Entity =
   ## Implements the lookup action described in the specification.
   result = c.scope.getOrDefault(name, Entity(kind: ekNone))
-  # built-ins are not added to any scope, and can thus be used to detect
-  # a lookup failure here
   if result.kind == ekNone:
     result.kind = BuiltIns.getOrDefault(name, ekNone)
 

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -22,8 +22,8 @@ type
 
   EntityKind = enum
     ekNone        ## signals "non-existent"
-    ekBuiltin     ## some built-in special entity
-    ekBuiltinProc ## some built-in special
+    ekBuiltinVal  ## some built-in named value
+    ekBuiltinProc ## some built-in procedure
     ekProc
     ekType
 
@@ -78,8 +78,8 @@ const
     "<=": ekBuiltinProc,
     "<": ekBuiltinProc,
     "not": ekBuiltinProc,
-    "true": ekBuiltin,
-    "false": ekBuiltin
+    "true": ekBuiltinVal,
+    "false": ekBuiltinVal
   }.toTable
 
 using
@@ -513,7 +513,7 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): SemType =
       name = t.getString(n)
       ent = c.lookup(name)
     case ent.kind
-    of ekBuiltin:
+    of ekBuiltinVal:
       case name
       of "false":
         bu.add Node(kind: IntVal, val: 0)

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -70,7 +70,7 @@ entity with `name` part of `scope`.
 ### Expressions
 
 At the moment, a few names are automatically part of a scope: `+`, `-`, `==`,
-`<`, `<=`, `not`.
+`<`, `<=`, `not`, `true`, and `false`.
 
 #### Identifiers
 

--- a/tests/expr/t06_redeclaration_error_3.test
+++ b/tests/expr/t06_redeclaration_error_3.test
@@ -1,0 +1,5 @@
+discard """
+  reject: true
+"""
+(ProcDecl (Ident "+") (UnitTy) (Params)
+  (Return))


### PR DESCRIPTION
## Summary

* an error is now reported when using the name of a built-in for a
  procedure or type declaration
* error messages for using entities in an incorrect context are
  improved
* `false` and `true` are now treated as built-ins
* the internal implementation of lookup is improved

## Details

The specification already said that built-in names were disallowed, but
`source2il` didn't adhere to it.

* add the `lookup` procedure, implementing lookup in a single place
* replace all manual `scope` lookup with `lookup`
* add a table that keeps track of all built-in entities
* improve error messages for unexpected entity kinds
* list `true` and `false` as names automatically part of every scope

Instead of adding the built-ins to `scope`, the constant `BuiltIns`
table is queried as a fallback when lookup in `scope` failed, which is
a tiny bit more memory efficient.

---

## Notes For Reviewers
* split-out from the work on assignments and locals