### PR TITLE
pass10: fix nested loop data-flow analysis

### DIFF
--- a/passes/pass10.nim
+++ b/passes/pass10.nim
@@ -422,17 +422,28 @@ proc lowerProc(c: var PassCtx, tree; n; changes) =
 
   block:
     var
-      loopStart = -1
-      inLoop = false
+      previous = -1
       i = 0
 
-    # forward propagation pass. Outermost loops are iterated twice
+    # reaching definitions analysis: compute for every BB the set of available
+    # locals (stored in the `has` set), which is a forward data-flow problem.
+    # The BBs are sorted in reverse postorder (with the BBs with the back-edges
+    # coming immediately after the other BBs part of the loop). There are also
+    # no jumps to *within a loop*, meaning that a loop's entry BB dominates all
+    # other BBs part of the loop. It follows that:
+    # * after one iteration (in reverse postorder) over a loop's BBs:
+    #   * the reaching definitions of the entry BB were propagated to all BBs
+    #     in the loop
+    #   * the reaching definitions from all within the loop are propagated to
+    #     the back-edge (and thus the entry BB)
+    # * after a second iteration, all reaching definitions from within the
+    #   loop were propagated along every edge leaving the loop
+    #
+    # We therefore know that a loop must only ever be executed twice (at most).
+    # BBs part of a block are visited 2 + N times, where N is the nesting
+    # depth.
     while i < c.bblocks.len:
       let it = addr c.bblocks[i]
-
-      if not inLoop and i > loopStart and it.isLoopStart:
-        inLoop = true
-        loopStart = i
 
       for param in it.params.items:
         it.needs.excl param
@@ -445,14 +456,14 @@ proc lowerProc(c: var PassCtx, tree; n; changes) =
           # that information available to follow-up blocks, for pinned locals
           c.bblocks[o].has.incl it.needs * c.pinned
 
-      if inLoop and it.term == termLoop and it.outgoing[0] == loopStart:
-        # end of the loop reached; jump back to the start of it
-        swap(i, loopStart) # prevent inner loops from being repeated
-        inLoop = false
+      if it.term == termLoop and i > previous:
+        # found a not-yet followed back edge -> follow it
+        previous = i
+        i = it.outgoing[0]
       else:
-        inc i
+        inc i # go to the next BB
 
-    # handle pinned locals: mark them as needed in every block where:
+    # handle pinned locals: mark them as live in every block where:
     # * they're available
     # * a read or write through a pointer happens
     if c.pinned.len > 0:
@@ -460,18 +471,34 @@ proc lowerProc(c: var PassCtx, tree; n; changes) =
         if it.hasIndirectAccess:
           it.needs.incl c.pinned * it.has
 
-    loopStart = i
+    # liveness analysis: compute for every BB the set of locals live at the
+    # start of it, which is a backward data-flow problem. Iterating over the
+    # BB in postorder, given the CFG constraints listed above, it follows that:
+    # * after one iteration over a loop, the live set for the entry BB is
+    #   correct
+    # * after a second iteration, the live set for the loop's other BBs is
+    #   correct too
+    # Note that instead of following loops eagerly (like in the forward pass),
+    # they need to be followed outermost to innermost (i.e., the outermost
+    # loop has to complete a full iteration before any of its nested loops are
+    # repeated)
+    var
+      looping = false
+      entry = 0
+
+    previous = c.bblocks.len # set to something greater than any valid BB index
     i = c.bblocks.high
 
-    # backward propagation pass. Outermost loops are processed twice
     while i >= 0:
       let it = addr c.bblocks[i]
 
-      if not inLoop and i < loopStart and it.term == termLoop:
-        inLoop = true
-        loopStart = i
+      if not looping and i < previous and it.term == termLoop:
+        previous = i
+        looping = true # don't repeat nested loops
+        entry = it.outgoing[0] # the entry BB of the loop
 
-      # a block needs access to every locals its targets need access to:
+      # all locals live in outgoing blocks and of which a definition reaches
+      # here are also live in the current block
       for o in it.outgoing.items:
         it.needs.incl c.bblocks[o].needs * c.bblocks[o].has
 
@@ -479,10 +506,10 @@ proc lowerProc(c: var PassCtx, tree; n; changes) =
       for param in it.params.items:
         it.needs.excl param
 
-      if inLoop and c.bblocks[loopStart].outgoing[0] == i:
-        # start of the loop reached; jump back to the end of it
-        swap(i, loopStart)
-        inLoop = false
+      if looping and entry == i:
+        # entry of the loop reached -> follow the back-edge (in reverse)
+        looping = false # now repeat nested loops
+        i = previous
       else:
         dec i
 

--- a/tests/pass10/t03_ssa_loop_4.expected
+++ b/tests/pass10/t03_ssa_loop_4.expected
@@ -1,0 +1,43 @@
+;$sexp
+(TypeDefs
+  (Int 8)
+  (ProcTy (Void)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Continuations
+      (Continuation (Params)
+        (Locals (Type 0))
+        (Continue 1
+          (List
+            (Move (Local 0)))))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (SelectBool (IntVal 1)
+          (Continue 3 (List))
+          (Continue 2
+            (List
+              (Move (Local 0))))))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (Drop
+          (Copy (Local 0)))
+        (Continue 5
+          (List
+            (Move (Local 0)))))
+      (Continuation (Params) (Locals)
+        (Continue 4 (IntVal 100) (List)))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (Continue 5
+          (List
+            (Move (Local 0)))))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (Loop 1
+          (List
+            (Move (Local 0))))))))

--- a/tests/pass10/t03_ssa_loop_4.test
+++ b/tests/pass10/t03_ssa_loop_4.test
@@ -1,0 +1,17 @@
+discard """
+  description: "
+    Ensure liveness/reaching definitions analysis works with infinite loops.
+  "
+  arguments: "--compileOnly"
+"""
+(TypeDefs
+  (Int 8)
+  (ProcTy (Void)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Locals (Type 0))
+    (Loop
+      (If (IntVal 1)
+        (Drop (Copy (Local 0)))
+        (Asgn (Local 0) (IntVal 100))))))

--- a/tests/pass10/t03_ssa_loop_5.expected
+++ b/tests/pass10/t03_ssa_loop_5.expected
@@ -1,0 +1,81 @@
+;$sexp
+(TypeDefs
+  (Int 8)
+  (ProcTy (Void)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Continuations
+      (Continuation (Params)
+        (Locals (Type 0) (Type 0))
+        (Continue 1
+          (List
+            (Move (Local 0))
+            (Move (Local 1)))))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (SelectBool (IntVal 1)
+          (Continue 3
+            (List
+              (Move (Local 0))
+              (Move (Local 1))))
+          (Continue 2 (List))))
+      (Continuation (Params) (Locals)
+        (Continue 10 (List)))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (Continue 4
+          (List
+            (Move (Local 0))
+            (Move (Local 1)))))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (SelectBool (IntVal 1)
+          (Continue 6
+            (List
+              (Move (Local 1))))
+          (Continue 5
+            (List
+              (Move (Local 0))))))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (Continue 8
+          (List
+            (Move (Local 0)))))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (Drop
+          (Copy (Local 0)))
+        (Continue 7 (IntVal 100)
+          (List
+            (Move (Local 0)))))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (Loop 4
+          (List
+            (Move (Local 0))
+            (Move (Local 1)))))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (Continue 9 (IntVal 200)
+          (List
+            (Move (Local 0)))))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (Drop
+          (Copy (Local 1)))
+        (Loop 1
+          (List
+            (Move (Local 1))
+            (Move (Local 0)))))
+      (Continuation (Params) (Locals)
+        (Continue 11 (List)))
+      (Continuation (Params)))))

--- a/tests/pass10/t03_ssa_loop_5.test
+++ b/tests/pass10/t03_ssa_loop_5.test
@@ -1,0 +1,25 @@
+discard """
+  description: "
+    Ensure liveness/reaching definitions analysis works with nested loops
+    (case 1).
+  "
+"""
+(TypeDefs
+  (Int 8)
+  (ProcTy (Void)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Locals (Type 0) (Type 0))
+    (Stmts
+      (Loop
+        (Stmts
+          (If (IntVal 1) (Break 1))
+          (Loop
+            (Stmts
+              (If (IntVal 1) (Break 1))
+              (Drop (Copy (Local 0)))
+              (Asgn (Local 1) (IntVal 100))))
+          (Asgn (Local 0) (IntVal 200))
+          (Drop (Copy (Local 1)))))
+      (Return))))

--- a/tests/pass10/t03_ssa_loop_6.expected
+++ b/tests/pass10/t03_ssa_loop_6.expected
@@ -1,0 +1,79 @@
+;$sexp
+(TypeDefs
+  (Int 8)
+  (ProcTy (Void)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Continuations
+      (Continuation (Params)
+        (Locals (Type 0))
+        (Continue 1
+          (List
+            (Move (Local 0)))))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (Continue 2 (IntVal 200)
+          (List
+            (Move (Local 0)))))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (Drop
+          (Copy (Local 1)))
+        (SelectBool (IntVal 1)
+          (Continue 4
+            (List
+              (Move (Local 0))
+              (Move (Local 1))))
+          (Continue 3 (List))))
+      (Continuation (Params) (Locals)
+        (Continue 10 (List)))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (Continue 5
+          (List
+            (Move (Local 0))
+            (Move (Local 1)))))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (SelectBool (IntVal 1)
+          (Continue 7
+            (List
+              (Move (Local 0))))
+          (Continue 6
+            (List
+              (Move (Local 1))))))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (Continue 9
+          (List
+            (Move (Local 0)))))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (Drop
+          (Copy (Local 0)))
+        (Continue 8 (IntVal 100)
+          (List
+            (Move (Local 0)))))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (Loop 5
+          (List
+            (Move (Local 1))
+            (Move (Local 0)))))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (Loop 1
+          (List
+            (Move (Local 0)))))
+      (Continuation (Params) (Locals)
+        (Continue 11 (List)))
+      (Continuation (Params)))))

--- a/tests/pass10/t03_ssa_loop_6.test
+++ b/tests/pass10/t03_ssa_loop_6.test
@@ -1,0 +1,25 @@
+discard """
+  description: "
+    Ensure liveness/reaching definitions analysis works with nested loops
+    (case 2).
+  "
+"""
+(TypeDefs
+  (Int 8)
+  (ProcTy (Void)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Locals (Type 0) (Type 0))
+    (Stmts
+      (Loop
+        (Stmts
+          (Asgn (Local 0) (IntVal 200))
+          (Drop (Copy (Local 1)))
+          (If (IntVal 1) (Break 1))
+          (Loop
+            (Stmts
+              (If (IntVal 1) (Break 1))
+              (Drop (Copy (Local 0)))
+              (Asgn (Local 1) (IntVal 100))))))
+      (Return))))

--- a/tests/pass10/t03_ssa_loop_7.expected
+++ b/tests/pass10/t03_ssa_loop_7.expected
@@ -1,0 +1,115 @@
+;$sexp
+(TypeDefs
+  (Int 8)
+  (ProcTy (Void)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Continuations
+      (Continuation (Params)
+        (Locals (Type 0) (Type 0))
+        (Continue 1
+          (List
+            (Move (Local 0))
+            (Move (Local 1)))))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (SelectBool (IntVal 1)
+          (Continue 3
+            (List
+              (Move (Local 0))
+              (Move (Local 1))))
+          (Continue 2 (List))))
+      (Continuation (Params) (Locals)
+        (Continue 14 (List)))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (Continue 4
+          (List
+            (Move (Local 0))
+            (Move (Local 1)))))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (SelectBool (IntVal 1)
+          (Continue 6
+            (List
+              (Move (Local 1))))
+          (Continue 5
+            (List
+              (Move (Local 0))
+              (Move (Local 1))))))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (Continue 8
+          (List
+            (Move (Local 0))
+            (Move (Local 1)))))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (Continue 7 (IntVal 200)
+          (List
+            (Move (Local 0)))))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (Drop
+          (Copy (Local 1)))
+        (Loop 4
+          (List
+            (Move (Local 0))
+            (Move (Local 1)))))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (Continue 9
+          (List
+            (Move (Local 0))
+            (Move (Local 1)))))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (SelectBool (IntVal 1)
+          (Continue 11
+            (List
+              (Move (Local 0))))
+          (Continue 10
+            (List
+              (Move (Local 0))
+              (Move (Local 1))))))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (Continue 13
+          (List
+            (Move (Local 0))
+            (Move (Local 1)))))
+      (Continuation
+        (Params (Type 0))
+        (Locals)
+        (Drop
+          (Copy (Local 0)))
+        (Continue 12 (IntVal 100)
+          (List
+            (Move (Local 0)))))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (Loop 9
+          (List
+            (Move (Local 1))
+            (Move (Local 0)))))
+      (Continuation
+        (Params (Type 0) (Type 0))
+        (Locals)
+        (Loop 1
+          (List
+            (Move (Local 0))
+            (Move (Local 1)))))
+      (Continuation (Params) (Locals)
+        (Continue 15 (List)))
+      (Continuation (Params)))))

--- a/tests/pass10/t03_ssa_loop_7.test
+++ b/tests/pass10/t03_ssa_loop_7.test
@@ -1,0 +1,28 @@
+discard """
+  description: "
+    Ensure liveness/reaching definitions analysis works with multiple nested
+    loops.
+  "
+"""
+(TypeDefs
+  (Int 8)
+  (ProcTy (Void)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1)
+    (Locals (Type 0) (Type 0))
+    (Stmts
+      (Loop
+        (Stmts
+          (If (IntVal 1) (Break 1))
+          (Loop
+            (Stmts
+              (If (IntVal 1) (Break 1))
+              (Asgn (Local 0) (IntVal 200))
+              (Drop (Copy (Local 1)))))
+          (Loop
+            (Stmts
+              (If (IntVal 1) (Break 1))
+              (Drop (Copy (Local 0)))
+              (Asgn (Local 1) (IntVal 100))))))
+      (Return))))


### PR DESCRIPTION
## Summary

Fix both the reaching definitions and liveness analysis not handling
nested loops correctly, resulting in compiler crashes or
miscompilation.

## Details

Only iterating the outermost loop twice doesn't ensure that a fixpoint
is reached -- it necessary to process *every* loop 2 + N times, where N
is the nesting depth. The documentation of both analysis passes is
improved to better describe what they do and why they work like they
do.

Tests are added to ensure that nested loops are handled correctly.
Except for `t03_ssa_loop_4`, the previous implementation produced
incorrect code for the new tests.