### PR TITLE
pass0: omit unnecessary jumps

### DIFF
--- a/tests/pass0/t03_checked_void_call.expected
+++ b/tests/pass0/t03_checked_void_call.expected
@@ -4,7 +4,5 @@
 .end
 .start t0 p1
   Call p0 0
-  Jmp L2
-.label L2
   Ret
 .end

--- a/tests/pass0/t03_drop.expected
+++ b/tests/pass0/t03_drop.expected
@@ -3,7 +3,5 @@
 .start t1 p0
   LdImmInt 8
   Drop
-  Jmp L3
-.label L3
   Ret
 .end

--- a/tests/pass0/t03_void_call.expected
+++ b/tests/pass0/t03_void_call.expected
@@ -4,7 +4,5 @@
 .end
 .start t0 p1
   Call p0 0
-  Jmp L2
-.label L2
   Ret
 .end

--- a/tests/pass0/t04_checked_call_asgn.expected
+++ b/tests/pass0/t04_checked_call_asgn.expected
@@ -8,8 +8,6 @@
 .local lo0 int
   Call p0 0
   PopLocal lo0
-  Jmp L3
-.label L3
   GetLocal lo0
   Ret
 .end


### PR DESCRIPTION
Don't emit single-instruction jumps to the following basic block at the
end of basic blocks. They're unnecessary, and omitting them
significantly reduces code size for procedures with many basic blocks.