### PR TITLE
vm: fix `opcBitNot` validation

### DIFF
--- a/tests/vm/t04_bitnot.test
+++ b/tests/vm/t04_bitnot.test
@@ -1,0 +1,9 @@
+discard """
+  output: "(Done (18446744072277895850 or -1431655766))"
+"""
+.type P1 (Proc (Int))
+.start P1 main
+LdImmInt 0x55555555 # 0101_0101...
+BitNot
+Ret
+.end

--- a/vm/vmvalidation.nim
+++ b/vm/vmvalidation.nim
@@ -149,7 +149,7 @@ proc run(ctx: var ValidationState, env: VmEnv, pos: PrgCtr, instr: Instr
     pop(vtInt)
     push(vtInt)
     check imm8(instr) in 0..63, "width not in range 0..63"
-  of opcNegInt, opcNot:
+  of opcNegInt, opcNot, opcBitNot:
     pop(vtInt)
     push(vtInt)
   of opcAddFloat, opcSubFloat, opcMulFloat, opcDivFloat:
@@ -158,7 +158,7 @@ proc run(ctx: var ValidationState, env: VmEnv, pos: PrgCtr, instr: Instr
   of opcNegFloat:
     pop(vtFloat)
     push(vtFloat)
-  of opcBitNot, opcOffset:
+  of opcOffset:
     pop(vtInt)
     pop(vtInt)
     push(vtInt)


### PR DESCRIPTION
## Summary

* fix validation for `opcBitNot` expecting two inputs (instead of only
  one)
* support integers in hexadecimal form (both `0xn` and `#n`) with the
  assembler

## Details

The `opcBitNot` operation only needs a single stack operand, but the
validation required two. This is now fixed, and a test for `opcBitNot`
is added to make sure validation and execution of it works.

For convenience of writing the test, the assembler is extended to
support integers in hexadecimal form in all places where integer
numbers are expected.

---

## Notes For Reviewers
* discovered while testing the VM with bytecode generated from a real-world codebase