### PR TITLE
pass0: fix `BitAnd` and `BitOr` translation

### DIFF
--- a/passes/pass0.nim
+++ b/passes/pass0.nim
@@ -290,12 +290,14 @@ proc genExpr(c; tree; val: NodeIndex) =
     c.instr(opcBitNot)
     c.mask(typ) # discard the unused higher bits
   of BitAnd:
-    c.genExpr(tree, tree.child(val, 0))
-    c.genExpr(tree, tree.child(val, 1))
+    let (_, a, b) = tree.triplet(val)
+    c.genExpr(tree, a)
+    c.genExpr(tree, b)
     c.instr(opcBitAnd)
   of BitOr:
-    c.genExpr(tree, tree.child(val, 0))
-    c.genExpr(tree, tree.child(val, 1))
+    let (_, a, b) = tree.triplet(val)
+    c.genExpr(tree, a)
+    c.genExpr(tree, b)
     c.instr(opcBitOr)
   of BitXor:
     c.genBinaryArithOp(tree, val, opcBitXor, opcBitXor, opcNop)

--- a/tests/pass0/t03_bitand.expected
+++ b/tests/pass0/t03_bitand.expected
@@ -1,0 +1,8 @@
+.type t0 (Int)
+.type t1 (Proc t0)
+.start t1 p0
+  LdImmInt 16
+  LdImmInt 48
+  BitAnd
+  Ret
+.end

--- a/tests/pass0/t03_bitand.test
+++ b/tests/pass0/t03_bitand.test
@@ -1,0 +1,14 @@
+discard """
+  output: "(Done 16)"
+"""
+(TypeDefs
+  (Int 8)
+  (ProcTy (Type 0)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1) (Locals)
+    (Continuations
+      (Continuation (Params) 0
+        (Continue 1
+          (BitAnd (Type 0) (IntVal 16) (IntVal 48))))
+      (Continuation (Params (Type 0))))))

--- a/tests/pass0/t03_bitor.expected
+++ b/tests/pass0/t03_bitor.expected
@@ -1,0 +1,8 @@
+.type t0 (Int)
+.type t1 (Proc t0)
+.start t1 p0
+  LdImmInt 48
+  LdImmInt 40
+  BitOr
+  Ret
+.end

--- a/tests/pass0/t03_bitor.test
+++ b/tests/pass0/t03_bitor.test
@@ -1,0 +1,14 @@
+discard """
+  output: "(Done 56)"
+"""
+(TypeDefs
+  (Int 8)
+  (ProcTy (Type 0)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 1) (Locals)
+    (Continuations
+      (Continuation (Params) 0
+        (Continue 1
+          (BitOr (Type 0) (IntVal 48) (IntVal 40))))
+      (Continuation (Params (Type 0))))))


### PR DESCRIPTION
The implementation erroneously treated the trees as having only two
child nodes, while they actually have three (type, operand a, operand
b).

---

## Notes For Reviewers
* discovered while testing the pass with some real-world code