### PR TITLE
add the `phy` CLI application

### DIFF
--- a/common/vmexec.nim
+++ b/common/vmexec.nim
@@ -174,7 +174,7 @@ proc run*(env: var VmEnv, prc: ProcIndex): string =
     result.addInt res.stub.int
   of yrkUnhandledException:
     result.add " "
-    result.add $res.exc
+    result.add $res.exc.uintVal
   of yrkUser:
     unreachable() # shouldn't happen
 

--- a/common/vmexec.nim
+++ b/common/vmexec.nim
@@ -12,6 +12,8 @@ import
     utils
   ]
 
+import vm/vmtypes except tkVoid, tkInt, tkFloat
+
 proc readInt(p: HostPointer, size: range[1..8]): int64 =
   copyMem(addr result, p, size)
 
@@ -138,3 +140,42 @@ proc run*(env: var VmEnv, prc: ProcIndex, typ: SemType): string =
     result = "unhandled exception: " & $res.exc.intVal
   of yrkStubCalled, yrkUser:
     unreachable() # shouldn't happen
+
+proc run*(env: var VmEnv, prc: ProcIndex): string =
+  ## Runs the nullary procedure with index `prc` and returns the VM's result
+  ## formatted as an S-expression.
+  var thread = vm.initThread(env, prc, 1024, @[])
+
+  let res = run(env, thread, nil)
+  env.dispose(thread)
+
+  # render the result:
+  result = "(" & substr($res.kind, 3)
+  case res.kind
+  of yrkDone:
+    case env.types[res.typ].kind
+    of vmtypes.TypeKind.tkVoid, tkProc, tkForeign:
+      discard
+    of vmtypes.TypeKind.tkInt:
+      result.add " "
+      if res.result.uintVal <= high(int64).uint64:
+        # the signed and unsigned interpretation yield the same value
+        result.addInt res.result.uintVal
+      else:
+        # output both interpretations
+        result.add "(" & $res.result.uintVal & " or " & $res.result.intVal & ")"
+    of vmtypes.TypeKind.tkFloat:
+      result.add " " & $res.result.floatVal
+  of yrkError:
+    result.add " "
+    result.add $res.error
+  of yrkStubCalled:
+    result.add " "
+    result.addInt res.stub.int
+  of yrkUnhandledException:
+    result.add " "
+    result.add $res.exc
+  of yrkUser:
+    unreachable() # shouldn't happen
+
+  result.add ")"

--- a/koch.nim
+++ b/koch.nim
@@ -19,7 +19,8 @@ Commands:
   Programs: seq[(string, string, bool)] = @[
     ("tester", "tools/tester.nim", true),
     ("passtool", "tools/passtool/passtool.nim", true),
-    ("repl", "tools/repl.nim", false)
+    ("repl", "tools/repl.nim", false),
+    ("phy", "phy/phy.nim", false)
   ]
     ## maps program names to the associated path and whether the program
     ## doesn't depend on generated modules

--- a/passes/spec.nim
+++ b/passes/spec.nim
@@ -67,5 +67,5 @@ proc toSexp*(tree: PackedTree[NodeKind], idx: NodeIndex,
   of Global:    sexp([newSSymbol("Global"), sexp n.val.int])
   else:         unreachable()
 
-proc fromSexp*(i: BiggestInt): TreeNode[NodeKind] =
+proc fromSexp*(i: BiggestInt, _: typedesc[NodeKind]): TreeNode[NodeKind] =
   TreeNode[NodeKind](kind: Immediate, val: i.uint32)

--- a/passes/spec_source.nim
+++ b/passes/spec_source.nim
@@ -56,5 +56,5 @@ proc toSexp*(tree: PackedTree[NodeKind], idx: NodeIndex,
   of Ident:     sexp([newSSymbol("Ident"), sexp tree.getString(idx)])
   else:         unreachable()
 
-proc fromSexp*(i: BiggestInt): TreeNode[NodeKind] =
+proc fromSexp*(i: BiggestInt, _: typedesc[NodeKind]): TreeNode[NodeKind] =
   TreeNode[NodeKind](kind: Immediate, val: i.uint32)

--- a/passes/trees.nim
+++ b/passes/trees.nim
@@ -247,7 +247,7 @@ proc fromSexp[T](n: SexpNode, to: var PackedTree[T]) =
       for i in 1..<n.len:
         fromSexp(n[i], to)
   of SInt:
-    to.nodes.add fromSexp(n.num)
+    to.nodes.add fromSexp(n.num, T)
   else:
     doAssert false
 

--- a/phy/nim.cfg
+++ b/phy/nim.cfg
@@ -1,0 +1,3 @@
+# add the root directory as a path, so that imports have direct access to
+# all directories in the root
+--path:"../"

--- a/phy/phy.nim
+++ b/phy/phy.nim
@@ -142,7 +142,7 @@ proc print(env: VmEnv) =
     stdout.write(disassemble(env))
 
 proc sourceToIL(text: string): (PackedTree[spec.NodeKind], SemType) =
-  ## Given a S-expression representation of the source language (`text`),
+  ## Given an S-expression representation of the source language (`text`),
   ## analyzes it and translates it to the highest-level IL. Also returns the
   ## return of the procedure to executre, or ``tkError`` if there is no
   ## procedure to run.

--- a/phy/phy.nim
+++ b/phy/phy.nim
@@ -1,0 +1,345 @@
+## Implements a CLI for running the various parts that make up Phy. This
+## includes the assembler, the various passes, `source2IL <source2il.html>`_,
+## and the VM.
+
+import
+  std/[
+    os,
+    parseopt,
+    streams,
+    strutils
+  ],
+  experimental/[
+    sexp
+  ],
+  common/[
+    vmexec
+  ],
+  generated/[
+    lang0_checks,
+    lang1_checks,
+    lang3_checks,
+    lang4_checks,
+    lang10_checks,
+    source_checks
+  ],
+  passes/[
+    changesets,
+    debugutils,
+    source2il,
+    pass0,
+    pass1,
+    pass3,
+    pass4,
+    pass10,
+    trees
+  ],
+  phy/[
+    default_reporting,
+    types
+  ],
+  vm/[
+    assembler,
+    disasm,
+    utils,
+    vmenv,
+    vmvalidation
+  ]
+
+# cannot import normally, as some type names would conflict
+import passes/spec except NodeKind
+import passes/spec_source except NodeKind
+
+type
+  Language = enum
+    langBytecode = "vm"
+    lang0 = "L0"
+    lang1 = "L1"
+    lang3 = "L3"
+    lang4 = "L4"
+    lang10 = "L10"
+    langSource = "source"
+
+  Command = enum
+    None
+    Compile = "c"
+    Eval = "e"
+
+const
+  HelpText = """
+Usage:
+  phy <command> [options] <filename>
+
+Options:
+  --source:lang               the language the input file uses
+  --target:lang               the language to translate/lower to
+  --tester                    enable some tester-specific functionality
+
+Commands:
+  c                           translates/lowers the code from the source
+                              language to the target language
+  e                           similar to 'c', but also runs the generated
+                              bytecode and echoes the result
+"""
+
+var
+  gShow: set[Language]
+    ## the set of languages for which the IR should be printed once available
+  gTester = false
+    ## whether the program is invoked as part of testing. This enables some
+    ## accomodations for the tester
+
+proc error(msg: string) =
+  echo "Error: ", msg
+  quit 1
+
+template syntaxCheck(code: PackedTree, module, name: untyped) {.dirty.} =
+  # for some reason, ``checkSyntax`` from ``debugutils`` doesn't want to work
+  # within this module
+  module.check(code, NodeIndex(0), name):
+    if node in code:
+      echo "Syntax error: \"", rule, "\" didn't match for child node '", child,
+          "' (kind = ", code[node, child].kind, ") of '", ord(node), "'"
+    else:
+      echo "Syntax error: \"", rule, "\" didn't match. Unexpected end"
+    quit(1)
+
+proc syntaxCheck(code: PackedTree[spec.NodeKind], lang: Language) =
+  ## Runs the syntax checks for `lang` on `code`, aborting the program with an
+  ## error if they don't succeed.
+  case lang
+  of lang0:  syntaxCheck(code, lang0_checks, module)
+  of lang1:  syntaxCheck(code, lang1_checks, module)
+  of lang3:  syntaxCheck(code, lang3_checks, module)
+  of lang4:  syntaxCheck(code, lang4_checks, module)
+  of lang10: syntaxCheck(code, lang10_checks, module)
+  else:      unreachable()
+
+template genericPrint(lang: Language, body: untyped) =
+  let L = lang
+  if L in gShow:
+    # for the tester, the output is formatted such that it's easy
+    # to detect where the end is
+    if not gTester:
+      stdout.writeLine("---- " & $L)
+
+    body
+
+    if gTester:
+      stdout.write("!BREAK!")
+    else:
+      stdout.writeLine("----")
+
+proc print(tree: PackedTree[spec.NodeKind], lang: Language) =
+  genericPrint(lang):
+    stdout.writeLine(pretty(tree, tree.child(0)))
+    stdout.writeLine(pretty(tree, tree.child(1)))
+    stdout.writeLine(pretty(tree, tree.child(2)))
+
+proc print(env: VmEnv) =
+  genericPrint(langBytecode):
+    stdout.write(disassemble(env))
+
+proc sourceToIL(text: string): (PackedTree[spec.NodeKind], SemType) =
+  ## Given a S-expression representation of the source language (`text`),
+  ## analyzes it and translates it to the highest-level IL. Also returns the
+  ## return of the procedure to executre, or ``tkError`` if there is no
+  ## procedure to run.
+  ##
+  ## A failure during analysis aborts the program.
+  var code = fromSexp[spec_source.NodeKind](parseSexp(text))
+
+  var reporter = initDefaultReporter[string]()
+  var ctx = source2il.open(reporter)
+
+  case code[NodeIndex(0)].kind
+  of DeclNodes:
+    # it's a single declaration
+    syntaxCheck(code, source_checks, decl)
+    ctx.declToIL(code, NodeIndex(0))
+  of ExprNodes:
+    # it's a standalone expression
+    syntaxCheck(code, source_checks, expr)
+    discard ctx.exprToIL(code)
+  of spec_source.NodeKind.Module:
+    # it's a full module. Translate all declarations
+    syntaxCheck(code, source_checks, module)
+    for it in code.items(NodeIndex(0)):
+      ctx.declToIL(code, it)
+
+    # the last procedure is the one that will be executed
+  else:
+    error "unexpected node: " & $code[NodeIndex(0)].kind
+
+  # don't continue if there was an error:
+  let messages = reporter[].retrieve()
+  if messages.len > 0:
+    for it in messages.items:
+      echo "Error: ", it
+    quit(2)
+
+  result[1] =
+    if ctx.procList.len > 0: ctx.procList[^1].result
+    else:                    prim(tkError)
+  result[0] = ctx.close()
+
+proc compile(tree: var PackedTree[spec.NodeKind], source, target: Language) =
+  assert source != langSource
+  assert ord(source) >= ord(target)
+  var current = source
+  while current != target:
+    case current
+    of lang0, langBytecode, langSource:
+      assert false, "cannot be handled here: " & $current
+    of lang1:
+      syntaxCheck(tree, lang1_checks, module)
+      # TODO: don't hardcode the pointer size
+      tree = tree.apply(pass1.lower(tree, 8))
+      current = lang0
+    of lang3:
+      syntaxCheck(tree, lang3_checks, module)
+      # TODO: don't hardcode the pointer size
+      tree = tree.apply(pass3.lower(tree, 8))
+      current = lang1
+    of lang4:
+      syntaxCheck(tree, lang4_checks, module)
+      tree = tree.apply(pass4.lower(tree))
+      current = lang3
+    of lang10:
+      syntaxCheck(tree, lang10_checks, module)
+      tree = tree.apply(pass10.lower(tree))
+      current = lang4
+
+    print(tree, current)
+
+proc main(args: openArray[string]) =
+  var opts = initOptParser(args)
+  var input = ""
+
+  var source = langSource
+  var target = langBytecode
+
+  var cmd = None
+
+  for (kind, key, arg) in opts.getopt():
+    case kind
+    of cmdShortOption:
+      error "unknown option: " & key
+    of cmdLongOption:
+      case key
+      of "tester":
+        gTester = true
+      of "source":
+        source = parseEnum[Language](arg)
+      of "target":
+        target = parseEnum[Language](arg)
+      of "show":
+        gShow.incl parseEnum[Language](arg)
+      else:
+        error "unknown option: " & key
+    of cmdArgument:
+      if cmd == None:
+        cmd = parseEnum[Command](key)
+      else:
+        # must be the input filename
+        input = key
+    of cmdEnd:
+      unreachable()
+
+  # make sure the command line arguments are sensible:
+  case cmd
+  of None:
+    echo HelpText
+    quit(1)
+  of Eval:
+    if target != langBytecode:
+      error "'e' requires the target language to be '" & $langBytecode & "'"
+  else:
+    discard "nothing special to do"
+
+  if ord(target) > ord(source):
+    error "invalid source and target language pair"
+
+  if input.len == 0:
+    error "a filename must be provided"
+
+  var s = openFileStream(input, fmRead)
+  if gTester:
+    # skip the test file header, if any
+    if s.readLine() == "discard \"\"\"":
+      while not s.readLine().endsWith("\"\"\""):
+        discard
+    else:
+      s.setPosition(0)
+
+  let text = s.readAll()
+  s.close()
+
+  var
+    env = initVm(1024, 1024 * 1024) # 1MB of memory
+    code: PackedTree[spec.NodeKind]
+    typ: SemType
+
+  if source == langBytecode:
+    # run the assembler on the input lines
+    var
+      a = AssemblerState()
+      lineN = 1
+
+    for line in splitLines(text, false):
+      try:
+        a.process(line, env)
+      except AssemblerError as e:
+        error input & "(" & $lineN & ", 1): " & e.msg
+      inc lineN
+  else:
+    var newSource = source
+
+    # the input is in some higher-level language
+    if source == langSource:
+      # translate to the highest-level IL first
+      (code, typ) = sourceToIL(text)
+      newSource = lang10
+      print(code, newSource)
+    elif gTester:
+      # in order to reduce visual noise in tests, the ``(Module ...)`` top
+      # level node is added implicitly
+      code = fromSexp[spec.NodeKind](parseSexp("(Module " & text & ")"))
+    else:
+      code = fromSexp[spec.NodeKind](parseSexp(text))
+
+    if target == langBytecode:
+      # compile to L0 code and then translate to bytecode
+      compile(code, newSource, lang0)
+      syntaxCheck(code, lang0)
+      pass0.translate(code, env)
+      # the bytecode is verified later
+    else:
+      compile(code, newSource, target)
+      # make sure the output code is correct:
+      syntaxCheck(code, target)
+
+  if target == langBytecode:
+    # make sure the environment is correct:
+    let errors = validate(env)
+    if errors.len > 0:
+      echo "Validation of the VM environment failed"
+      for it in errors.items:
+        echo "Error: ", it
+      quit(1)
+
+    print(env)
+
+    # handle the eval command:
+    if cmd == Eval:
+      if env.procs.len == 0:
+        error "there's nothing to run"
+
+      if source == langSource:
+        # we have type high-level type information
+        stdout.write run(env, env.procs.high.ProcIndex, typ)
+      else:
+        # we don't have high-level type information
+        stdout.write run(env, env.procs.high.ProcIndex)
+
+main(getExecArgs())

--- a/tests/pass0/runner.nim
+++ b/tests/pass0/runner.nim
@@ -13,6 +13,9 @@ import
   experimental/[
     sexp
   ],
+  common/[
+    vmexec
+  ],
   generated/[
     lang0_checks
   ],
@@ -65,42 +68,5 @@ if args.len > 1 and args[0] == "--noRun":
   stdout.write("(Done)")
   quit(0)
 
-var
-  thread = vm.initThread(env, env.procs.high.ProcIndex, 1024, @[])
-  res = run(env, thread, nil)
-env.dispose(move thread)
-
-# XXX: the rendering logic is - for the largest part - the same as for the VM
-#      runner. The code should not be duplicated like this
-# render the result:
-var output = "(" & substr($res.kind, 3)
-case res.kind
-of yrkDone:
-  case env.types[res.typ].kind
-  of tkVoid, tkProc, tkForeign:
-    discard
-  of tkInt:
-    output.add " "
-    if res.result.uintVal <= high(int64).uint64:
-      # the signed and unsigned interpretation yield the same value
-      output.addInt res.result.uintVal
-    else:
-      # output both interpretations
-      output.add "(" & $res.result.uintVal & " or " & $res.result.intVal & ")"
-  of tkFloat:
-    output.add " " & $res.result.floatVal
-of yrkError:
-  output.add " "
-  output.add $res.error
-of yrkStubCalled:
-  output.add " "
-  output.addInt res.stub.int
-of yrkUnhandledException:
-  output.add " "
-  output.addInt res.exc.intVal
-of yrkUser:
-  unreachable()
-
-output.add ")"
 # output it:
-stdout.write(output)
+stdout.write(run(env, env.procs.high.ProcIndex))


### PR DESCRIPTION
## Summary

Bundle the passes, `source2il`, the assembler, and the VM into a single
CLI application. The idea with it is to help with development, by
providing a convenient way to invoke the passes/VM/etc. and inspect the
(intermediate) output.

## Details

The `phy` program provides a small command line interface for
specifying the source and target language are, what IRs to print, and
what to do (only compile or also evaluate).

Much of the implementation is copied from the various test runner:
* `source2il` invocation and comes from the `expr` test runner
* rendering VM execution results without high-level type information
  is moved over from the `pass0` test runner (into `vmexec.nim`)

The program also provides the `--runner` option, which makes it
behave in a way such that it's suitable as being used as a test runner,
by lifting some input restrictions and altering the output formatting,
so that it can maybe replace the currently used custom test runners at
some point.
