### PR TITLE
ci: update MacOS runner

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,7 +38,7 @@ jobs:
           - name: MacOS (M1)
             runner: macos-14
           - name: MacOS
-            runner: macos-12
+            runner: macos-13
           - name: Windows
             runner: windows-2022
 


### PR DESCRIPTION
Update the non-arm MacOS runner to the `macos-13` image. The currently
used `macos-12` image is [deprecated](https://github.com/actions/runner-images/issues/10721) and will soon become unsupported.