### PR TITLE
lang: add the logical `And` and `Or` operators

### DIFF
--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -429,7 +429,7 @@ proc fitExprStrict(c; e: sink Expr, typ: SemType): Expr =
     result = e # all good
   else:
     c.error("expected expression of type $1 but got type $2" %
-            [$e.typ.kind, $typ.kind])
+            [$typ.kind, $e.typ.kind])
     # turn into an error expression:
     result = Expr(stmts: e.stmts, expr: @[Node(kind: IntVal)],
                   typ: errorType())

--- a/passes/spec_source.nim
+++ b/passes/spec_source.nim
@@ -12,6 +12,7 @@ type
     Immediate, IntVal, FloatVal
     Ident,
     VoidTy, UnitTy, BoolTy, IntTy, FloatTy, TupleTy, UnionTy
+    And, Or
     If
     Call
     TupleCons
@@ -27,8 +28,8 @@ type
     Module
 
 const
-  ExprNodes* = {IntVal, FloatVal, Ident, If, Call, TupleCons, FieldAccess,
-                Asgn, Return, Unreachable, Exprs, Decl}
+  ExprNodes* = {IntVal, FloatVal, Ident, And, Or, If, Call, TupleCons,
+                FieldAccess, Asgn, Return, Unreachable, Exprs, Decl}
   DeclNodes* = {ProcDecl, TypeDecl}
   AllNodes* = {low(NodeKind) .. high(NodeKind)}
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -314,6 +314,40 @@ expression is `void`, otherwise the type is that of the trailing expression.
 **Expression kind**: same as that of the trailing expression
 **Uses**: nothing
 
+#### Logical `And`
+
+```grammar
+expr += (And a:<expr> b:<expr>)
+```
+
+Evaluates to `true` when both `a` and `b` evaluate to `true`, `false`
+otherwise. `b` is only evaluated if `a` evaluates to `true`. The type of an
+`And` expression is `bool`.
+
+In terms of scoping, `(And a b)` is equivalent with `(If a b (Ident "false"))`.
+
+An error is reported if the type of either `a` or `b` is not `bool`.
+
+**Expression kind**: rvalue
+**Uses**: `a` and `b`
+
+#### Logical `Or`
+
+```grammar
+expr += (Or a:<expr> b:<expr>)
+```
+
+Evaluates to `true` when `a`, `b`, or both `a` and `b` evaluate to `true`,
+`false` otherwise. `b` is only evaluated if `a` evaluates to `false`. The type
+of an `Or` expression is `bool`.
+
+In terms of scoping, `(Or a b)` is equivalent with `(If a (Ident "true") b)`.
+
+An error is reported if the type of either `a` or `b` is not `bool`.
+
+**Expression kind**: rvalue
+**Uses**: `a` and `b`
+
 #### Assignment
 
 ```grammar

--- a/tests/expr/t12_and_result_1.test
+++ b/tests/expr/t12_and_result_1.test
@@ -1,0 +1,4 @@
+discard """
+  output: "true: bool"
+"""
+(And (Ident "true") (Ident "true"))

--- a/tests/expr/t12_and_result_2.test
+++ b/tests/expr/t12_and_result_2.test
@@ -1,0 +1,4 @@
+discard """
+  output: "false: bool"
+"""
+(And (Ident "true") (Ident "false"))

--- a/tests/expr/t12_and_result_3.test
+++ b/tests/expr/t12_and_result_3.test
@@ -1,0 +1,4 @@
+discard """
+  output: "false: bool"
+"""
+(And (Ident "false") (Ident "true"))

--- a/tests/expr/t12_and_result_4.test
+++ b/tests/expr/t12_and_result_4.test
@@ -1,0 +1,4 @@
+discard """
+  output: "false: bool"
+"""
+(And (Ident "false") (Ident "false"))

--- a/tests/expr/t12_and_scoping.test
+++ b/tests/expr/t12_and_scoping.test
@@ -1,0 +1,15 @@
+discard """
+  description: "
+    Declarations in the first operand expression are part of the surrounding
+    scope.
+  "
+  output: "100: int"
+"""
+(Exprs
+  (Decl (Ident "a")
+    (And
+      (Exprs
+        (Decl (Ident "b") (IntVal 100))
+        (Ident "true"))
+      (Ident "true")))
+  (Ident "b"))

--- a/tests/expr/t12_and_scoping_error.test
+++ b/tests/expr/t12_and_scoping_error.test
@@ -1,0 +1,15 @@
+discard """
+  description: "
+    Declarations in the second operand expression are *not* part of the
+    surrounding scope.
+  "
+  reject: true
+"""
+(Exprs
+  (Decl (Ident "a")
+    (And
+      (Ident "true")
+      (Exprs
+        (Decl (Ident "b") (IntVal 100))
+        (Ident "true"))))
+  (Ident "b"))

--- a/tests/expr/t12_and_short_circuit.test
+++ b/tests/expr/t12_and_short_circuit.test
@@ -1,0 +1,16 @@
+discard """
+  description: "
+    The second `And` operand expression is not evaluated when the first one
+    evaluates to false.
+  "
+  output: "100: int"
+"""
+(Exprs
+  (Decl (Ident "a") (IntVal 100))
+  (Decl (Ident "b")
+    (And
+      (Ident "false")
+      (Exprs
+        (Asgn (Ident "a") (IntVal 200))
+        (Ident "true"))))
+  (Ident "a"))

--- a/tests/expr/t12_and_typing_1_error.test
+++ b/tests/expr/t12_and_typing_1_error.test
@@ -1,0 +1,4 @@
+discard """
+  reject: true
+"""
+(And (IntVal 100) (Ident "false"))

--- a/tests/expr/t12_and_typing_2_error.test
+++ b/tests/expr/t12_and_typing_2_error.test
@@ -1,0 +1,4 @@
+discard """
+  reject: true
+"""
+(And (Ident "false") (IntVal 100))

--- a/tests/expr/t12_or_result_1.test
+++ b/tests/expr/t12_or_result_1.test
@@ -1,0 +1,4 @@
+discard """
+  output: "true: bool"
+"""
+(Or (Ident "true") (Ident "true"))

--- a/tests/expr/t12_or_result_2.test
+++ b/tests/expr/t12_or_result_2.test
@@ -1,0 +1,4 @@
+discard """
+  output: "true: bool"
+"""
+(Or (Ident "true") (Ident "false"))

--- a/tests/expr/t12_or_result_3.test
+++ b/tests/expr/t12_or_result_3.test
@@ -1,0 +1,4 @@
+discard """
+  output: "true: bool"
+"""
+(Or (Ident "false") (Ident "true"))

--- a/tests/expr/t12_or_result_4.test
+++ b/tests/expr/t12_or_result_4.test
@@ -1,0 +1,4 @@
+discard """
+  output: "false: bool"
+"""
+(Or (Ident "false") (Ident "false"))

--- a/tests/expr/t12_or_scoping.test
+++ b/tests/expr/t12_or_scoping.test
@@ -1,0 +1,15 @@
+discard """
+  description: "
+    Declarations in the first operand expression are part of the surrounding
+    scope.
+  "
+  output: "100: int"
+"""
+(Exprs
+  (Decl (Ident "a")
+    (Or
+      (Exprs
+        (Decl (Ident "b") (IntVal 100))
+        (Ident "true"))
+      (Ident "true")))
+  (Ident "b"))

--- a/tests/expr/t12_or_scoping_error.test
+++ b/tests/expr/t12_or_scoping_error.test
@@ -1,0 +1,15 @@
+discard """
+  description: "
+    Declarations in the second operand expression are *not* part of the
+    surrounding scope.
+  "
+  reject: true
+"""
+(Exprs
+  (Decl (Ident "a")
+    (Or
+      (Ident "false")
+      (Exprs
+        (Decl (Ident "b") (IntVal 100))
+        (Ident "true"))))
+  (Ident "b"))

--- a/tests/expr/t12_or_short_circuit.test
+++ b/tests/expr/t12_or_short_circuit.test
@@ -1,0 +1,16 @@
+discard """
+  description: "
+    The second `Or` operand expression is not evaluated when the first one
+    evaluates to true.
+  "
+  output: "100: int"
+"""
+(Exprs
+  (Decl (Ident "a") (IntVal 100))
+  (Decl (Ident "b")
+    (Or
+      (Ident "true")
+      (Exprs
+        (Asgn (Ident "a") (IntVal 200))
+        (Ident "true"))))
+  (Ident "a"))

--- a/tests/expr/t12_or_typing_1_error.test
+++ b/tests/expr/t12_or_typing_1_error.test
@@ -1,0 +1,4 @@
+discard """
+  reject: true
+"""
+(Or (IntVal 100) (Ident "false"))

--- a/tests/expr/t12_or_typing_2_error.test
+++ b/tests/expr/t12_or_typing_2_error.test
@@ -1,0 +1,4 @@
+discard """
+  reject: true
+"""
+(Or (Ident "false") (IntVal 100))


### PR DESCRIPTION
## Summary

Add the logical `And` and `Or` operators to the source language.

## Details

Both operators short-circuit evaluation of the second operand. For this
reason, dedicated expression kinds are used instead of built-in calls.

Since the second expression of both `And` and `Or` is evaluated
conditionally, it is analyzed within its own scope in order to prevent
declarations therein from being visible to the outside -- such locals
would be in an undefined state when the expression is not evaluated.

`And` is implemented as the statement version of `(If a b False)`; `Or`
is implemented as the statement version of `(If a True b)`.
