### PR TITLE
source2il: fix code generation for usage of locals

### DIFF
--- a/tests/expr/t13_usage_in_and.test
+++ b/tests/expr/t13_usage_in_and.test
@@ -1,0 +1,7 @@
+discard """
+  description: "Make sure a local can be used as both `And` operands"
+  output: "false: bool"
+"""
+(Exprs
+  (Decl (Ident "a") (Ident "false"))
+  (And (Ident "a") (Ident "a")))

--- a/tests/expr/t13_usage_in_if_cond.test
+++ b/tests/expr/t13_usage_in_if_cond.test
@@ -1,0 +1,8 @@
+discard """
+  description: "Make sure a local can be used as the `If` condition"
+  output: "(): unit"
+"""
+(Exprs
+  (Decl (Ident "a") (Ident "false"))
+  (If (Ident "a")
+    (Unreachable)))

--- a/tests/expr/t13_usage_in_not.test
+++ b/tests/expr/t13_usage_in_not.test
@@ -1,0 +1,7 @@
+discard """
+  description: "Make sure a local can be used as the `not` operand"
+  output: "true: bool"
+"""
+(Exprs
+  (Decl (Ident "a") (Ident "false"))
+  (Call (Ident "not") (Ident "a"))))

--- a/tests/expr/t13_usage_in_or.test
+++ b/tests/expr/t13_usage_in_or.test
@@ -1,0 +1,7 @@
+discard """
+  description: "Make sure a local can be used as both `Or` operands"
+  output: "false: bool"
+"""
+(Exprs
+  (Decl (Ident "a") (Ident "false"))
+  (Or (Ident "a") (Ident "a")))

--- a/tests/expr/t13_usage_in_return.test
+++ b/tests/expr/t13_usage_in_return.test
@@ -1,0 +1,8 @@
+discard """
+  description: "Make sure a local can be used as the `Return` operand"
+  output: "100: int"
+"""
+(ProcDecl (Ident "man") (IntTy) (Params)
+  (Exprs
+    (Decl (Ident "a") (IntVal 100))
+    (Return (Ident "a"))))


### PR DESCRIPTION
## Summary

Fix a `source2il` translation bug causing internal syntax errors when
using locals as `not`, `And`, `Or`, `If` or `Return` operands.

## Details

In the L30 language, loading the underlying value stored in a local
requires using `Copy` (which is also enforced by the gramamr). This was
not considered everywhere in `source2il`, leading to the L30 output
having syntax errors.

The problematic translation is changed to use `genUse` instead of
`inline` or manually adding the node sequences. For convenience, a
`genUse` overload is added that takes an `Expr`.

A test is added for each case where compilation previously failed.

---

## Notes for Reviewers
* discovered as part of #67 
* I've audited every use of `inline` and every manual appending of `Expr.expr` for whether it's correct
