### PR TITLE
pass0: fix `Conv` for float-to-float conversions

### DIFF
--- a/passes/pass0.nim
+++ b/passes/pass0.nim
@@ -388,15 +388,11 @@ proc genExpr(c; tree; val: NodeIndex) =
         c.instr(opcUIntToFloat, int8(dtyp.size * 8))
       of t0kFloat:
         if styp.size == 8 and dtyp.size == 4:
-          # narrowing conversion
-          c.instr(opcStackAlloc, int32 4)
-          c.instr(opcSwap)
-          c.instr(opcDup)
-          # write to memory location
-          c.instr(opcWrFlt32)
-          # read back
-          c.instr(opcLdFlt32)
-          c.instr(opcStackFree, int32 4)
+          # demote 64-bit float to 32-bit float value. Reinterpret the bits as
+          # a 32-bit integer (which internally converts to a 32-bit float
+          # first) and then reinterpret the result as a 32-bit float
+          c.instr(opcReinterpI32)
+          c.instr(opcReinterpF32)
   of Call:
     c.genCall(tree, val, 0, ^1)
   else:

--- a/tests/pass0/t03_conv_float64_to_32.expected
+++ b/tests/pass0/t03_conv_float64_to_32.expected
@@ -1,0 +1,10 @@
+.type t0 (Float)
+.type t1 (Float)
+.type t2 (Proc t0)
+.const c0 0.5000000149
+.start t2 p0
+  LdConst c0
+  ReinterpI32
+  ReinterpF32
+  Ret
+.end

--- a/tests/pass0/t03_conv_float64_to_32.test
+++ b/tests/pass0/t03_conv_float64_to_32.test
@@ -1,0 +1,15 @@
+discard """
+  output: "(Done 0.5)"
+"""
+(TypeDefs
+  (Float 4)
+  (Float 8)
+  (ProcTy (Type 0)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 2) (Locals)
+    (Continuations
+      (Continuation (Params) 0
+        (Continue 1
+          (Conv (Type 0) (Type 1) (FloatVal 0.5000000149))))
+      (Continuation (Params (Type 0))))))


### PR DESCRIPTION
## Summary

Fix code generation for float demotion. The previously generated code
did not pass bytecode validation.

## Details

With float value `x` on the operand stack, the instruction sequence
`StackAlloc` + `Swap` + `Dup` results in the operand stack
`x, x, address` (from top to bottom), which is incorrect and fails
validation, as `opcWrFloat32` expects one int and one float input, not
two float inputs.

Memory operations are not needed for implementing float demotion at
all. Reinterpreting the float value as a 32-bit integer (which
internally demotes the float value) first and then reinterpreting the
integer as a 32-bit float suffices.

---

## Note For Reviewer
* the bug was discovered with the help of [skully](https://github.com/nim-works/phy/pull/70)