### PR TITLE
lang: add `While` loops

### DIFF
--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -869,8 +869,8 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): ExprType =
     if cond.typ.kind != tkBool:
       c.error("condition expression must be of type bool")
 
-    if body.typ.kind != tkUnit:
-      c.error("`While` body must be a unit expression")
+    if body.typ.kind notin {tkUnit, tkVoid}:
+      c.error("`While` body must be a unit or void expression")
 
     stmts.addStmt Loop:
       bu.subTree Stmts:

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -857,6 +857,41 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): ExprType =
         c.genAsgn(Node(kind: Local, val: tmp), fe.expr, fe.typ, bu)
     genLocal(tmp, typ, bu)
     result = typ + {}
+  of SourceKind.While:
+    let (a, b) = t.pair(n)
+
+    c.openScope()
+    let
+      cond = c.exprToIL(t, a)
+      body = c.exprToIL(t, b)
+    c.closeScope()
+
+    if cond.typ.kind != tkBool:
+      c.error("condition expression must be of type bool")
+
+    if body.typ.kind != tkUnit:
+      c.error("`While` body must be a unit expression")
+
+    stmts.addStmt Loop:
+      bu.subTree Stmts:
+        bu.add cond.stmts
+        bu.subTree If:
+          bu.subTree Not:
+            genUse(cond.expr, bu)
+          bu.subTree Break:
+            bu.add Node(kind: Immediate, val: 1)
+
+        bu.add body.stmts
+        genDrop(body.expr, body.typ, bu)
+
+    if t[a].kind == SourceKind.Ident and t.getString(a) == "true":
+      # it's a loop that doesn't exit via non-exception control-flow
+      stmts.addStmt Unreachable:
+        discard
+      result = prim(tkVoid) + {}
+    else:
+      bu.add UnitNode
+      result = prim(tkUnit) + {}
   of SourceKind.Call:
     result = callToIL(c, t, n, bu, stmts) + {}
   of SourceKind.TupleCons:

--- a/passes/spec_source.nim
+++ b/passes/spec_source.nim
@@ -14,6 +14,7 @@ type
     VoidTy, UnitTy, BoolTy, IntTy, FloatTy, TupleTy, UnionTy, ProcTy
     And, Or
     If
+    While
     Call
     TupleCons
     FieldAccess
@@ -28,7 +29,7 @@ type
     Module
 
 const
-  ExprNodes* = {IntVal, FloatVal, Ident, And, Or, If, Call, TupleCons,
+  ExprNodes* = {IntVal, FloatVal, Ident, And, Or, If, While, Call, TupleCons,
                 FieldAccess, Asgn, Return, Unreachable, Exprs, Decl}
   DeclNodes* = {ProcDecl, TypeDecl}
   AllNodes* = {low(NodeKind) .. high(NodeKind)}

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -227,6 +227,10 @@ The type of a `While` expression depends on the `cond` expression. If `cond`
 is the built-in `true` literal `(Ident "true")`, then the expression is of
 type `void`, otherwise it is of type `unit`.
 
+> TODO: once constant expression evaluation is specified, consider changing the
+>       rules such that a `While` is of type `void` when the is a constant
+>       expression that evaluates to true
+
 **Expression kind**: r-value
 **Uses**: `cond` and `body`
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -209,6 +209,27 @@ The type of the `If` expression is the common type between `A` and `B`.
 **Expression kind**: r-value
 **Uses**: `cond`, `body`, and - if present - `else`
 
+#### `While`
+
+```grammar
+expr += (While cond:<expr> body:<expr>)
+```
+
+Repeatedly evaluates `body`, as long as `cond` evaluates to `true`. Both
+`body` and `cond` are part of a new scope.
+
+Let `C` be the type of `cond` and let `T` be the type of `body`. An error is
+reported if:
+* `C` is not `bool`
+* `T` is not `unit`
+
+The type of a `While` expression depends on the `cond` expression. If `cond`
+is the built-in `true` literal `(Ident "true")`, then the expression is of
+type `void`, otherwise it is of type `unit`.
+
+**Expression kind**: r-value
+**Uses**: `cond` and `body`
+
 #### `Return`
 
 ```grammar

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -221,7 +221,7 @@ Repeatedly evaluates `body`, as long as `cond` evaluates to `true`. Both
 Let `C` be the type of `cond` and let `T` be the type of `body`. An error is
 reported if:
 * `C` is not `bool`
-* `T` is not `unit`
+* `T` is neither `unit` nor `void`
 
 The type of a `While` expression depends on the `cond` expression. If `cond`
 is the built-in `true` literal `(Ident "true")`, then the expression is of

--- a/tests/expr/t15_while_1.test
+++ b/tests/expr/t15_while_1.test
@@ -1,0 +1,16 @@
+discard """
+  description: "
+    The body is evaluated repeatedly, as long as the condition evaluates
+    to true
+  "
+  output: "10: int"
+"""
+(Exprs
+  (Decl (Ident "repeat") (Ident "true"))
+  (Decl (Ident "x") (IntVal 0))
+  (While (Ident "repeat")
+    (Exprs
+      (Asgn (Ident "repeat") (Ident "false"))
+      (Asgn (Ident "x")
+        (Call (Ident "+") (Ident "x") (IntVal 10)))))
+  (Ident "x"))

--- a/tests/expr/t15_while_2.test
+++ b/tests/expr/t15_while_2.test
@@ -1,0 +1,13 @@
+discard """
+  description: "The condition expression is always evaluated at least once"
+  output: "10: int"
+"""
+(Exprs
+  (Decl (Ident "x") (IntVal 0))
+  (While
+    (Exprs
+      (Asgn (Ident "x")
+        (Call (Ident "+") (Ident "x") (IntVal 10)))
+      (Ident "false"))
+    (TupleCons))
+  (Ident "x"))

--- a/tests/expr/t15_while_body_must_be_unit_error.test
+++ b/tests/expr/t15_while_body_must_be_unit_error.test
@@ -1,5 +1,0 @@
-discard """
-  reject: true
-"""
-(While (Ident "true")
-  (Unreachable))

--- a/tests/expr/t15_while_body_must_be_unit_error.test
+++ b/tests/expr/t15_while_body_must_be_unit_error.test
@@ -1,0 +1,5 @@
+discard """
+  reject: true
+"""
+(While (Ident "true")
+  (Unreachable))

--- a/tests/expr/t15_while_body_must_be_unit_or_void_error.test
+++ b/tests/expr/t15_while_body_must_be_unit_or_void_error.test
@@ -1,0 +1,5 @@
+discard """
+  reject: true
+"""
+(While (Ident "false")
+  (IntVal 1))

--- a/tests/expr/t15_while_cond_must_be_bool_error.test
+++ b/tests/expr/t15_while_cond_must_be_bool_error.test
@@ -1,0 +1,5 @@
+discard """
+  reject: true
+"""
+(While (IntVal 1)
+  (TupleCons))

--- a/tests/expr/t15_while_scoping_1.test
+++ b/tests/expr/t15_while_scoping_1.test
@@ -1,0 +1,11 @@
+discard """
+  description: "
+    Declarations within the `While` condition are visible to the body
+  "
+  output: "(): unit"
+"""
+(While
+  (Exprs
+    (Decl (Ident "x") (TupleCons))
+    (Ident "false"))
+  (Ident "x"))

--- a/tests/expr/t15_while_scoping_2_error.test
+++ b/tests/expr/t15_while_scoping_2_error.test
@@ -1,0 +1,10 @@
+discard """
+  description: "
+    Declarations within the `While` body are not visible to the outside
+  "
+  reject: true
+"""
+(Exprs
+  (While (Ident "false")
+    (Decl (Ident "x") (IntVal 0)))
+  (Ident "x"))

--- a/tests/expr/t15_while_scoping_3_error.test
+++ b/tests/expr/t15_while_scoping_3_error.test
@@ -1,0 +1,13 @@
+discard """
+  description: "
+    Declarations within the `While` condition are not visible to the outside
+  "
+  reject: true
+"""
+(Exprs
+  (While
+    (Exprs
+      (Decl (Ident "x") (IntVal 0))
+      (Ident "false"))
+    (TupleCons))
+  (Ident "x"))

--- a/tests/expr/t15_while_true.test
+++ b/tests/expr/t15_while_true.test
@@ -1,0 +1,10 @@
+discard """
+  description: "
+    A `(While (Ident true))` loop never exits normally, and is thus of type
+    void
+  "
+  arguments: "c"
+"""
+(ProcDecl (Ident "p") (VoidTy) (Params)
+  (While (Ident "true")
+    (TupleCons)))

--- a/tests/expr/t15_while_true.test
+++ b/tests/expr/t15_while_true.test
@@ -3,7 +3,7 @@ discard """
     A `(While (Ident true))` loop never exits normally, and is thus of type
     void
   "
-  arguments: "c"
+  arguments: "c" # don't run the program; it doesn't terminate
 """
 (ProcDecl (Ident "p") (VoidTy) (Params)
   (While (Ident "true")

--- a/tests/expr/t15_while_true_complex_error.test
+++ b/tests/expr/t15_while_true_complex_error.test
@@ -1,0 +1,10 @@
+discard """
+  description: "
+    If the condition is not an immediate `(Ident true)` expression, the
+    `While` is not a void expression
+  "
+  reject: true
+"""
+(ProcDecl (Ident "p") (VoidTy) (Params)
+  (While (Exprs (TupleCons) (Ident "true"))
+    (TupleCons)))

--- a/tests/expr/t15_while_unit_body.test
+++ b/tests/expr/t15_while_unit_body.test
@@ -1,0 +1,5 @@
+discard """
+  output: "(): unit"
+"""
+(While (Ident "false")
+  (TupleCons))

--- a/tests/expr/t15_while_void_body.test
+++ b/tests/expr/t15_while_void_body.test
@@ -1,0 +1,5 @@
+discard """
+  output: "(): unit"
+"""
+(While (Ident "false")
+  (Unreachable))


### PR DESCRIPTION
## Summary

Add the `While` loop construct to the source language. A `While` loop
repeatedly evaluates a given unit expression as long as the given
condition evaluates to true.

## Details

A `While` loop is implemented as a `Loop` + conditional `Break` in the
target IL.

At the moment, a `(While (Ident "true") ...)` is always typed as
`void`, as - without a `Break`-like statement - control-flow can never
reach the code immediately following the loop. Due to the current lack
of early constant folding, detection of such loops needs to be syntax-
based, and thus more complex cases (such as `(Exprs (Ident "true"))`)
are *not* typed as `void`.
