### PR TITLE
support standalone numbers and symbols in source code

### DIFF
--- a/passes/spec.nim
+++ b/passes/spec.nim
@@ -69,5 +69,14 @@ proc toSexp*(tree: PackedTree[NodeKind], idx: NodeIndex,
   of Global:    sexp([newSSymbol("Global"), sexp n.val.int])
   else:         unreachable()
 
-proc fromSexp*(i: BiggestInt, _: typedesc[NodeKind]): TreeNode[NodeKind] =
+proc fromSexp*(tree: var PackedTree[NodeKind], i: BiggestInt
+              ): TreeNode[NodeKind] =
   TreeNode[NodeKind](kind: Immediate, val: i.uint32)
+
+proc fromSexp*(tree: var PackedTree[NodeKind], i: BiggestFloat
+              ): TreeNode[NodeKind] =
+  TreeNode[NodeKind](kind: FloatVal, val: tree.pack(i))
+
+proc fromSexpSym*(tree: var PackedTree[NodeKind], sym: string
+                 ): TreeNode[NodeKind] =
+  unreachable("standalone S-expr symbols are not supported")

--- a/passes/spec_source.nim
+++ b/passes/spec_source.nim
@@ -9,7 +9,7 @@ import
 
 type
   NodeKind* {.pure.} = enum
-    Immediate, IntVal, FloatVal
+    IntVal, FloatVal
     Ident,
     VoidTy, UnitTy, BoolTy, IntTy, FloatTy, TupleTy, UnionTy, ProcTy
     And, Or
@@ -51,11 +51,19 @@ proc fromSexp*(tree: var PackedTree[NodeKind], kind: NodeKind,
 proc toSexp*(tree: PackedTree[NodeKind], idx: NodeIndex,
              n: TreeNode[NodeKind]): SexpNode =
   case n.kind
-  of Immediate: sexp(n.val.int)
   of IntVal:    sexp([newSSymbol("IntVal"), sexp tree.getInt(idx)])
   of FloatVal:  sexp([newSSymbol("FloatVal"), sexp tree.getFloat(idx)])
   of Ident:     sexp([newSSymbol("Ident"), sexp tree.getString(idx)])
   else:         unreachable()
 
-proc fromSexp*(i: BiggestInt, _: typedesc[NodeKind]): TreeNode[NodeKind] =
-  TreeNode[NodeKind](kind: Immediate, val: i.uint32)
+proc fromSexp*(tree: var PackedTree[NodeKind], i: BiggestInt
+              ): TreeNode[NodeKind] =
+  TreeNode[NodeKind](kind: IntVal, val: tree.pack(i))
+
+proc fromSexp*(tree: var PackedTree[NodeKind], f: BiggestFloat
+              ): TreeNode[NodeKind] =
+  TreeNode[NodeKind](kind: FloatVal, val: tree.pack(f))
+
+proc fromSexpSym*(tree: var PackedTree[NodeKind], sym: string
+                 ): TreeNode[NodeKind] =
+  TreeNode[NodeKind](kind: Ident, val: tree.pack(sym))

--- a/passes/trees.nim
+++ b/passes/trees.nim
@@ -235,7 +235,7 @@ proc toSexp*[T](tree: PackedTree[T], at: NodeIndex): SexpNode =
       result.add toSexp(tree, it)
 
 proc fromSexp[T](n: SexpNode, to: var PackedTree[T]) =
-  mixin isAtom, fromSexp
+  mixin isAtom, fromSexp, fromSexpSym
   case n.kind
   of SList:
     assert n.len > 0
@@ -247,7 +247,11 @@ proc fromSexp[T](n: SexpNode, to: var PackedTree[T]) =
       for i in 1..<n.len:
         fromSexp(n[i], to)
   of SInt:
-    to.nodes.add fromSexp(n.num, T)
+    to.nodes.add fromSexp(to, n.num)
+  of SFloat:
+    to.nodes.add fromSexp(to, n.fnum)
+  of SSymbol:
+    to.nodes.add fromSexpSym(to, n.symbol)
   else:
     doAssert false
 


### PR DESCRIPTION
## Summary

In S-expressions representing source language code, symbols and numbers
can now appear anywhere. If not appearing in a special position,
they're parsed as `(Ident x)` and `(IntVal x)`/`(FloatVal x)`,
respectively.

For example, `(Asgn (Ident "x") (IntVal 1))` can now be written as
`(Asgn x 1)`.

## Details

Standalone symbols and numbers can be unambiguously parsed as `Ident`
and `IntVal`/`FloatVal` nodes. The aim is to make writing source
language code easier (until a non-S-expression syntax is developed).

In terms of implementation, `tree.fromSexp` now calls the generic
`fromSexp` and `fromSexpSym` procedures provided for the node kind
enum.

For `spec_source` (the source language tree representation), standalone
symbols parse as `Ident`, floating-point numbers as `FloatVal`, and
integer numbers as `IntVal` (instead of `Immediate`). The `Immediate`
node kind is not used anywhere else, so it's removed.

The enum for the IL node kinds does not support standalone S-expression
symbols (because there's no ident-like node kind), but it does support
standalone floating-pointer numbers now (which are parsed as `FloatVal`
nodes).

---

## Notes For Reviewers
* not having to write out `Ident`/`IntVal`/`FloatVal` makes the S-expression representation feel much more like a "real" language
* the plan is still to eventually introduce a non-S-expression syntax