### PR TITLE
vm: use a simpler type representation

### DIFF
--- a/common/vmexec.nim
+++ b/common/vmexec.nim
@@ -166,8 +166,8 @@ proc run*(env: var VmEnv, prc: ProcIndex): string =
   result = "(" & substr($res.kind, 3)
   case res.kind
   of yrkDone:
-    case env.types[res.typ].kind
-    of vmtypes.TypeKind.tkVoid, vmtypes.TypeKind.tkProc, tkForeign:
+    case res.typ
+    of vmtypes.TypeKind.tkVoid, tkForeign:
       discard
     of vmtypes.TypeKind.tkInt:
       result.add " "

--- a/tests/pass0/t01_empty.expected
+++ b/tests/pass0/t01_empty.expected
@@ -1,4 +1,4 @@
-.type t0 (Proc (Void))
+.type t0 () -> void
 .start t0 p0
   Ret
 .end

--- a/tests/pass0/t02_basic_return.expected
+++ b/tests/pass0/t02_basic_return.expected
@@ -1,6 +1,5 @@
-.type t0 (Int)
-.type t1 (Proc t0)
-.start t1 p0
+.type t0 () -> int
+.start t0 p0
   LdImmInt 2
   Ret
 .end

--- a/tests/pass0/t03_basic_global.expected
+++ b/tests/pass0/t03_basic_global.expected
@@ -1,7 +1,6 @@
-.type t0 (Int)
-.type t1 (Proc t0)
+.type t0 () -> int
 .global g0 1
-.start t1 p0
+.start t0 p0
   GetGlobal g0
   Ret
 .end

--- a/tests/pass0/t03_basic_local.expected
+++ b/tests/pass0/t03_basic_local.expected
@@ -1,6 +1,5 @@
-.type t0 (Int)
-.type t1 (Proc t0)
-.start t1 p0
+.type t0 () -> int
+.start t0 p0
 .local lo0 int
   LdImmInt 1
   PopLocal lo0

--- a/tests/pass0/t03_basic_stack.expected
+++ b/tests/pass0/t03_basic_stack.expected
@@ -1,6 +1,5 @@
-.type t0 (Int)
-.type t1 (Proc t0)
-.start t1 p0
+.type t0 () -> int
+.start t0 p0
 .local lo0 int
   StackAlloc 8
   PopLocal lo0

--- a/tests/pass0/t03_bitand.expected
+++ b/tests/pass0/t03_bitand.expected
@@ -1,6 +1,5 @@
-.type t0 (Int)
-.type t1 (Proc t0)
-.start t1 p0
+.type t0 () -> int
+.start t0 p0
   LdImmInt 16
   LdImmInt 48
   BitAnd

--- a/tests/pass0/t03_bitor.expected
+++ b/tests/pass0/t03_bitor.expected
@@ -1,6 +1,5 @@
-.type t0 (Int)
-.type t1 (Proc t0)
-.start t1 p0
+.type t0 () -> int
+.start t0 p0
   LdImmInt 48
   LdImmInt 40
   BitOr

--- a/tests/pass0/t03_call_with_result.expected
+++ b/tests/pass0/t03_call_with_result.expected
@@ -1,10 +1,9 @@
-.type t0 (Int)
-.type t1 (Proc t0)
-.start t1 p0
+.type t0 () -> int
+.start t0 p0
   LdImmInt 100
   Ret
 .end
-.start t1 p1
+.start t0 p1
   Call p0 0
   Ret
 .end

--- a/tests/pass0/t03_checked_void_call.expected
+++ b/tests/pass0/t03_checked_void_call.expected
@@ -1,4 +1,4 @@
-.type t0 (Proc (Void))
+.type t0 () -> void
 .start t0 p0
   Ret
 .end

--- a/tests/pass0/t03_conv_float64_to_32.expected
+++ b/tests/pass0/t03_conv_float64_to_32.expected
@@ -1,8 +1,6 @@
-.type t0 (Float)
-.type t1 (Float)
-.type t2 (Proc t0)
+.type t0 () -> float
 .const c0 0.5000000149
-.start t2 p0
+.start t0 p0
   LdConst c0
   ReinterpI32
   ReinterpF32

--- a/tests/pass0/t03_drop.expected
+++ b/tests/pass0/t03_drop.expected
@@ -1,6 +1,5 @@
-.type t0 (Int)
-.type t1 (Proc (Void))
-.start t1 p0
+.type t0 () -> void
+.start t0 p0
   LdImmInt 8
   Drop
   Ret

--- a/tests/pass0/t03_loop.expected
+++ b/tests/pass0/t03_loop.expected
@@ -1,4 +1,4 @@
-.type t0 (Proc (Void))
+.type t0 () -> void
 .start t0 p0
 .label L0
   Jmp L0

--- a/tests/pass0/t03_proc_value.expected
+++ b/tests/pass0/t03_proc_value.expected
@@ -1,6 +1,5 @@
-.type t0 (Int)
-.type t1 (Proc t0)
-.start t1 p0
+.type t0 () -> int
+.start t0 p0
 .local lo0 int
   LdImmInt 1
   Ret

--- a/tests/pass0/t03_raise.expected
+++ b/tests/pass0/t03_raise.expected
@@ -1,6 +1,5 @@
-.type t0 (Int)
-.type t1 (Proc (Void))
-.start t1 p0
+.type t0 () -> void
+.start t0 p0
   LdImmInt 1
   Raise
 .end

--- a/tests/pass0/t03_select_bool.expected
+++ b/tests/pass0/t03_select_bool.expected
@@ -1,6 +1,5 @@
-.type t0 (Int)
-.type t1 (Proc t0)
-.start t1 p0
+.type t0 () -> int
+.start t0 p0
   LdImmInt 1
   Branch L3 0
   Jmp L5

--- a/tests/pass0/t03_select_float.expected
+++ b/tests/pass0/t03_select_float.expected
@@ -1,7 +1,5 @@
-.type t0 (Int)
-.type t1 (Float)
-.type t2 (Proc t0)
-.start t2 p0
+.type t0 () -> int
+.start t0 p0
   LdImmFloat 20.0
   LdImmFloat 19.0
   EqFloat

--- a/tests/pass0/t03_select_float_range.expected
+++ b/tests/pass0/t03_select_float_range.expected
@@ -1,7 +1,5 @@
-.type t0 (Int)
-.type t1 (Float)
-.type t2 (Proc t0)
-.start t2 p0
+.type t0 () -> int
+.start t0 p0
   LdImmFloat 15.0
   LdImmFloat 20.0
   LeFloat

--- a/tests/pass0/t03_select_int.expected
+++ b/tests/pass0/t03_select_int.expected
@@ -1,6 +1,5 @@
-.type t0 (Int)
-.type t1 (Proc t0)
-.start t1 p0
+.type t0 () -> int
+.start t0 p0
   LdImmInt 20
   LdImmInt 19
   EqInt

--- a/tests/pass0/t03_select_int_range.expected
+++ b/tests/pass0/t03_select_int_range.expected
@@ -1,6 +1,5 @@
-.type t0 (Int)
-.type t1 (Proc t0)
-.start t1 p0
+.type t0 () -> int
+.start t0 p0
   LdImmInt 15
   LdImmInt 20
   LeInt

--- a/tests/pass0/t03_unreachable.expected
+++ b/tests/pass0/t03_unreachable.expected
@@ -1,4 +1,4 @@
-.type t0 (Proc (Void))
+.type t0 () -> void
 .start t0 p0
   Unreachable
 .end

--- a/tests/pass0/t03_void_call.expected
+++ b/tests/pass0/t03_void_call.expected
@@ -1,4 +1,4 @@
-.type t0 (Proc (Void))
+.type t0 () -> void
 .start t0 p0
   Ret
 .end

--- a/tests/pass0/t04_checked_call_asgn.expected
+++ b/tests/pass0/t04_checked_call_asgn.expected
@@ -1,10 +1,9 @@
-.type t0 (Int)
-.type t1 (Proc t0)
-.start t1 p0
+.type t0 () -> int
+.start t0 p0
   LdImmInt 100
   Ret
 .end
-.start t1 p1
+.start t0 p1
 .local lo0 int
   Call p0 0
   PopLocal lo0

--- a/tests/pass0/t04_except.expected
+++ b/tests/pass0/t04_except.expected
@@ -1,6 +1,5 @@
-.type t0 (Int)
-.type t1 (Proc t0)
-.start t1 p0
+.type t0 () -> int
+.start t0 p0
 .local lo0 int
   LdImmInt 10
   Raise

--- a/tests/pass0/t04_indirect_call.expected
+++ b/tests/pass0/t04_indirect_call.expected
@@ -1,11 +1,10 @@
-.type t0 (Int)
-.type t1 (Proc t0)
-.start t1 p0
+.type t0 () -> int
+.start t0 p0
   LdImmInt 100
   Ret
 .end
-.start t1 p1
+.start t0 p1
   LdImmInt 1
-  IndCall t1 0
+  IndCall t0 0
   Ret
 .end

--- a/tests/pass0/t04_load_store.expected
+++ b/tests/pass0/t04_load_store.expected
@@ -1,6 +1,5 @@
-.type t0 (Int)
-.type t1 (Proc t0)
-.start t1 p0
+.type t0 () -> int
+.start t0 p0
 .local lo0 int
   StackAlloc 8
   PopLocal lo0

--- a/tests/pass0/t04_load_store_small.expected
+++ b/tests/pass0/t04_load_store_small.expected
@@ -1,6 +1,5 @@
-.type t0 (Int)
-.type t1 (Proc t0)
-.start t1 p0
+.type t0 () -> int
+.start t0 p0
 .local lo0 int
   StackAlloc 8
   PopLocal lo0

--- a/tests/pass0/t04_parameters.expected
+++ b/tests/pass0/t04_parameters.expected
@@ -1,7 +1,6 @@
-.type t0 (Int)
-.type t1 (Proc t0 t0 t0)
-.type t2 (Proc t0)
-.start t1 p0
+.type t0 (int, int) -> int
+.type t1 () -> int
+.start t0 p0
 .local lo0 int
 .local lo1 int
   PopLocal lo1
@@ -9,7 +8,7 @@
   GetLocal lo1
   Ret
 .end
-.start t2 p1
+.start t1 p1
   LdImmInt 1
   LdImmInt 2
   Call p0 2

--- a/tests/vm/runner.nim
+++ b/tests/vm/runner.nim
@@ -67,8 +67,8 @@ env.dispose(move thread)
 var output = "(" & substr($res.kind, 3)
 case res.kind
 of yrkDone:
-  case env.types[res.typ].kind
-  of tkVoid, tkProc, tkForeign:
+  case res.typ
+  of tkVoid, tkForeign:
     discard
   of tkInt:
     output.add " "

--- a/tests/vm/t01_basic_program.test
+++ b/tests/vm/t01_basic_program.test
@@ -5,7 +5,7 @@ discard """
   "
   output: "(Done)"
 """
-.type P1 (Proc (Void))
+.type P1 () -> void
 .start P1 main
 ret
 .end

--- a/tests/vm/t02_immediate_int.test
+++ b/tests/vm/t02_immediate_int.test
@@ -1,7 +1,7 @@
 discard """
   output: "(Done 1)"
 """
-.type P1 (Proc (Int))
+.type P1 () -> int
 .start P1 main
 LdImmInt 1
 Ret

--- a/tests/vm/t03_immediate_float.test
+++ b/tests/vm/t03_immediate_float.test
@@ -1,7 +1,7 @@
 discard """
   output: "(Done -0.5)"
 """
-.type P1 (Proc (Float))
+.type P1 () -> float
 .start P1 main
 LdImmFloat -0.5
 Ret

--- a/tests/vm/t04_bitnot.test
+++ b/tests/vm/t04_bitnot.test
@@ -1,7 +1,7 @@
 discard """
   output: "(Done (18446744072277895850 or -1431655766))"
 """
-.type P1 (Proc (Int))
+.type P1 () -> int
 .start P1 main
 LdImmInt 0x55555555 # 0101_0101...
 BitNot

--- a/tests/vm/t04_float_local.test
+++ b/tests/vm/t04_float_local.test
@@ -1,7 +1,7 @@
 discard """
   output: "(Done 0.5)"
 """
-.type P1 (Proc (Float))
+.type P1 () -> float
 .start P1 main
 .local tmp float
 LdImmFloat 0.5

--- a/tests/vm/t04_float_local_set.test
+++ b/tests/vm/t04_float_local_set.test
@@ -1,7 +1,7 @@
 discard """
   output: "(Done 0.5)"
 """
-.type P1 (Proc (Float))
+.type P1 () -> float
 .start P1 main
 .local tmp float
 LdImmFloat 0.5

--- a/tests/vm/t04_int_local copy.test
+++ b/tests/vm/t04_int_local copy.test
@@ -1,7 +1,7 @@
 discard """
   output: "(Done 1)"
 """
-.type P1 (Proc (Int))
+.type P1 () -> int
 .start P1 main
 .local tmp int
 LdImmInt 1

--- a/tests/vm/t04_int_local.test
+++ b/tests/vm/t04_int_local.test
@@ -1,7 +1,7 @@
 discard """
   output: "(Done 1)"
 """
-.type P1 (Proc (Int))
+.type P1 () -> int
 .start P1 main
 .local tmp int
 LdImmInt 1

--- a/tests/vm/t04_stack_alloc.test
+++ b/tests/vm/t04_stack_alloc.test
@@ -1,7 +1,7 @@
 discard """
   output: "(Done 4096)"
 """
-.type P1 (Proc (Int))
+.type P1 () -> int
 .start P1 main
 StackAlloc 8
 Ret

--- a/tests/vm/t05_read_write_float32.test
+++ b/tests/vm/t05_read_write_float32.test
@@ -1,7 +1,7 @@
 discard """
   output: "(Done 1.5)"
 """
-.type P1 (Proc (Float))
+.type P1 () -> float
 .start P1 main
 .local tmp Int
 StackAlloc 4

--- a/tests/vm/t05_read_write_float64.test
+++ b/tests/vm/t05_read_write_float64.test
@@ -1,7 +1,7 @@
 discard """
   output: "(Done 1.5)"
 """
-.type P1 (Proc (Float))
+.type P1 () -> float
 .start P1 main
 .local tmp Int
 StackAlloc 8

--- a/vm/disasm.nim
+++ b/vm/disasm.nim
@@ -21,9 +21,8 @@ template toOpenArray[T; I: Ordinal](s: seq[T], sl: HOslice[I]): untyped =
   s.toOpenArray(sl.a.int, sl.b.int - 1)
 
 proc formatValue(result: var string, t: TypeId, specifier: string) =
-  assert t != VoidType
   result.add 't'
-  result.addInt(t.int - 1)
+  result.addInt(t.int)
 
 proc formatValue(result: var string, v: TypedValue, specifier: string) =
   case v.typ
@@ -115,28 +114,23 @@ proc disassemble*(env: VmEnv): string =
   ## the output results in a program behaving exactly the same); some
   ## information may be lost.
   # emit the type directives:
-  for i in 1..<env.types.types.len:
-    let typ = env.types.types[i]
-    result.add fmt".type t{(i - 1)} "
-    case typ.kind
-    of tkVoid:
-      unreachable()
-    of tkInt:
-      result.add "(Int)"
-    of tkFloat:
-      result.add "(Float)"
-    of tkProc:
-      result.add "(Proc"
-      for it in typ.a..<typ.b:
-        if env.types.params[it] == VoidType:
-          result.add " (Void)"
-        else:
-          result.add fmt" {env.types.params[it]}"
-      result.add ")"
-    of tkForeign:
-      result.add "(Foreign)"
+  for i in 0..<env.types.types.len:
+    let id = TypeId(i)
+    result.add fmt".type t{i} ("
 
-    result.add "\n"
+    proc toString(kind: TypeKind): string =
+      case kind
+      of tkVoid:    "void"
+      of tkInt:     "int"
+      of tkFloat:   "float"
+      of tkForeign: "foreign"
+
+    for i, it in parameters(env.types, id):
+      if i > 0:
+        result.add ", "
+      result.add toString(it)
+
+    result.add ") -> " & toString(env.types.returnType(id)) & "\n"
 
   # emit the constants:
   for i, val in env.constants.pairs:

--- a/vm/vm.nim
+++ b/vm/vm.nim
@@ -39,7 +39,7 @@ type
     ## The result of a VM invocation. Describes why the execution stopped.
     case kind*: YieldReasonKind:
     of yrkDone:
-      typ*: TypeId        ## the return value's type (void indicates "none")
+      typ*: TypeKind      ## the return value's type (void indicates "none")
       result*: Value
     of yrkError:
       error*: ErrorCode
@@ -376,7 +376,7 @@ proc run*(c: var VmEnv, t: var VmThread, cl: RootRef): YieldReason {.raises: [].
         fp = t.frames[^1].start
       else:
         let ret = c.types.returnType(c[top.prc].typ)
-        if c.types[ret].kind == tkVoid:
+        if ret == tkVoid:
           return YieldReason(kind: yrkDone, typ: ret)
         else:
           return YieldReason(kind: yrkDone, typ: ret, result: stack.pop())

--- a/vm/vmenv.nim
+++ b/vm/vmenv.nim
@@ -125,8 +125,7 @@ template `[]`*(e: VmEnv, i: ProcIndex): ProcHeader =
 
 proc initVm*(initial, maxHost: uint): VmEnv =
   ## Sets up and returns a VM execution environment.
-  VmEnv(types: initTypeEnv(),
-        allocator: initAllocator(initial, maxHost))
+  VmEnv(allocator: initAllocator(initial, maxHost))
 
 # instruction decoding
 template opcode*(x: Instr): Opcode =

--- a/vm/vmtypes.nim
+++ b/vm/vmtypes.nim
@@ -3,61 +3,53 @@
 
 type
   TypeId* = distinct uint32
-    ## The unique ID of a `TypeId`. Internally, it's an index into a sequence
+    ## Identifies a procedure signature.
 
   TypeKind* = enum
     tkVoid
     tkInt
     tkFloat
-    tkProc
     tkForeign
 
-  VmType* = object
-    ## Basic run-time type information (=RTTI). Flat in-memory representation
-    ## so that it's easily serializable.
-    kind*: TypeKind
-    a*: uint32 ## meaning depends on the kind
-    b*: uint32 ## meaning depends on the kind
+  VmType* = TypeKind # for backwards compatibility
 
   TypeEnv* = object
     ## Flat and data-oriented for the purpose of being easy to serialize and
     ## fast to operate on.
-    types* {.requiresInit.}: seq[VmType]
-    params*: seq[TypeId]
-
-const
-  VoidType* = TypeId(0)
+    types*: seq[Slice[uint32]]
+      ## list of procedure signatures. A signature is a sequence of types,
+      ## with a minimum length of 1. The actual types are stored separately in
+      ## `params`
+    params*: seq[VmType]
 
 proc `==`*(a, b: TypeId): bool {.borrow.}
 
-proc initTypeEnv*(): TypeEnv =
-  # setup the environment with a void type as the first element
-  result = TypeEnv(types: @[VmType(kind: tkVoid)])
-
-template `[]`*(e: TypeEnv, id: TypeId): VmType =
+template `[]`*(e: TypeEnv, id: TypeId): Slice[uint32] =
   e.types[ord(id)]
 
-iterator parameters*(e: TypeEnv, id: TypeId): (int, TypeId) =
+iterator parameters*(e: TypeEnv, id: TypeId): (int, VmType) =
   ## Returns all parameters for procedure type `id`.
   var i = e[id].a + 1
   let fin = e[id].b
-  while i < fin:
-    yield (int(i - e[id].a), e.params[i])
+  while i <= fin:
+    yield (int(i - e[id].a - 1), e.params[i])
     inc i
 
-func param*(e: TypeEnv, id: TypeId, i: Natural): TypeId =
+func numParams*(e: TypeEnv, id: TypeId): int =
+  ## Returns the number of parameters the signature identified by `id` has.
+  result = e[id].len - 1
+
+func param*(e: TypeEnv, id: TypeId, i: Natural): VmType =
   ## The `i`th parameter's type.
   e.params[e[id].a + 1 + uint32(i)]
 
-func returnType*(e: TypeEnv, id: TypeId): TypeId =
+func returnType*(e: TypeEnv, id: TypeId): VmType =
   ## The return type of procedure `id`.
   e.params[e[id].a]
 
-func len*(typ: VmType): int {.inline.} =
-  ## Number of types in the procedure signature.
-  int(typ.b - typ.a)
-
-func add*(e: var TypeEnv, desc: VmType): TypeId =
+func add*(e: var TypeEnv, ret: VmType, params: openArray[VmType]): TypeId =
   ## Adds `desc` to the environment, returning the ID to later address it with.
   result = e.types.len.TypeId
-  e.types.add(desc)
+  e.types.add(e.params.len.uint32 .. uint32(e.params.len + params.len))
+  e.params.add ret
+  e.params.add params

--- a/vm/vmvalidation.nim
+++ b/vm/vmvalidation.nim
@@ -36,20 +36,16 @@ type
 
 const
   errNotForwardJump = "not a forward jump"
-  errNotAProcType   = "type is not a proc type"
 
 proc toValueType(t: VmType): ValueType =
-  case t.kind
-  of tkInt, tkProc: vtInt
-  of tkFloat:       vtFloat
-  of tkForeign:     vtRef
-  of tkVoid:        unreachable()
+  case t
+  of tkInt:     vtInt
+  of tkFloat:   vtFloat
+  of tkForeign: vtRef
+  of tkVoid:    unreachable()
 
 proc param(env: TypeEnv, t: TypeId, i: int): ValueType =
-  toValueType(env[env.params[env[t].a + i.uint32 + 1]])
-
-proc numArgs(typ: VmType): int =
-  typ.len - 1
+  toValueType(vmtypes.param(env, t, i))
 
 proc test(a: seq|openArray, i: SomeInteger): bool =
   when i is SomeUnsignedInt:
@@ -203,8 +199,8 @@ proc run(ctx: var ValidationState, env: VmEnv, pos: PrgCtr, instr: Instr
     expectEmpty()
     jump(rel)
   of opcRet:
-    let expect = env.types[env.types.returnType(env[ctx.prc].typ)]
-    if expect.kind != tkVoid:
+    let expect = env.types.returnType(env[ctx.prc].typ)
+    if expect != tkVoid:
       pop(toValueType expect)
     expectEmpty()
     ctx.active = false
@@ -220,21 +216,21 @@ proc run(ctx: var ValidationState, env: VmEnv, pos: PrgCtr, instr: Instr
     of opcCall:
       typ = checked(env.procs, idx).typ
     of opcIndCall:
-      check checked(env.types.types, idx).kind == tkProc, errNotAProcType
+      discard checked(env.types.types, idx)
       typ = TypeId idx
       pop(vtInt) # callee
     else:
       unreachable()
 
-    check env.types[typ].numArgs() == num, "arity doesn't match"
+    check env.types.numParams(typ) == num, "arity doesn't match"
 
     # pop all arguments from the stack, expecting the given kinds
     for i in 0..<num:
       pop(env.types.param(typ, num - i - 1))
 
     # push the return value, if any
-    let ret = env.types[env.types.returnType(typ)]
-    if ret.kind != tkVoid:
+    let ret = env.types.returnType(typ)
+    if ret != tkVoid:
       push(toValueType ret)
   of opcExcept:
     check not ctx.active, "control-flow reaches 'opcExcept'"
@@ -289,7 +285,6 @@ proc verify*(hdr: ProcHeader, env: VmEnv): CheckResult =
     discard
 
   check test(env.types.types, hdr.typ.uint32), Error
-  check env.types[hdr.typ].kind == tkProc, errNotAProcType
   result.initSuccess()
 
 proc verify*(env: VmEnv, prc: ProcIndex, code: openArray[Instr]): CheckResult =
@@ -299,7 +294,7 @@ proc verify*(env: VmEnv, prc: ProcIndex, code: openArray[Instr]): CheckResult =
 
   # push all parameters to the operand stack:
   for _, it in parameters(env.types, env[prc].typ):
-    ctx.stack.add(toValueType env.types[it])
+    ctx.stack.add(toValueType it)
 
   # run abstract evaluation for all instructions:
   for pos, instr in code.pairs:
@@ -314,27 +309,13 @@ proc verify*(env: VmEnv, prc: ProcIndex, code: openArray[Instr]): CheckResult =
 
 proc verify*(types: TypeEnv): CheckResult =
   ## Verifies the type environment, making sure it is well-formed.
-  check types.types.len > 0, "type environment is empty"
-  check types[VoidType].kind == tkVoid, "void type is not valid"
-
   for i, it in types.types.pairs:
-    let i = uint32(i)
-    case it.kind
-    of tkInt, tkFloat, tkForeign:
-      discard "nothing to check"
-    of tkVoid:
-      check i == 0, "only the very first type can be a 'tkVoid'"
-    of tkProc:
-      check it.b > it.a, "proc type has no elements"
+    check it.a <= it.b, "illformed signature entry"
+    check test(types.params, it.a), "illformed signature entry"
+    check test(types.params, it.b), "illformed signature entry"
 
-      for x in it.a..<it.b:
-        let typ = types.params[x]
-        check uint32(typ) < i, "forward reference"
-        var se = {tkInt, tkFloat, tkForeign}
-        if x == it.a:
-          se.incl tkVoid # void is only allowed for the return type
-
-        check types[typ].kind in se, "parameter type isn't valid"
+    for _, p in parameters(types, TypeId i):
+      check p != tkVoid, "void is not a valid parameter type"
 
   result.initSuccess()
 


### PR DESCRIPTION
## Summary

Simplify the type representation used by the VM in order to reduce the
size of types (in memory) and cost of validation.

## Details

Instead of having a list of types and a list with parameters (for
signature types), theres now a list of signatures and a list of
parameter types. `TypeId`s can only refer to signature types now.

This has a multiple benefits:
* there's no more requirement that the first element in the type list
  is a `tkVoid` type
* the type environment takes up less space in memory (and on disk)
* looking up a parameter type requires one less indirection

The VM validation layer is updated accordingly. For the assembler, the
type directive is changed such that only signature types are allowed,
whose syntax is now `(T*) -> T`, which should make it clearer what the
syntax represents (compared to the previous `(Proc ...)`.

For the tests, the expected output of `pass0` tests as well as the `vm`
tests are updated to the changed assembler syntax.

There are some changes relevant to embedders of the VM:
* the `initTypeEnv` procedure is removed, as an empty `TypeEnv` is now
  valid
* `YieldReason.typ` is a `TypeKind` instead of `TypeId` now 

---

## Notes For Reviewers
* a preparation for adding VM modules
