### PR TITLE
lang0: rename blit operation to `Blit`

### DIFF
--- a/passes/lang0.md
+++ b/passes/lang0.md
@@ -81,7 +81,7 @@ exit ::= <goto>
 stmt ::= (Asgn <local> <value>)
       |  (Store <type_id> <value> <value>)
       |  (Clear <value> <value>)
-      |  (Copy <value> <value> <value>)
+      |  (Blit <value> <value> <value>)
       |  (Call <proc> <value>*)
       |  (Call <type_id> <value>+)
       |  (Drop <value>)

--- a/passes/pass0.nim
+++ b/passes/pass0.nim
@@ -544,7 +544,7 @@ proc genStmt(c; tree; n: NodeIndex) =
     c.genExpr(tree, tree.child(n, 0))
     c.genExpr(tree, tree.child(n, 1))
     c.instr(opcMemClear)
-  of Copy:
+  of Blit:
     c.genExpr(tree, tree.child(n, 0))
     c.genExpr(tree, tree.child(n, 1))
     c.genExpr(tree, tree.child(n, 2))

--- a/passes/pass25.nim
+++ b/passes/pass25.nim
@@ -66,7 +66,7 @@ type
       ## locals that need to be pinned in memory (i.e., don't change location)
 
 const
-  IndirectAccess = {Copy, Clear, Store, Load, Call, CheckedCall,
+  IndirectAccess = {Blit, Clear, Store, Load, Call, CheckedCall,
                     CheckedCallAsgn}
     ## every operation that reads or writes through a pointer. Calls have to
     ## conservatively be treated as performing an indirect access.

--- a/passes/pass3.nim
+++ b/passes/pass3.nim
@@ -196,8 +196,8 @@ proc lowerExpr(c; tree; n; bu: var BuilderOrChangeset) =
         c.lowerExpr(tree, it, bu)
 
 proc genMemCopy(c; tree; n, dst, src, typ: NodeIndex, changes) =
-  ## Replaces the subtree at `n` with a ``Copy`` statement.
-  changes.replace(n, Copy):
+  ## Replaces the subtree at `n` with a ``Blit`` statement.
+  changes.replace(n, Blit):
     # can be either an l- or rvalue, depending on who called ``genMemCopy``
     if tree[dst].kind in {Field, At, Local}:
       c.lowerPathElem(tree, dst, bu)
@@ -247,7 +247,7 @@ proc lowerStmt(c; tree; n; changes) =
     else:
       c.lowerExpr(tree, a, changes)
       c.lowerExpr(tree, b, changes)
-  of Copy:
+  of Blit:
     let (a, b, size) = triplet(tree, n)
     c.lowerExpr(tree, a, changes)
     c.lowerExpr(tree, b, changes)

--- a/passes/spec.nim
+++ b/passes/spec.nim
@@ -18,11 +18,11 @@ type
 
     Join
 
-    Copy, Asgn, Drop, Clear
+    Asgn, Drop, Clear, Blit
 
     Load, Store, Addr, Call
     Deref, Field, At
-    Move, Rename
+    Copy, Move, Rename
 
     Neg, Add, Sub, Mul, Div, Mod
     AddChck, SubChck

--- a/tests/pass25/t03_ssa_addr_keep_alive_5.expected
+++ b/tests/pass25/t03_ssa_addr_keep_alive_5.expected
@@ -27,6 +27,6 @@
       (Continuation
         (Params (Type 0))
         (Locals)
-        (Copy (IntVal 0) (IntVal 0) (IntVal 1))
+        (Blit (IntVal 0) (IntVal 0) (IntVal 1))
         (Continue 3 (List)))
       (Continuation (Params)))))

--- a/tests/pass25/t03_ssa_addr_keep_alive_5.test
+++ b/tests/pass25/t03_ssa_addr_keep_alive_5.test
@@ -13,5 +13,5 @@
       (Join 0)
       (Drop (IntVal 200))
       (Join 1)
-      (Copy (IntVal 0) (IntVal 0) (IntVal 1))
+      (Blit (IntVal 0) (IntVal 0) (IntVal 1))
       (Return))))

--- a/tests/pass3/t04_asgn_aggregate.expected
+++ b/tests/pass3/t04_asgn_aggregate.expected
@@ -11,7 +11,7 @@
     (Continuations
       (Continuation (Params)
         (Locals (Local 0) (Local 1))
-        (Copy
+        (Blit
           (Addr (Local 0))
           (Addr (Local 1))
           (IntVal 8))

--- a/tests/pass3/t04_asgn_sub_aggregate.expected
+++ b/tests/pass3/t04_asgn_sub_aggregate.expected
@@ -12,7 +12,7 @@
     (Continuations
       (Continuation (Params)
         (Locals (Local 0) (Local 1))
-        (Copy
+        (Blit
           (Add (Type 4)
             (Addr (Local 0))
             (IntVal 0))

--- a/tests/pass3/t04_load_aggregate.expected
+++ b/tests/pass3/t04_load_aggregate.expected
@@ -11,7 +11,7 @@
     (Continuations
       (Continuation (Params)
         (Locals (Local 0))
-        (Copy
+        (Blit
           (Addr (Local 0))
           (IntVal 0)
           (IntVal 8))

--- a/tests/pass3/t04_store_aggregate.expected
+++ b/tests/pass3/t04_store_aggregate.expected
@@ -11,7 +11,7 @@
     (Continuations
       (Continuation (Params)
         (Locals (Local 0))
-        (Copy (IntVal 0)
+        (Blit (IntVal 0)
           (Addr (Local 0))
           (IntVal 8))
         (Continue 1))


### PR DESCRIPTION
## Summary

Instead of `Copy`, the memcopy/blit operation is now named `Blit`,
making it clearer what the operation does.

## Details

Both the copy and memcopy operation used the name `Copy`, which -
besides being confusing - made searching for either of them using just
the node kind impossible (the shape had to be considered for
discriminating between them).

---

## Notes For Reviewers
* this is a split-out from the pass rework