### PR TITLE
lang0: make globals explicitly typed

### DIFF
--- a/passes/lang0.md
+++ b/passes/lang0.md
@@ -103,7 +103,8 @@ continuation ::= (Continuation (Params) stack:<int> <stmt>* <exit>)
               |  (Except <local> stack:<int> <stmt>* <exit>)
 
 procdef ::= (ProcDef <type_id> (Locals <type>*) (Continuations <continuation>+))
-globaldef ::= <intVal> | <floatVal>
+int_or_float ::= <intVal> | <floatVal>
+globaldef ::= (GlobalDef <type> <int_or_float>)
 ```
 
 ### Foreign Procedures

--- a/passes/pass0.nim
+++ b/passes/pass0.nim
@@ -671,18 +671,14 @@ proc translate*(module: PackedTree[NodeKind]): VmModule =
 
   # add the defined globals to the environment:
   for def in module.items(globals):
-    # the type is inferred from the value's node kind
-    let val =
-      case module[def].kind
-      of FloatVal:
-        TypedValue(val: cast[Value](getFloat(module, def)), typ: vtFloat)
-      of IntVal:
+    let (typ, val) = module.pair(def)
+    result.globals.add:
+      case parseType(module, types, typ).kind
+      of t0kFloat:
+        TypedValue(val: cast[Value](getFloat(module, val)), typ: vtFloat)
+      of t0kInt, t0kUInt:
         # signedness doesn't matter here
-        TypedValue(val: cast[Value](getUInt(module, def)), typ: vtInt)
-      else:
-        unreachable()
-
-    result.globals.add val
+        TypedValue(val: cast[Value](getUInt(module, val)), typ: vtInt)
 
   # generate the code for the procedures and add them to the environment:
   for i, def in module.pairs(procs):

--- a/tests/pass0/t03_basic_global.test
+++ b/tests/pass0/t03_basic_global.test
@@ -6,7 +6,7 @@ discard """
   (ProcTy (Type 0))
 )
 (GlobalDefs
-  (IntVal 1)
+  (GlobalDef (Int 8) (IntVal 1))
 )
 (ProcDefs
   (ProcDef (Type 1) (Locals) (Continuations


### PR DESCRIPTION
## Summary

Require definitions of global variables to also provide a type, instead
of just a literal value (from which the type is inferred).

## Details

Having an explicit type is a requirement for querying the type of
expressions with a global variable at the root, something which is not
implemented at the moment, but will be needed by future passes
(especially once the source language supports globals).

Having a dedicated node kind / subtree for a global definitions also
makes it easier/possible to extend the definition with additional
information (such as whether the global is mutable).

---

## Notes For Reviewers
* a split-out from the pass rework