### PR TITLE
lang25: make procedure parameters explicit

### DIFF
--- a/passes/lang25.md
+++ b/passes/lang25.md
@@ -9,7 +9,7 @@ of statements:
 
 ```grammar
 procdef -= (ProcDef <type_id> (Continuations <continuation>+))
-procdef += (ProcDef <type_id> (Locals <type>*) (Stmts <stmt>+))
+procdef += (ProcDef <type_id> (Params <local>*) (Locals <type>*) (Stmts <stmt>+))
 ```
 
 ### Control Flow

--- a/passes/lang30.md
+++ b/passes/lang30.md
@@ -8,8 +8,8 @@ Instead of one flat list of statements, statements in a procedure can now be
 nested:
 
 ```grammar
-procdef -= (ProcDef <type_id> (Locals <type>*) (Stmts <stmt>+))
-procdef += (ProcDef <type_id> (Locals <type>*) <single_stmt>)
+procdef -= (ProcDef <type_id> (Params <local>*) (Locals <type>*) (Stmts <stmt>+))
+procdef += (ProcDef <type_id> (Params <local>*) (Locals <type>*) <single_stmt>)
 ```
 
 The goto-based control-flow constructs are replaced with structured equivalents.

--- a/passes/pass30.nim
+++ b/passes/pass30.nim
@@ -187,11 +187,11 @@ proc lowerStmt(c; tree; n, bu): bool =
 
 proc lowerProc(c: var PassCtx, tree; n; changes) =
   c.nextLabel = 0
-  c.locals = tree.child(n, 1)
+  c.locals = tree.child(n, 2)
 
-  changes.replace(tree.child(n, 2), Stmts):
+  changes.replace(tree.child(n, 3), Stmts):
     # the body of a procedure must always end with a terminator
-    doAssert c.lowerStmt(tree, tree.child(n, 2), bu),
+    doAssert c.lowerStmt(tree, tree.child(n, 3), bu),
               "control-flow falls out of the body"
 
   assert c.context.len == 0, "context stack is not empty"

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -308,6 +308,12 @@ proc typeToIL(c; typ: SemType): uint32 =
     # of procedural values. For values, the underlying storage type is a uint
     c.addType Node(kind: UInt, val: 8)
 
+func numILParams(typ: SemType): int =
+  ## Returns the number of parameters the IL signature type generated from
+  ## `typ` is going to have.
+  assert typ.kind == tkProc
+  typ.elems.len - 1 + ord(typ.elems[0].kind in AggregateTypes)
+
 proc rawGenProcType(c; typ: SemType): uint32 =
   ## Generates the IL representation for the procedure signature type `typ`
   ## and adds it to `c`.
@@ -1093,6 +1099,9 @@ proc exprToIL*(c; t): SemType =
 
   bu.subTree ProcDef:
     bu.add Node(kind: Type, val: signature)
+    bu.subTree Params:
+      for i in 0..<numILParams(procTy):
+        bu.add Node(kind: Local, val: i.uint32)
     bu.subTree Locals:
       for it in c.locals.items:
         bu.add Node(kind: Type, val: c.typeToIL(it))
@@ -1171,6 +1180,9 @@ proc declToIL*(c; t; n: NodeIndex) =
 
     var bu = initBuilder[NodeKind](ProcDef)
     bu.add Node(kind: Type, val: signature)
+    bu.subTree Params:
+      for i in 0..<numILParams(procTy):
+        bu.add Node(kind: Local, val: i.uint32)
     bu.subTree Locals:
       for it in c.locals.items:
         bu.add Node(kind: Type, val: c.typeToIL(it))

--- a/tests/pass25/t01_loop.test
+++ b/tests/pass25/t01_loop.test
@@ -5,7 +5,7 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (Join 0)
       (Loop 0))))

--- a/tests/pass25/t01_raise.test
+++ b/tests/pass25/t01_raise.test
@@ -6,6 +6,6 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Stmts
       (Raise (IntVal 100) (Unwind)))))

--- a/tests/pass25/t01_return.test
+++ b/tests/pass25/t01_return.test
@@ -2,6 +2,6 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (Return))))

--- a/tests/pass25/t01_select.test
+++ b/tests/pass25/t01_select.test
@@ -6,7 +6,7 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Stmts
       (Select (Type 0) (IntVal 1)
         (Choice (IntVal 1)

--- a/tests/pass25/t01_unreachable.test
+++ b/tests/pass25/t01_unreachable.test
@@ -5,7 +5,7 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (Drop (IntVal 100))
       (Unreachable))))

--- a/tests/pass25/t02_checked_call.test
+++ b/tests/pass25/t02_checked_call.test
@@ -3,10 +3,10 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Stmts
       (Return)))
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Stmts
       (CheckedCall (Proc 0) (Unwind))
       (Return))))

--- a/tests/pass25/t02_checked_call_asgn.test
+++ b/tests/pass25/t02_checked_call_asgn.test
@@ -4,10 +4,10 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Stmts
       (Return (IntVal 100))))
-  (ProcDef (Type 2)
+  (ProcDef (Type 2) (Params)
     (Locals (Type 0))
     (Stmts
       (CheckedCallAsgn (Local 0) (Proc 0) (Unwind))

--- a/tests/pass25/t02_parameters.expected
+++ b/tests/pass25/t02_parameters.expected
@@ -10,6 +10,8 @@
       (Continuation
         (Params (Type 0) (Type 0))
         (Locals)
+        (Drop (Copy (Local 0)))
+        (Drop (Copy (Local 1)))
         (Continue 1 (List)))
       (Continuation (Params))))
   (ProcDef (Type 2)

--- a/tests/pass25/t02_parameters.test
+++ b/tests/pass25/t02_parameters.test
@@ -5,11 +5,14 @@
 (GlobalDefs)
 (ProcDefs
   (ProcDef (Type 1)
+    (Params (Local 1) (Local 0))
     (Locals (Type 0) (Type 0))
     (Stmts
+      (Drop (Copy (Local 1)))
+      (Drop (Copy (Local 0)))
       (Return)))
 
-  (ProcDef (Type 2) (Locals)
+  (ProcDef (Type 2) (Params) (Locals)
     (Stmts
       (Call (Proc 0) (IntVal 100) (IntVal 200))
       (Return))))

--- a/tests/pass25/t02_raise_except.test
+++ b/tests/pass25/t02_raise_except.test
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Raise (IntVal 100) (Continue 0))

--- a/tests/pass25/t02_return_value.test
+++ b/tests/pass25/t02_return_value.test
@@ -4,11 +4,11 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Stmts
       (Return (IntVal 100))))
 
-  (ProcDef (Type 2) (Locals)
+  (ProcDef (Type 2) (Params) (Locals)
     (Stmts
       (Drop (Call (Proc 0)))
       (Return))))

--- a/tests/pass25/t03_auto_spawn.test
+++ b/tests/pass25/t03_auto_spawn.test
@@ -12,7 +12,7 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Drop (Copy (Local 0)))

--- a/tests/pass25/t03_checked_call_except.test
+++ b/tests/pass25/t03_checked_call_except.test
@@ -3,10 +3,10 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Stmts
       (Return)))
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (CheckedCall (Proc 0) (Continue 0))

--- a/tests/pass25/t03_ssa_addr.test
+++ b/tests/pass25/t03_ssa_addr.test
@@ -9,7 +9,7 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Asgn (Local 0) (IntVal 100))

--- a/tests/pass25/t03_ssa_addr_keep_alive_1.test
+++ b/tests/pass25/t03_ssa_addr_keep_alive_1.test
@@ -9,7 +9,7 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Asgn (Local 0) (IntVal 0))

--- a/tests/pass25/t03_ssa_addr_keep_alive_2.test
+++ b/tests/pass25/t03_ssa_addr_keep_alive_2.test
@@ -9,7 +9,7 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Drop (Addr (Local 0)))

--- a/tests/pass25/t03_ssa_addr_keep_alive_3.test
+++ b/tests/pass25/t03_ssa_addr_keep_alive_3.test
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Drop (Addr (Local 0)))

--- a/tests/pass25/t03_ssa_addr_keep_alive_4.test
+++ b/tests/pass25/t03_ssa_addr_keep_alive_4.test
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Drop (Addr (Local 0)))

--- a/tests/pass25/t03_ssa_addr_keep_alive_5.test
+++ b/tests/pass25/t03_ssa_addr_keep_alive_5.test
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Drop (Addr (Local 0)))

--- a/tests/pass25/t03_ssa_addr_keep_alive_6.test
+++ b/tests/pass25/t03_ssa_addr_keep_alive_6.test
@@ -3,9 +3,9 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Stmts (Return)))
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Drop (Addr (Local 0)))

--- a/tests/pass25/t03_ssa_addr_keep_alive_7.test
+++ b/tests/pass25/t03_ssa_addr_keep_alive_7.test
@@ -3,9 +3,9 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Stmts (Return)))
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Drop (Addr (Local 0)))

--- a/tests/pass25/t03_ssa_addr_keep_alive_8.test
+++ b/tests/pass25/t03_ssa_addr_keep_alive_8.test
@@ -4,10 +4,10 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Stmts
       (Return (IntVal 100))))
-  (ProcDef (Type 2)
+  (ProcDef (Type 2) (Params)
     (Locals (Type 0) (Type 0))
     (Stmts
       (Drop (Addr (Local 0)))

--- a/tests/pass25/t03_ssa_addr_keep_alive_array.test
+++ b/tests/pass25/t03_ssa_addr_keep_alive_array.test
@@ -10,7 +10,7 @@ discard """
 )
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 2)
+  (ProcDef (Type 2) (Params)
     (Locals (Type 1))
     (Stmts
       (Drop (Addr (At (Local 0) (IntVal 0))))

--- a/tests/pass25/t03_ssa_addr_keep_alive_record.test
+++ b/tests/pass25/t03_ssa_addr_keep_alive_record.test
@@ -10,7 +10,7 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 2)
+  (ProcDef (Type 2) (Params)
     (Locals (Type 1))
     (Stmts
       (Drop (Addr (Field (Local 0) 0)))

--- a/tests/pass25/t03_ssa_addr_keep_alive_used_only.test
+++ b/tests/pass25/t03_ssa_addr_keep_alive_used_only.test
@@ -9,7 +9,7 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Drop (Addr (Local 0)))

--- a/tests/pass25/t03_ssa_def.test
+++ b/tests/pass25/t03_ssa_def.test
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Asgn (Local 0) (IntVal 100))

--- a/tests/pass25/t03_ssa_def_def.test
+++ b/tests/pass25/t03_ssa_def_def.test
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Asgn (Local 0) (IntVal 100))

--- a/tests/pass25/t03_ssa_def_use.test
+++ b/tests/pass25/t03_ssa_def_use.test
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Asgn (Local 0) (IntVal 100))

--- a/tests/pass25/t03_ssa_join_1.test
+++ b/tests/pass25/t03_ssa_join_1.test
@@ -9,7 +9,7 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (SelectBool (IntVal 0)

--- a/tests/pass25/t03_ssa_join_2.test
+++ b/tests/pass25/t03_ssa_join_2.test
@@ -9,7 +9,7 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (SelectBool (IntVal 0)

--- a/tests/pass25/t03_ssa_loop_1.test
+++ b/tests/pass25/t03_ssa_loop_1.test
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Join 0)

--- a/tests/pass25/t03_ssa_loop_2.test
+++ b/tests/pass25/t03_ssa_loop_2.test
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Join 0)

--- a/tests/pass25/t03_ssa_loop_3.test
+++ b/tests/pass25/t03_ssa_loop_3.test
@@ -6,7 +6,7 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Asgn (Local 0) (IntVal 200))

--- a/tests/pass25/t03_ssa_loop_4.test
+++ b/tests/pass25/t03_ssa_loop_4.test
@@ -9,7 +9,7 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0))
     (Stmts
       (Join 0)

--- a/tests/pass25/t03_ssa_loop_5.test
+++ b/tests/pass25/t03_ssa_loop_5.test
@@ -9,7 +9,7 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0) (Type 0))
     (Stmts
       (Join 0)

--- a/tests/pass25/t03_ssa_loop_6.test
+++ b/tests/pass25/t03_ssa_loop_6.test
@@ -9,7 +9,7 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0) (Type 0))
     (Stmts
       (Join 0)

--- a/tests/pass25/t03_ssa_loop_7.test
+++ b/tests/pass25/t03_ssa_loop_7.test
@@ -9,7 +9,7 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0) (Type 0))
     (Stmts
       (Join 0)

--- a/tests/pass25/t04_ping_pong.test
+++ b/tests/pass25/t04_ping_pong.test
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1)
+  (ProcDef (Type 1) (Params)
     (Locals (Type 0) (Type 0))
     (Stmts
       (Asgn (Local 1) (IntVal 100))

--- a/tests/pass30/t01_loop.expected
+++ b/tests/pass30/t01_loop.expected
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (Join 0)
       (Drop (IntVal 100))

--- a/tests/pass30/t01_loop.test
+++ b/tests/pass30/t01_loop.test
@@ -5,5 +5,5 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Loop (Drop (IntVal 100)))))

--- a/tests/pass30/t01_raise.expected
+++ b/tests/pass30/t01_raise.expected
@@ -4,6 +4,6 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Stmts
       (Raise (IntVal 100) (Unwind)))))

--- a/tests/pass30/t01_raise.test
+++ b/tests/pass30/t01_raise.test
@@ -6,5 +6,5 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Raise (IntVal 100))))

--- a/tests/pass30/t01_return.expected
+++ b/tests/pass30/t01_return.expected
@@ -3,5 +3,5 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts (Return))))

--- a/tests/pass30/t01_return.test
+++ b/tests/pass30/t01_return.test
@@ -2,5 +2,5 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Return)))

--- a/tests/pass30/t01_unreachable.expected
+++ b/tests/pass30/t01_unreachable.expected
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (Drop (IntVal 100))
       (Unreachable))))

--- a/tests/pass30/t01_unreachable.test
+++ b/tests/pass30/t01_unreachable.test
@@ -5,7 +5,7 @@ discard """
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (Drop (IntVal 100))
       (Unreachable))))

--- a/tests/pass30/t02_break_block.expected
+++ b/tests/pass30/t02_break_block.expected
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (Drop (IntVal 100))
       (Drop (IntVal 200))

--- a/tests/pass30/t02_break_block.test
+++ b/tests/pass30/t02_break_block.test
@@ -2,7 +2,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (Drop (IntVal 100))
       (Block

--- a/tests/pass30/t02_break_case.expected
+++ b/tests/pass30/t02_break_case.expected
@@ -4,7 +4,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Stmts
       (Drop (IntVal 100))
       (Select (Type 0) (IntVal 0)

--- a/tests/pass30/t02_break_case.test
+++ b/tests/pass30/t02_break_case.test
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Stmts
       (Drop (IntVal 100))
       (Case (Type 0) (IntVal 0)

--- a/tests/pass30/t02_break_if.expected
+++ b/tests/pass30/t02_break_if.expected
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (Drop (IntVal 100))
       (SelectBool (IntVal 0)

--- a/tests/pass30/t02_break_if.test
+++ b/tests/pass30/t02_break_if.test
@@ -2,7 +2,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (Drop (IntVal 100))
       (If (IntVal 0)

--- a/tests/pass30/t02_break_if_else.expected
+++ b/tests/pass30/t02_break_if_else.expected
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (Drop (IntVal 100))
       (SelectBool (IntVal 0)

--- a/tests/pass30/t02_break_if_else.test
+++ b/tests/pass30/t02_break_if_else.test
@@ -2,7 +2,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (Drop (IntVal 100))
       (If (IntVal 0)

--- a/tests/pass30/t02_break_loop.expected
+++ b/tests/pass30/t02_break_loop.expected
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (Drop (IntVal 100))
       (Join 0)

--- a/tests/pass30/t02_break_loop.test
+++ b/tests/pass30/t02_break_loop.test
@@ -2,7 +2,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (Drop (IntVal 100))
       (Loop

--- a/tests/pass30/t02_case.expected
+++ b/tests/pass30/t02_case.expected
@@ -4,7 +4,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Stmts
       (Select (Type 0) (IntVal 0)
         (Choice (IntVal 0)

--- a/tests/pass30/t02_case.test
+++ b/tests/pass30/t02_case.test
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Stmts
       (Case (Type 0) (IntVal 0)
         (Choice (IntVal 0)

--- a/tests/pass30/t02_checked_call.expected
+++ b/tests/pass30/t02_checked_call.expected
@@ -3,9 +3,9 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts (Return)))
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (CheckedCall (Proc 0) (Unwind))
       (Return))))

--- a/tests/pass30/t02_checked_call.test
+++ b/tests/pass30/t02_checked_call.test
@@ -2,9 +2,9 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Return))
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (CheckedCall (Proc 0))
       (Return))))

--- a/tests/pass30/t02_checked_call_asgn.expected
+++ b/tests/pass30/t02_checked_call_asgn.expected
@@ -5,10 +5,10 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Stmts
       (Return (IntVal 100))))
-  (ProcDef (Type 2)
+  (ProcDef (Type 2) (Params)
     (Locals (Type 0))
     (Stmts
       (CheckedCallAsgn (Local 0) (Proc 0) (Unwind))

--- a/tests/pass30/t02_checked_call_asgn.test
+++ b/tests/pass30/t02_checked_call_asgn.test
@@ -4,9 +4,9 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Return (IntVal 100)))
-  (ProcDef (Type 2)
+  (ProcDef (Type 2) (Params)
     (Locals (Type 0))
     (Stmts
       (CheckedCallAsgn (Local 0) (Proc 0))

--- a/tests/pass30/t02_if_then.expected
+++ b/tests/pass30/t02_if_then.expected
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (SelectBool (IntVal 0)
         (Continue 1)

--- a/tests/pass30/t02_if_then.test
+++ b/tests/pass30/t02_if_then.test
@@ -2,7 +2,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (If (IntVal 0)
         (Drop (IntVal 100)))

--- a/tests/pass30/t02_if_then_else.expected
+++ b/tests/pass30/t02_if_then_else.expected
@@ -3,7 +3,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (SelectBool (IntVal 0)
         (Continue 1)

--- a/tests/pass30/t02_if_then_else.test
+++ b/tests/pass30/t02_if_then_else.test
@@ -2,7 +2,7 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 0) (Locals)
+  (ProcDef (Type 0) (Params) (Locals)
     (Stmts
       (If (IntVal 0)
         (Drop (IntVal 100))

--- a/tests/pass30/t02_return_value.expected
+++ b/tests/pass30/t02_return_value.expected
@@ -5,10 +5,10 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Stmts
       (Return (IntVal 100))))
-  (ProcDef (Type 2) (Locals)
+  (ProcDef (Type 2) (Params) (Locals)
     (Stmts
       (Drop
         (Call (Proc 0)))

--- a/tests/pass30/t02_return_value.test
+++ b/tests/pass30/t02_return_value.test
@@ -4,9 +4,9 @@
   (ProcTy (Void)))
 (GlobalDefs)
 (ProcDefs
-  (ProcDef (Type 1) (Locals)
+  (ProcDef (Type 1) (Params) (Locals)
     (Return (IntVal 100)))
-  (ProcDef (Type 2) (Locals)
+  (ProcDef (Type 2) (Params) (Locals)
     (Stmts
       (Drop (Call (Proc 0)))
       (Return))))


### PR DESCRIPTION
## Summary

Require the locals receiving the procedure parameter to be designated
as such in the `L25` and `L30` intermediate languages.

## Details

Previously, the first N locals in the list of a procedure's locals
received the parameter values. Now, which local receives which
parameter is specified via an explicit parameter list.

This is meant to make the affected ILs easier to work with, as it
allows - for example - for appending new parameters without having to
update all references to locals within the procedure (due to the
shifted positions).

The `L25` and `L30` using tests are updated to work with the changed
languages, by adding a (usually empty) `Params` list to the procdefs,
and `pass25/t02_parameters.test` is extended with a test to make sure
translating procedure parameters to block parameters works.  

---

## Notes For Reviewers
* a split-out from the pass rework