### PR TITLE
rework the passes and intermediate languages

### DIFF
--- a/passes/lang1.md
+++ b/passes/lang1.md
@@ -4,35 +4,20 @@
 .extends lang0
 ```
 
-Blob types describe arbitrarily-sized untyped binary data:
+Numeric types can be identified types and identified types can be used in all
+places where types are expected.
 
 ```grammar
-typedesc += (Blob size:<int>)
+typedesc += <numtype>
+type += <type_id>
 ```
 
-The `Addr` operation only applies to locals instead of address offsets. Only
-blob locals are allowed as `Addr` operands.
+`Blob` types exist, but they're not yet allowed to be used in any context. The
+`Blob` type represents sized untyped memory that has an alignment requirement.
+The memory address of a blob value must be a multiple of its requested
+alignment.
 
 ```grammar
-rvalue -= (Addr (IntVal <int>))
-rvalue += (Addr <local>)
+typedesc += (Blob size:<int> align:<int>)
+type     += (Blob size:<int> align:<int>)
 ```
-
-Locals of `Blob` type cannot be anywhere except for `Addr` operands. The `Blob`
-type is also disallowed for parameters or the return type of procedures.
-
-*Rationale:* keeps the pass simpler.
-
-Each continuation names the locals alive for the duration of it:
-
-```grammar
-continuation -= (Continuation (Params) stack:<int> <stmt>* <exit>)
-              | (Except <local> stack:<int> <stmt>* <exit>)
-
-continuation += (Continuation (Params) (Locals <local>*) <stmt>* <exit>)
-              | (Except <local> (Locals <local>*) <stmt>* <exit>)
-```
-
-*Rationale:* the lowering pass can focus stack allocation, without having to a
-perform control-flow analysis for computing the set of alive locals for each
-continuation.

--- a/passes/lang2.md
+++ b/passes/lang2.md
@@ -1,0 +1,19 @@
+## L2 Language
+
+```grammar
+.extends lang1
+```
+
+Procedures no longer specify the size of their stack frame.
+
+```grammar
+procdef -= (ProcDef <type_id> <int> (Locals <type>*) (List <bblock>+))
+procdef += (ProcDef <type_id> (Locals <type>*) (List <bblock>+))
+```
+
+In addition, locals may be of `Blob` type. Blob locals may also have
+their address taken (locals of numeric type must not).
+
+```grammar
+expr += (Addr <local>)
+```

--- a/passes/lang25.md
+++ b/passes/lang25.md
@@ -1,46 +1,36 @@
 ## L25 Language
 
 ```grammar
-.extends lang4
+.extends lang5
 ```
 
-Procedures are no subdivided into continuations, but instead consist of a list
-of statements:
+Procedure bodies are not subdivided into basic-blocks, but instead consist of
+a list of statements:
 
 ```grammar
-procdef -= (ProcDef <type_id> (Continuations <continuation>+))
+procdef -= (ProcDef <type_id> (Locals <type>*) (List <bblock>+))
 procdef += (ProcDef <type_id> (Params <local>*) (Locals <type>*) (Stmts <stmt>+))
 ```
 
 ### Control Flow
 
-Control-flow statements can now appear in normal statement contexts:
+Control-flow statements can now appear in a normal statement context:
 
 ```grammar
-exit -= (Continue <cont_name> <value> (List <cont_arg>*))
-      | (Loop <cont_name> (List <cont_arg>*))
-      | (Raise <value> <err_goto>)
-      | (CheckedCall <proc> <value>* <goto> <err_goto>)
-      | (CheckedCall <type> <value>+ <goto> <err_goto>)
+exit -= (CheckedCall <proc> <expr>* <goto> <err_goto>)
+      | (CheckedCall <type_id> <expr>+ <goto> <err_goto>)
 
-exit += (Continue <cont_name> <value>)
-      | (Loop <cont_name>)
-      | (Return <value>?)
-      | (Raise <value> <err_goto>)
-      | (CheckedCall <proc> <value>* <err_goto>)
-      | (CheckedCall <type> <value>+ <err_goto>)
-      | (CheckedCallAsgn <local> <proc> <value>* <err_goto>)
-      | (CheckedCallAsgn <local> <type> <value>+ <err_goto>)
-
-goto -= (Continue <cont_name> (List <cont_arg>*))
-goto += (Continue <cont_name>)
+exit += (CheckedCall <proc> <expr>* <err_goto>)
+      | (CheckedCall <type_id> <expr>+ <err_goto>)
+      | (CheckedCallAsgn <local> <proc> <expr>* <err_goto>)
+      | (CheckedCallAsgn <local> <type_id> <expr>+ <err_goto>)
 
 stmt += <goto>
       | <exit>
 ```
 
 ```grammar
-stmt += (Join label:<cont_name>)
+stmt += (Join label:<block_name>)
 ```
 
 A `Join` statement represents the destination of a non-exceptional control-
@@ -48,7 +38,7 @@ flow statement. Control-flow is allowed to reach a `Join` statement without a
 jump. Labels can be arbitrary numbers.
 
 ```grammar
-stmt += (Except label:<cont_name> <local>)
+stmt += (Except label:<block_name> <local>)
 ```
 
 An `Except` statement represents the jump target for exceptional control-flow.

--- a/passes/lang30.md
+++ b/passes/lang30.md
@@ -26,21 +26,21 @@ choice -= (Choice <intVal> <goto>)
 choice += (Choice <intVal> <single_stmt>)
         | (Choice <floatVal> <single_stmt>)
 
-stmt -= (Join   <cont_name>)
-      | (Except <cont_name> <local>)
+stmt -= (Join   <block_name>)
+      | (Except <block_name> <local>)
       | <exit>
       | <goto>
 
 stmt += (Block <single_stmt>)
       | (Loop <single_stmt>)
-      | (If <value> <single_stmt> <single_stmt>?)
-      | (Case <type> <simple> <choice>+)
-      | (CheckedCall <proc> <value>*)
-      | (CheckedCall <type> <value>+)
-      | (CheckedCallAsgn <local> <proc> <value>*)
-      | (CheckedCallAsgn <local> <type> <value>+)
-      | (Return <value>?)
-      | (Raise <value>)
+      | (If <expr> <single_stmt> <single_stmt>?)
+      | (Case <type_id> <simple> <choice>+)
+      | (CheckedCall <proc> <expr>*)
+      | (CheckedCall <type_id> <expr>+)
+      | (CheckedCallAsgn <local> <proc> <expr>*)
+      | (CheckedCallAsgn <local> <type_id> <expr>+)
+      | (Return <expr>?)
+      | (Raise <expr>)
       | (Unreachable)
 ```
 

--- a/passes/lang4.md
+++ b/passes/lang4.md
@@ -4,56 +4,5 @@
 .extends lang3
 ```
 
-There are no more procedure-wide locals:
-
-```grammar
-procdef -= (ProcDef <type_id> (Locals <type>*) (Continuations <continuation>+))
-procdef += (ProcDef <type_id> (Continuations <continuation>+))
-```
-
-Instead, locals are per-continuation state. A continuation has parameters, and
-a list of new locals it spawns:
-
-```grammar
-continuation -= (Continuation (Params) (Locals <local>*) <stmt>* <exit>)
-              | (Except       <local>  (Locals <local>*) <stmt>* <exit>)
-continuation += (Continuation (Params <type>*) (Locals <type>*) <stmt>* <exit>)
-              | (Except       (Params <type>*) (Locals <type>*) <stmt>* <exit>)
-```
-
-A `Local` with an ID < *number of parameters* refers to a parameter --
-all others refer to a spawned local.
-
-Values are passed explicitly to continuations:
-
-```grammar
-cont_arg ::= (Move <local>)   # move the value
-          |  (Rename <local>) # the identity (read, address) must stay the same
-```
-
-Every jump to another `Continuation` must specify which locals are moved
-across; arity and types need to match those of the target continuation:
-
-```grammar
-exit -= (Continue <cont_name> <value>)
-      | (Loop <cont_name>)
-
-exit += (Continue <cont_name> <value> (List <cont_arg>*))
-      | (Loop <cont_name> (List <cont_arg>*))
-
-goto -= (Continue <cont_name>)
-goto += (Continue <cont_name> (List <cont_arg>*))
-```
-
-There are no `CheckedCallAsgn`. Checked calls that return something use
-`CheckedCall`s, with the result implicitly passed to the follow-up
-continuation's first parameter. The target continuation must not be the
-procedure exit continuation.
-
-```grammar
-exit -= (CheckedCallAsgn <local> <proc> <value>* <goto> <err_goto>)
-      | (CheckedCallAsgn <local> <type> <value>+ <goto> <err_goto>)
-```
-
-Exits via exceptional control-flow always implicitly pass the exception to the
-first `Continuation` parameter.
+There's no change in the grammar, but procedure parameters and return values
+may now be of aggregate type.

--- a/passes/lang5.md
+++ b/passes/lang5.md
@@ -1,0 +1,20 @@
+## L5 Language
+
+```grammar
+.extends lang4
+```
+
+Instead of flat `Path` expressions, records and unions are accessed via the
+`Field` and arrays via the `At` lvalue expression.
+
+```grammar
+
+path -= (Path <type> <local> <path_idx>+)
+      | (Path <type> (Deref <type> <expr>) <path_idx>+)
+path += (Field <path_elem> <int>)
+      | (At    <path_elem> <expr>)
+
+path_elem ::= (Deref <type> <expr>) # a path root
+           |  <local>               # also a path root
+           |  <path>
+```

--- a/passes/spec.nim
+++ b/passes/spec.nim
@@ -15,7 +15,7 @@ type
 
     List
 
-    Void, ProcTy, Blob, Record, Array
+    Void, ProcTy, Blob, Record, Union, Array
 
     Join
 
@@ -23,7 +23,7 @@ type
 
     Load, Store, Addr, Call
     Deref, Field, At
-    Copy, Move, Rename
+    Copy
 
     Neg, Add, Sub, Mul, Div, Mod
     AddChck, SubChck
@@ -34,10 +34,10 @@ type
 
     Conv, Reinterp
 
-    Continue, Loop, Raise, Unreachable, Select, SelectBool
+    Goto, Loop, Raise, Unreachable, Select, Branch
     CheckedCall, CheckedCallAsgn, Unwind, Choice
 
-    Module, TypeDefs, ProcDefs, ProcDef, Locals, Continuations, Continuation,
+    Module, TypeDefs, ProcDefs, ProcDef, Locals,
     Except, Params, GlobalDefs, GlobalDef, Foreign
 
     Break, Return, Case, If, Block, Stmts


### PR DESCRIPTION
Redesign large parts of the intermediate languages, fixing some mistakes made with their first iteration.

Some terminology is changed (e.g., continuation -> basic block), transformations are redistributed between passes, new passes are introduced, and the languages are simplified. The most significant simplification is the temporary removal of the SSA form and associated transformation. It results in simpler ILs, much smaller IL code sizes, and much faster passes, at the cost of a major regression in quality of the generated VM bytecode.

In addition, the following important features are now supported by the `L30` IL:
* alignment requirements for aggregate types
* locals of scalar type can have their address taken
* procedure parameter and return values can be of aggregate type

---

## To-Do
* [ ] implement the new passes
* [ ] adjust the existing passes where necessary (`pass0` and `pass25`)
* [ ] change `source2il` to produce valid `L30` code (according to the new specification)
* [ ] write tests for the new passes
* [ ] remove the obsolete tests and passes
* [ ] write a proper commit message

## Notes For Reviewers
* this PR is the successor to #64