### PR TITLE
source2il: use a tree-based IR

### DIFF
--- a/passes/ir.nim
+++ b/passes/ir.nim
@@ -1,0 +1,197 @@
+## Implements an IR for the highest-level IL that's not flat. It's meant as a
+## helper for ``source2il``, to make tree construction easier and less prone
+## to mistakes. The IR is meant to be a temporary measure until more lowering
+## is delegated to separate passes.
+##
+## Some common things, like wrapping lvalue expression in a `Copy` operation
+## when appearing in a usage context, are handled during to-packed-tree
+## translation.
+
+import
+  passes/[builders, spec, trees],
+  vm/utils
+
+type
+  IrNode* = object
+    case kind*: NodeKind
+    of IntVal:
+      intVal*: int
+    of FloatVal:
+      floatVal*: float
+    of Local, Proc, Type:
+      id*: uint32
+    of Field, At, Deref, Addr, Call, Stmts, Drop, Asgn, Break, Return, Loop,
+       If, Add, Sub, Mul, Div, Mod, Not, Eq, Lt, Le:
+      children*: seq[IrNode]
+    else:
+      discard
+
+  Node = TreeNode[NodeKind]
+
+const None* = Immediate
+  ## Represents an uninitialized node
+
+template `[]`*(n: IrNode, i: int): IrNode =
+  n.children[i]
+
+template add*(n: var IrNode, elem: IrNode) =
+  ## Adds `elem` to `n`. The expression passed to `elem` is allowed to
+  ## modify `n`.
+  let tmp = elem
+  n.children.add tmp
+
+template add*(n: var IrNode, elems: seq[IrNode]) =
+  ## Adds `elems` to `n`. The expression passed to `elem` is allowed to
+  ## modify `n`.
+  let tmp = elems
+  n.children.add tmp
+
+proc newIntVal*(v: BiggestInt): IrNode =
+  IrNode(kind: IntVal, intVal: v.int)
+
+proc newFloatVal*(val: float): IrNode =
+  IrNode(kind: FloatVal, floatVal: val)
+
+proc newLocal*(id: uint32): IrNode =
+  IrNode(kind: Local, id: id)
+
+proc newIf*(cond, then, els: sink IrNode): IrNode =
+  IrNode(kind: If, children: @[cond, then, els])
+
+proc newIf*(cond, then: sink IrNode): IrNode =
+  IrNode(kind: If, children: @[cond, then])
+
+proc newAsgn*(dest, src: sink IrNode): IrNode =
+  # allow none for the sake of error correction
+  assert dest.kind in {Field, At, Local, Deref, None}
+  IrNode(kind: Asgn, children: @[dest, src])
+
+proc newFieldExpr*(n: sink IrNode, index: int): IrNode =
+  assert n.kind in {Field, At, Local, Deref, None}
+  IrNode(kind: Field, children: @[n, newIntVal(index)])
+
+proc newDeref*(typ: uint32, n: sink IrNode): IrNode =
+  IrNode(kind: Deref, children: @[IrNode(kind: Type, id: typ), n])
+
+proc newReturn*(n: sink IrNode): IrNode =
+  IrNode(kind: Return, children: @[n])
+
+proc newBreak*(depth: Natural): IrNode =
+  IrNode(kind: Break, children: @[newIntVal(depth)])
+
+proc newCall*(prc: uint32, arg: sink IrNode): IrNode =
+  IrNode(kind: Call, children: @[IrNode(kind: Proc, id: prc), arg])
+
+proc newCall*(prc: uint32, args: sink seq[IrNode]): IrNode =
+  args.insert IrNode(kind: Proc, id: prc)
+  IrNode(kind: Call, children: args)
+
+proc newNot*(n: sink IrNode): IrNode =
+  IrNode(kind: Not, children: @[n])
+
+proc newDrop*(e: sink IrNode): IrNode =
+  IrNode(kind: Drop, children: @[e])
+
+proc newAddr*(e: sink IrNode): IrNode =
+  IrNode(kind: Addr, children: @[e])
+
+proc newUnreachable*(): IrNode =
+  IrNode(kind: Unreachable)
+
+proc newBinaryOp*(op: NodeKind, typ: uint32, a, b: sink IrNode): IrNode =
+  case op
+  of Add, Sub, Mul, Div, Mod, Eq, Lt, Le:
+    IrNode(kind: op, children: @[IrNode(kind: Type, id: typ), a, b])
+  else:
+    unreachable()
+
+proc convert*(n: IrNode, lit: var Literals, bu: var Builder[NodeKind])
+
+proc use*(n: IrNode, lit: var Literals, bu: var Builder[NodeKind]) =
+  ## Emits `n` to `bu`. If `n` is an lvalue expression, it's first turned
+  ## into a proper rvalue expression.
+  case n.kind
+  of Field, At, Local:
+    bu.subTree Copy:
+      convert(n, lit, bu)
+  of Deref:
+    bu.subTree Load:
+      convert(n[0], lit, bu)
+      use(n[1], lit, bu)
+  of Proc:
+    bu.add Node(kind: ProcVal, val: n.id)
+  else:
+    convert(n, lit, bu)
+
+proc convert*(n: IrNode, lit: var Literals, bu: var Builder[NodeKind]) =
+  ## Emits `n` to `bu` as is.
+  case n.kind
+  of None:
+    # okay, ignore. None should only be possible after error-correcting, in
+    # which case the resulting code is not used anyway
+    discard
+  of IntVal:
+    bu.add Node(kind: IntVal, val: lit.pack(n.intVal))
+  of FloatVal:
+    bu.add Node(kind: FloatVal, val: lit.pack(n.floatVal))
+  of Field:
+    bu.subTree Field:
+      convert(n[0], lit, bu)
+      bu.add Node(kind: Immediate, val: n[1].intVal.uint32)
+  of At, Deref:
+    bu.subTree n.kind:
+      convert(n[0], lit, bu)
+      use(n[1], lit, bu)
+  of Drop, Not:
+    bu.subTree n.kind:
+      use(n[0], lit, bu)
+  of Local, Proc, Type:
+    bu.add Node(kind: n.kind, val: n.id)
+  of Addr:
+    bu.subTree Addr:
+      convert(n[0], lit, bu)
+  of Call:
+    bu.subTree Call:
+      for i, it in n.children.pairs:
+        if i == 0:
+          convert(it, lit, bu)
+        else:
+          use(it, lit, bu)
+  of Asgn:
+    if n[0].kind == Deref:
+      # (Asgn (Deref typ x) y) -> (Store typ x y)
+      bu.subTree Store:
+        convert(n[0][0], lit, bu)
+        use(n[0][1], lit, bu)
+        use(n[1], lit, bu)
+    else:
+      bu.subTree Asgn:
+        convert(n[0], lit, bu)
+        use(n[1], lit, bu)
+  of Break:
+    bu.subTree Break:
+      bu.add Node(kind: Immediate, val: n[0].intVal.uint32)
+  of Return:
+    bu.subTree Return:
+      if n.children.len == 1:
+        use(n[0], lit, bu)
+  of Unreachable:
+    bu.subTree Unreachable:
+      discard
+  of If:
+    bu.subTree If:
+      use(n[0], lit, bu)
+      convert(n[1], lit, bu)
+      if n.children.len == 3:
+        convert(n[2], lit, bu)
+  of Loop:
+    bu.subTree Loop:
+      convert(n[0], lit, bu)
+  of Stmts:
+    bu.subTree Stmts:
+      for it in n.children.items:
+        convert(it, lit, bu)
+  else:
+    bu.subTree n.kind:
+      for it in n.children.items:
+        use(it, lit, bu)

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -8,7 +8,7 @@
 
 import
   std/[algorithm, sequtils, tables],
-  passes/[builders, spec, trees],
+  passes/[builders, ir, spec, trees],
   phy/[reporting, types],
   vm/[utils]
 
@@ -20,7 +20,6 @@ type
   SourceKind = spec_source.NodeKind
   InTree     = PackedTree[SourceKind]
   Node       = TreeNode[NodeKind]
-  NodeSeq    = seq[Node]
 
   EntityKind = enum
     ekNone        ## signals "non-existent"
@@ -91,8 +90,8 @@ type
     # XXX: the target IL doesn't support expression lists (yet), so we have
     #      to apply the necessary lowering here, for now. Efficiency doesn't
     #      matter
-    stmts: seq[NodeSeq] # can be empty
-    expr: NodeSeq
+    stmts: seq[IrNode] # can be empty
+    expr: IrNode
     typ: SemType
     attribs: set[ExprFlag]
 
@@ -108,9 +107,9 @@ const
     "false": ekBuiltinVal
   }.toTable
 
-  UnitNode = Node(kind: IntVal)
+  UnitNode = IrNode(kind: IntVal, intVal: 0)
     ## the node representing the unitary value
-  unitExpr = Expr(expr: @[UnitNode], typ: prim(tkUnit))
+  unitExpr = Expr(expr: UnitNode, typ: prim(tkUnit))
     ## the expression evaluating to the unitary value
 
   pointerType = prim(tkInt)
@@ -121,7 +120,8 @@ using
   c: var ModuleCtx
   t: InTree
   bu: var Builder[NodeKind]
-  stmts: var seq[NodeSeq]
+  expr: var IrNode
+  stmts: var seq[IrNode]
 
 template `+`(t: SemType, a: set[ExprFlag]): ExprType =
   ## Convenience shortcut for creating an ``ExprType``.
@@ -159,12 +159,6 @@ func openScope(c) =
 func closeScope(c) =
   ## Closes the current scope and makes its parent the current one.
   c.scopes.shrink(c.scopes.len - 1)
-
-func add(bu; trees: openArray[NodeSeq]) =
-  ## Appends all `trees` to the current sub-tree. The trees must each either
-  ## represent a single atomic node, or a complete subtree.
-  for t in trees.items:
-    bu.add t
 
 template addType(c; kind: NodeKind, body: untyped): uint32 =
   c.types.subTree kind:
@@ -360,93 +354,37 @@ proc genProcType(c; typ: SemType): uint32 =
     result = rawGenProcType(c, typ)
     c.procTypeCache[typ] = result
 
-template buildTree(kind: NodeKind, body: untyped): NodeSeq =
-  ## Makes a builder available to `body`, evaluates `body`, and returns the
-  ## generated tree.
-  var res: NodeSeq
-  if true: # open a new scope
-    var bu {.inject.} = initBuilder[NodeKind](kind)
-    body
-    res = finish(bu)
-  res
-
-template addStmt(stmts: var seq[NodeSeq], body: untyped) =
-  if true: # open a new scope
-    var bu {.inject.} = initBuilder[NodeKind]()
-    body
-    stmts.add finish(bu)
-
-template addStmt(stmts: var seq[NodeSeq], kind: NodeKind, body: untyped) =
-  stmts.add buildTree(kind, body)
-
 proc resetProcContext(c) =
   c.locals.setLen(0) # re-use the memory
 
-proc newTemp(c; typ: SemType): uint32 =
+proc newTemp(c; typ: SemType): IrNode =
   ## Allocates a new temporary of `typ` type.
   case typ.kind
-  of tkVoid: discard "do not create a temp for void"
+  of tkVoid:
+    # do not create a temp for void
+    result = IrNode(kind: None)
   else:
-    result = c.locals.len.uint32
+    result = newLocal(c.locals.len.uint32)
     c.locals.add typ
 
-proc genLocal(val: uint32, typ: SemType, bu) =
-  ## Emits a ``Local val`` to `bu`, so long as `typ` is not `tkVoid`.
-  case typ.kind
-  of tkVoid: discard "nothing to generate"
-  else: bu.add Node(kind: Local, val: val)
+proc wrap(e: sink Expr, dest: IrNode): IrNode =
+  ## Turns `e` into a statement list. The expression part is turned into an
+  ## assignment to `dest`, but only if not a void expression.
+  result = IrNode(kind: Stmts, children: e.stmts)
+  if e.typ.kind != tkVoid:
+    result.add newAsgn(dest, e.expr)
 
-proc genUse(a: Node|NodeSeq, bu) =
-  ## Emits `a` to `bu`, wrapping the expression in a ``Copy`` operation when
-  ## it's an lvalue expression.
-  case (when a is Node: a.kind else: a[0].kind)
-  of Field, At, Local:
-    bu.subTree Copy:
-      bu.add a
-  of Deref:
-    when a is NodeSeq:
-      # ``(Deref typ x)`` -> ``(Load typ x)``
-      bu.subTree Load:
-        bu.add a[1]
-        bu.add a.toOpenArray(2, a.high)
-    else:
-      unreachable()
-  else:
-    bu.add a
-
-proc genUse(e: Expr, bu; stmts) =
-  ## Emits a usage of expression `e` to `bu` and `stmts`.
+proc inline(e: sink Expr, stmts): IrNode =
+  ## Adds the statement part of `e` to `stmts` and returns the expression part.
   stmts.add e.stmts
-  genUse(e.expr, bu)
+  e.expr
 
-proc genAsgn(c; a: Node|NodeSeq, b: NodeSeq, typ: SemType, bu) =
-  ## Emits an ``a = b`` assignment to `bu`. For convenience, if `typ` is a
-  ## ``tkVoid``, no assignment is emitted.
-  if typ.kind != tkVoid:
-    bu.subTree Asgn:
-      bu.add a
-      genUse(b, bu)
-
-proc genDrop(a: Node|NodeSeq, typ: SemType, bu) =
-  ## Emits a ``Drop a`` to `bu`, so long as `typ` is not `void`.
-  if typ.kind != tkVoid:
-    bu.subTree Drop:
-      genUse(a, bu)
-
-proc inline(bu; e: sink Expr; stmts) =
-  ## Appends the trailing expression directly to `bu`.
-  stmts.add e.stmts
-  bu.add e.expr
-
-proc capture(c; e: sink Expr; stmts): Node =
+proc capture(c; e: sink Expr; stmts): IrNode =
   ## Commits expression `e` to a fresh temporary. This is part of the
   ## expression-list lowering machinery.
-  let tmp = c.newTemp(e.typ)
-  result = Node(kind: Local, val: tmp)
-
+  result = c.newTemp(e.typ)
   stmts.add e.stmts
-  stmts.addStmt:
-    c.genAsgn(result, e.expr, e.typ, bu)
+  stmts.add newAsgn(result, e.expr)
 
 proc fitExpr(c; e: sink Expr, target: SemType): Expr =
   ## Makes sure `e` fits into the `target` type, returning the expression
@@ -470,22 +408,13 @@ proc fitExpr(c; e: sink Expr, target: SemType): Expr =
         # error occurred during union construction
 
         # emit the tag assignment:
-        result.stmts.addStmt Asgn:
-          bu.subTree Field:
-            bu.add Node(kind: Local, val: tmp)
-            bu.add Node(kind: Immediate, val: 0)
-          bu.add Node(kind: IntVal, val: c.literals.pack(idx))
-
+        result.stmts.add:
+          newAsgn(newFieldExpr(tmp, 0), newIntVal(idx))
         # emit the value assignment:
-        result.stmts.addStmt Asgn:
-          bu.subTree Field:
-            bu.subTree Field:
-              bu.add Node(kind: Local, val: tmp)
-              bu.add Node(kind: Immediate, val: 1)
-            bu.add Node(kind: Immediate, val: idx.uint32)
-          genUse(e.expr, bu)
+        result.stmts.add:
+          newAsgn(newFieldExpr(newFieldExpr(tmp, 1), idx), e.expr)
 
-        result.expr = @[Node(kind: Local, val: tmp)]
+        result.expr = tmp
       of tkError:
         # error correction: keep the original expression as is when fitting
         # to the error type
@@ -496,8 +425,7 @@ proc fitExpr(c; e: sink Expr, target: SemType): Expr =
   else:
     # TODO: this needs a better error message
     c.error("type mismatch")
-    result = Expr(stmts: e.stmts, expr: @[Node(kind: IntVal)],
-                  typ: errorType())
+    result = Expr(stmts: e.stmts, typ: errorType())
 
 proc fitExprStrict(c; e: sink Expr, typ: SemType): Expr =
   ## Makes sure expression `e` fits `typ` exactly, reporting an error and
@@ -508,19 +436,17 @@ proc fitExprStrict(c; e: sink Expr, typ: SemType): Expr =
     c.error("expected expression of type $1 but got type $2" %
             [$typ.kind, $e.typ.kind])
     # turn into an error expression:
-    result = Expr(stmts: e.stmts, expr: @[Node(kind: IntVal)],
-                  typ: errorType())
+    result = Expr(stmts: e.stmts, typ: errorType())
 
-proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): ExprType
+proc exprToIL(c; t: InTree, n: NodeIndex, expr, stmts): ExprType
 
 proc exprToIL(c; t: InTree, n: NodeIndex): Expr =
-  var bu = initBuilder[NodeKind]()
-  (result.typ, result.attribs) = exprToIL(c, t, n, bu, result.stmts)
-  result.expr = finish(bu)
+  result.expr = IrNode(kind: None)
+  (result.typ, result.attribs) = exprToIL(c, t, n, result.expr, result.stmts)
   # verify some postconditions:
-  assert result.typ.kind != tkVoid or result.expr.len == 0,
+  assert result.typ.kind != tkVoid or result.expr.kind == None,
          "void `Expr` cannot have a trailing expression"
-  assert result.typ.kind in {tkVoid, tkError} or result.expr.len > 0,
+  assert result.typ.kind in {tkVoid, tkError} or result.expr.kind != None,
          "non-void `Expr` must have a trailing expression"
 
 proc scopedExprToIL(c; t; n: NodeIndex): Expr =
@@ -530,17 +456,16 @@ proc scopedExprToIL(c; t; n: NodeIndex): Expr =
   result = c.exprToIL(t, n)
   c.closeScope()
 
-template lenCheck(t; n: NodeIndex, bu; expected: int) =
+template lenCheck(t; n: NodeIndex, expected: int) =
   ## Exits the current analysis procedure with an error, if `n` doesn't have
   ## `expected` children.
   if t.len(n) != expected:
     c.error("expected " & $expected & " arguments, but got " & $t.len(n))
-    bu.add Node(kind: IntVal)
     return errorType()
 
-proc binaryArithToIL(c; t; n: NodeIndex, name: string, bu, stmts): SemType =
+proc binaryArithToIL(c; t; n: NodeIndex, name: string, expr, stmts): SemType =
   ## Analyzes and emits the IL for a binary arithmetic operation.
-  lenCheck(t, n, bu, 3)
+  lenCheck(t, n, 3)
 
   let
     (_, a, b)  = t.triplet(n)
@@ -562,18 +487,14 @@ proc binaryArithToIL(c; t; n: NodeIndex, name: string, bu, stmts): SemType =
     c.error("arguments must be of 'int' or 'float' type")
     result = errorType()
   else:
-    bu.subTree op:
-      bu.add Node(kind: Type, val: c.typeToIL(eA.typ))
-      bu.subTree Copy:
-        bu.add c.capture(eA, stmts)
-      bu.subTree Copy:
-        bu.add c.capture(eB, stmts)
-
+    expr = newBinaryOp(op, c.typeToIL(eA.typ),
+                       c.capture(eA, stmts),
+                       c.capture(eB, stmts))
     result = eA.typ
 
-proc relToIL(c; t; n: NodeIndex, name: string, bu; stmts): SemType =
+proc relToIL(c; t; n: NodeIndex, name: string, expr; stmts): SemType =
   ## Analyzes and emits the IL for a relational operation.
-  lenCheck(t, n, bu, 3)
+  lenCheck(t, n, 3)
 
   let
     (_, a, b)  = t.triplet(n)
@@ -588,52 +509,37 @@ proc relToIL(c; t; n: NodeIndex, name: string, bu; stmts): SemType =
     else:   unreachable()
 
   if eA.typ == eB.typ and eA.typ.kind in valid:
-    bu.subTree op:
-      bu.add Node(kind: Type, val: c.typeToIL(eA.typ))
-      bu.subTree Copy:
-        bu.add c.capture(eA, stmts)
-      bu.subTree Copy:
-        bu.add c.capture(eB, stmts)
-
+    expr = newBinaryOp(op, c.typeToIL(eA.typ),
+                       c.capture(eA, stmts),
+                       c.capture(eB, stmts))
     result = prim(tkBool)
   elif tkError in {eA.typ.kind, eB.typ.kind}:
     result = errorType()
   else:
     c.error("arguments have mismatching types")
-    bu.add Node(kind: IntVal)
     result = errorType()
 
-proc notToIL(c; t; n: NodeIndex, bu; stmts): SemType =
-  lenCheck(t, n, bu, 2)
+proc notToIL(c; t; n: NodeIndex, expr; stmts): SemType =
+  lenCheck(t, n, 2)
 
   let arg = exprToIL(c, t, t.child(n, 1))
 
   if arg.typ.kind == tkBool:
     # a single argument, so no capture is necessary
-    bu.subTree Not:
-      genUse(arg, bu, stmts)
+    expr = newNot(inline(arg, stmts))
     result = prim(tkBool)
   else:
     c.error("expected 'bool' expression")
-    bu.add Node(kind: IntVal)
     result = errorType()
 
-proc userCallToIL(c; t; n: NodeIndex, bu; stmts): SemType =
+proc userCallToIL(c; t; n: NodeIndex, expr; stmts): SemType =
   ## Analyzes a non-built-in call expression and translates it to its IL
   ## representation.
   let callee = c.exprToIL(t, t.child(n, 0))
 
   if callee.typ.kind == tkProc:
-    proc useCallee(c; e: sink Expr, bu; stmts) =
-      stmts.add e.stmts
-      if e.expr[0].kind == ProcVal:
-        # the callee is a statically-known procedure; it's a static call
-        bu.add Node(kind: Proc, val: e.expr[0].val)
-      else:
-        bu.add Node(kind: Type, val: c.genProcType(e.typ))
-        genUse(e.expr, bu)
-
-    proc argsToIL(c; t; n: NodeIndex; prc: SemType, bu; stmts) {.nimcall.} =
+    proc addArgs(call: var IrNode, c; t; n: NodeIndex; prc: SemType; stmts
+                ) {.nimcall.} =
       var i = 1 # 1 means argument 0
       for it in t.items(n, 1):
         # only try fitting the argument if there's a corresponding parameter
@@ -649,10 +555,9 @@ proc userCallToIL(c; t; n: NodeIndex, bu; stmts): SemType =
         if arg.typ.kind in AggregateTypes:
           # XXX: due to lack of support in the IL, aggregate values need to be
           #      passed by address at the moment
-          bu.subTree Addr:
-            bu.add tmp
+          call.add newAddr(tmp)
         else:
-          genUse(tmp, bu)
+          call.add tmp
 
         inc i
 
@@ -661,31 +566,34 @@ proc userCallToIL(c; t; n: NodeIndex, bu; stmts): SemType =
         c.error("expected $1 arguments but got $2" %
                 [$(prc.elems.len - 1), $(i - 1)])
 
+    stmts.add callee.stmts
+
+    var call = IrNode(kind: Call)
+    if callee.expr.kind == Proc:
+      # the callee is a statically-known procedure; it's a static call
+      call.add callee.expr
+    else:
+      call.add IrNode(kind: Type, id: c.genProcType(callee.typ))
+      call.add callee.expr
+
+    call.addArgs(c, t, n, callee.typ, stmts)
+
     # some return types need special handling
     case callee.typ.elems[0].kind
     of tkVoid:
-      stmts.addStmt Call:
-        c.useCallee(callee, bu, stmts)
-        c.argsToIL(t, n, callee.typ, bu, stmts)
+      stmts.add call
       # mark the non-exceptional call exit as unreachable:
-      stmts.addStmt Unreachable:
-        discard
+      stmts.add newUnreachable()
     of AggregateTypes:
       # the value is not returned normally, but passed via an out parameter
       let tmp = c.newTemp(callee.typ.elems[0])
-      stmts.addStmt Drop:
-        bu.subTree Call:
-          c.useCallee(callee, bu, stmts)
-          c.argsToIL(t, n, callee.typ, bu, stmts)
-          bu.subTree Addr:
-            bu.add Node(kind: Local, val: tmp)
+      call.add newAddr(tmp)
+      stmts.add newDrop(call)
 
       # return the temporary as the expression
-      bu.add Node(kind: Local, val: tmp)
+      expr = tmp
     else:
-      bu.subTree Call:
-        c.useCallee(callee, bu, stmts)
-        c.argsToIL(t, n, callee.typ, bu, stmts)
+      expr = call
 
     result = callee.typ.elems[0]
   else:
@@ -697,10 +605,9 @@ proc userCallToIL(c; t; n: NodeIndex, bu; stmts): SemType =
       discard c.exprToIL(t, it)
 
     # return an error
-    bu.add Node(kind: IntVal)
     result = errorType()
 
-proc callToIL(c; t; n: NodeIndex, bu; stmts): SemType =
+proc callToIL(c; t; n: NodeIndex, expr; stmts): SemType =
   # first check whether its call to a built-in procedure (those take
   # precedence)
   let callee = t.child(n, 0)
@@ -712,19 +619,19 @@ proc callToIL(c; t; n: NodeIndex, bu; stmts): SemType =
     if ent.kind == ekBuiltinProc:
       case name
       of "+", "-":
-        result = binaryArithToIL(c, t, n, name, bu, stmts)
+        result = binaryArithToIL(c, t, n, name, expr, stmts)
       of "==", "<", "<=":
-        result = relToIL(c, t, n, name, bu, stmts)
+        result = relToIL(c, t, n, name, expr, stmts)
       of "not":
-        result = notToIL(c, t, n, bu, stmts)
+        result = notToIL(c, t, n, expr, stmts)
       else:
         unreachable()
       return
 
   # it must be a call to a user-defined procedure (or an error)
-  result = userCallToIL(c, t, n, bu, stmts)
+  result = userCallToIL(c, t, n, expr, stmts)
 
-proc localDeclToIL(c; t; n: NodeIndex, bu, stmts) =
+proc localDeclToIL(c; t; n: NodeIndex, stmts) =
   ## Translates a procedure-local declaration to the target IL.
   let
     (npos, init) = t.pair(n)
@@ -735,12 +642,10 @@ proc localDeclToIL(c; t; n: NodeIndex, bu, stmts) =
     c.error("cannot initialize local with `void` expression")
     # turn into an error expression:
     e.typ = errorType()
-    e.expr = @[Node(kind: IntVal)]
+    e.expr = IrNode(kind: None)
 
   let local = c.newTemp(e.typ)
-  stmts.add e.stmts
-  stmts.addStmt:
-    c.genAsgn(Node(kind: Local, val: local), e.expr, e.typ, bu)
+  stmts.add newAsgn(local, inline(e, stmts))
 
   # verify that the name isn't in use already *after* analyzing the
   # initializer; the expression could introduce an entity with the same name
@@ -750,15 +655,15 @@ proc localDeclToIL(c; t; n: NodeIndex, bu, stmts) =
     # correction
 
   # register the declaration *after* analyzing the expression
-  c.addDecl(name, Entity(kind: ekLocal, id: local.int))
+  c.addDecl(name, Entity(kind: ekLocal, id: local.id.int))
 
-proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): ExprType =
+proc exprToIL(c; t: InTree, n: NodeIndex, expr, stmts): ExprType =
   case t[n].kind
   of SourceKind.IntVal:
-    bu.add Node(kind: IntVal, val: c.literals.pack(t.getInt(n)))
+    expr = newIntVal(t.getInt(n))
     result = prim(tkInt) + {}
   of SourceKind.FloatVal:
-    bu.add Node(kind: FloatVal, val: c.literals.pack(t.getFloat(n)))
+    expr = newFloatVal(t.getFloat(n))
     result = prim(tkFloat) + {}
   of SourceKind.Ident:
     let
@@ -768,36 +673,32 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): ExprType =
     of ekBuiltinVal:
       case name
       of "false":
-        bu.add Node(kind: IntVal, val: 0)
+        expr = newIntVal(0)
         result = prim(tkBool) + {}
       of "true":
-        bu.add Node(kind: IntVal, val: 1)
+        expr = newIntVal(1)
         result = prim(tkBool) + {}
     of ekLocal:
-      bu.add Node(kind: Local, val: ent.id.uint32)
+      expr = newLocal(ent.id.uint32)
       result = c.locals[ent.id] + {Lvalue, Mutable}
     of ekParam:
       if c.params[ent.id].typ.kind in AggregateTypes:
         # aggregate parameters use pass-by-address
-        bu.subTree Deref:
-          bu.add Node(kind: Type, val: c.typeToIL(c.params[ent.id].typ))
-          bu.subTree Copy:
-            bu.add Node(kind: Local, val: c.params[ent.id].local)
+        expr = newDeref(c.typeToIL(c.params[ent.id].typ),
+                        newLocal(c.params[ent.id].local))
       else:
-        bu.add Node(kind: Local, val: c.params[ent.id].local)
+        expr = newLocal(c.params[ent.id].local)
       result = c.params[ent.id].typ + {Lvalue}
     of ekProc:
       # expand to a procedure address (`ProcVal`), which is always correct;
       # the callsite can turn it into a static reference (`Proc`) as needed
-      bu.add Node(kind: ProcVal, val: ent.id.uint32)
+      expr = IrNode(kind: Proc, id: ent.id.uint32)
       result = c.procList[ent.id].typ + {}
     of ekNone:
       c.error("undeclared identifier: " & t.getString(n))
-      bu.add Node(kind: IntVal)
       result = prim(tkError) + {}
     else:
       c.error("'" & name & "' cannot be used in this context")
-      bu.add Node(kind: IntVal)
       result = prim(tkError) + {}
   of SourceKind.And, SourceKind.Or:
     let
@@ -810,31 +711,17 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): ExprType =
 
     if t[n].kind == SourceKind.And:
       # (And a b) -> (If a b False)
-      stmts.addStmt If:
-        genUse(ea, bu, stmts)
-        bu.subTree Stmts: # then branch
-          bu.add eb.stmts
-          bu.subTree Asgn:
-            bu.add Node(kind: Local, val: tmp)
-            genUse(eb.expr, bu)
-        bu.subTree Asgn: # else branch
-          bu.add Node(kind: Local, val: tmp)
-          bu.add Node(kind: IntVal, val: c.literals.pack(0))
+      stmts.add newIf(inline(ea, stmts),
+                      wrap(eb, tmp),
+                      newAsgn(tmp, newIntVal(0)))
 
     else:
       # (Or a b) -> (If a True b)
-      stmts.addStmt If:
-        genUse(ea, bu, stmts)
-        bu.subTree Asgn: # then branch
-          bu.add Node(kind: Local, val: tmp)
-          bu.add Node(kind: IntVal, val: c.literals.pack(1))
-        bu.subTree Stmts: # else branch
-          bu.add eb.stmts
-          bu.subTree Asgn:
-            bu.add Node(kind: Local, val: tmp)
-            genUse(eb.expr, bu)
+      stmts.add newIf(inline(ea, stmts),
+                      newAsgn(tmp, newIntVal(1)),
+                      wrap(eb, tmp))
 
-    bu.add Node(kind: Local, val: tmp)
+    expr = tmp
     result = prim(tkBool) + {}
   of SourceKind.If:
     let
@@ -858,15 +745,8 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): ExprType =
           (c.fitExpr(body, typ), c.fitExpr(els, typ))
       tmp = c.newTemp(typ)
 
-    stmts.addStmt If:
-      genUse(cond, bu, stmts)
-      bu.subTree Stmts:
-        bu.add fb.stmts
-        c.genAsgn(Node(kind: Local, val: tmp), fb.expr, fb.typ, bu)
-      bu.subTree Stmts:
-        bu.add fe.stmts
-        c.genAsgn(Node(kind: Local, val: tmp), fe.expr, fe.typ, bu)
-    genLocal(tmp, typ, bu)
+    stmts.add newIf(inline(cond, stmts), wrap(fb, tmp), wrap(fe, tmp))
+    expr = tmp
     result = typ + {}
   of SourceKind.While:
     let (a, b) = t.pair(n)
@@ -883,34 +763,30 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): ExprType =
     if body.typ.kind notin {tkUnit, tkVoid}:
       c.error("`While` body must be a unit or void expression")
 
-    stmts.addStmt Loop:
-      bu.subTree Stmts:
-        bu.add cond.stmts
-        bu.subTree If:
-          bu.subTree Not:
-            genUse(cond.expr, bu)
-          bu.subTree Break:
-            bu.add Node(kind: Immediate, val: 1)
+    var sub = IrNode(kind: Stmts)
+    sub.add cond.stmts
+    sub.add newIf(newNot(cond.expr), newBreak(1))
+    sub.add body.stmts
+    if body.typ.kind != tkVoid:
+      sub.add newDrop(body.expr)
 
-        bu.add body.stmts
-        genDrop(body.expr, body.typ, bu)
+    stmts.add IrNode(kind: Loop, children: @[sub])
 
     if t[a].kind == SourceKind.Ident and t.getString(a) == "true":
       # it's a loop that doesn't exit via non-exception control-flow
-      stmts.addStmt Unreachable:
-        discard
+      stmts.add newUnreachable()
       result = prim(tkVoid) + {}
     else:
-      bu.add UnitNode
+      expr = UnitNode
       result = prim(tkUnit) + {}
   of SourceKind.Call:
-    result = callToIL(c, t, n, bu, stmts) + {}
+    result = callToIL(c, t, n, expr, stmts) + {}
   of SourceKind.TupleCons:
     if t.len(n) > 0:
       var elems = newSeq[SemType](t.len(n))
       # there are no tuple constructors in the target IL; all elements are
       # assigned individually
-      let tmp = Node(kind: Local, val: c.newTemp(errorType()))
+      let tmp = c.newTemp(errorType())
       for i, it in t.pairs(n):
         let e = c.exprToIL(t, it)
         elems[i] = e.typ
@@ -923,20 +799,16 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): ExprType =
 
         stmts.add e.stmts
         # add an assignment for the field:
-        stmts.addStmt:
-          let dest = buildTree Field:
-            bu.add tmp
-            bu.add Node(kind: Immediate, val: i.uint32)
-          c.genAsgn(dest, e.expr, e.typ, bu)
+        stmts.add newAsgn(newFieldExpr(tmp, i), e.expr)
 
       # now that we know the type, correct it:
-      c.locals[tmp.val] = SemType(kind: tkTuple, elems: elems)
+      c.locals[tmp.id] = SemType(kind: tkTuple, elems: elems)
 
-      bu.add tmp
-      result = c.locals[tmp.val] + {}
+      expr = tmp
+      result = c.locals[tmp.id] + {}
     else:
       # it's the unit value
-      bu.add UnitNode
+      expr = UnitNode
       result = prim(tkUnit) + {}
   of SourceKind.FieldAccess:
     let
@@ -947,9 +819,7 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): ExprType =
       let idx = t.getInt(b)
       if idx >= 0 and idx < tup.typ.elems.len:
         result = tup.typ.elems[idx] + tup.attribs
-        bu.subTree Field:
-          bu.inline(tup, stmts)
-          bu.add Node(kind: Immediate, val: idx.uint32)
+        expr = newFieldExpr(inline(tup, stmts), idx.int)
       else:
         c.error("tuple has no element with index " & $idx)
         result = errorType() + {Lvalue, Mutable}
@@ -960,54 +830,45 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): ExprType =
       result = errorType() + {}
   of SourceKind.Asgn:
     let (a, b) = t.pair(n)
-    stmts.addStmt Asgn:
-      # emit the destination expression in-place
-      let dst = c.exprToIL(t, a, bu, stmts)
-      if {Lvalue, Mutable} * dst.attribs < {Lvalue, Mutable}:
-        c.error("LHS expression must be a mutable l-value expression")
+    var dst = c.exprToIL(t, a)
+    if {Lvalue, Mutable} * dst.attribs < {Lvalue, Mutable}:
+      c.error("LHS expression must be a mutable l-value expression")
+      dst.expr = IrNode(kind: None)
 
-      let src = c.fitExpr(c.exprToIL(t, b), dst.typ)
-      stmts.add src.stmts
-      genUse(src.expr, bu)
+    let src = c.fitExpr(c.exprToIL(t, b), dst.typ)
+    stmts.add newAsgn(inline(dst, stmts), inline(src, stmts))
 
-    bu.add UnitNode
+    expr = UnitNode
     result = prim(tkUnit) + {}
   of SourceKind.Return:
     var e =
       case t.len(n)
-      of 0: Expr(expr: @[Node(kind: IntVal)], typ: prim(tkUnit))
+      of 0: unitExpr
       of 1: c.exprToIL(t, t.child(n, 0))
       else: unreachable() # syntax error
 
     if e.typ.kind == tkVoid:
       c.error("cannot return 'void' expression")
-      e.expr = @[Node(kind: IntVal)] # add a placholder
       e.typ = prim(tkError)
 
     # apply the necessary to-supertype conversions:
     e = c.fitExpr(e, c.retType)
 
     stmts.add e.stmts
-    stmts.addStmt Return:
-      case e.typ.kind
-      of tkError:
-        discard "do nothing"
-      of AggregateTypes:
-        # special handling for aggregate types: store through the out parameter
-        stmts.addStmt Store:
-          bu.add Node(kind: Type, val: c.typeToIL(e.typ))
-          bu.subTree Copy:
-            bu.add Node(kind: Local, val: c.returnParam)
-          genUse(e.expr, bu)
-
-        bu.add UnitNode # return the unitary value
-      else:
-        genUse(e.expr, bu)
+    case e.typ.kind
+    of tkError:
+      discard "do nothing"
+    of AggregateTypes:
+      # special handling for aggregate types: store through the out parameter
+      stmts.add newAsgn(newDeref(c.typeToIL(e.typ), newLocal(c.returnParam)),
+                        e.expr)
+      stmts.add newReturn(UnitNode)
+    else:
+      stmts.add newReturn(e.expr)
 
     result = prim(tkVoid) + {}
   of SourceKind.Unreachable:
-    stmts.addStmt Unreachable:
-      discard
+    stmts.add newUnreachable()
     result = prim(tkVoid) + {}
   of SourceKind.Exprs:
     let last = t.len(n) - 1
@@ -1024,7 +885,7 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): ExprType =
           result = e.typ + e.attribs
           case e.typ.kind
           of tkVoid: discard "okay, nothing to do"
-          else:      bu.add e.expr
+          else:      expr = e.expr
       else:
         case e.typ.kind
         of tkVoid:
@@ -1032,17 +893,15 @@ proc exprToIL(c; t: InTree, n: NodeIndex, bu, stmts): ExprType =
           seenVoidExpr = true # check, but drop further stmts & exprs
         of tkUnit:
           voidGuard:
-            stmts.addStmt:
-              genDrop(e.expr, e.typ, bu)
+            stmts.add newDrop(e.expr)
         else:
           c.error("non-trailing expressions must be unit or void, got: $1" %
                     [$e.typ.kind])
           voidGuard:
-            stmts.addStmt:
-              genDrop(e.expr, e.typ, bu) # error correction
+            stmts.add newDrop(e.expr) # error correction
   of SourceKind.Decl:
-    localDeclToIL(c, t, n, bu, stmts)
-    bu.add UnitNode
+    localDeclToIL(c, t, n, stmts)
+    expr = UnitNode
     result = prim(tkUnit) + {}
   of AllNodes - ExprNodes:
     unreachable($t[n].kind)
@@ -1108,12 +967,12 @@ proc exprToIL*(c; t): SemType =
     bu.subTree Stmts:
       # first emit all statements:
       for it in e.stmts.items:
-        bu.add it
+        convert(it, c.literals, bu)
 
       # then the expression:
       if e.typ.kind != tkVoid:
         bu.subTree Return:
-          genUse(e.expr, bu)
+          use(e.expr, c.literals, bu)
 
   c.procList.add ProcInfo(typ: procType(result))
 
@@ -1189,7 +1048,7 @@ proc declToIL*(c; t; n: NodeIndex) =
     # add the body:
     bu.subTree Stmts:
       for it in e.stmts.items:
-        bu.add it
+        convert(it, c.literals, bu)
 
     c.procs.add finish(bu)
   of SourceKind.TypeDecl:


### PR DESCRIPTION
## Summary

Construct IL expressions and statements using a nested tree-based IR,
replacing the usage of `Builder` and making tree construction easier to
read and write.

## Details

`source2il` has to perform various lowering intermixed with analysis at
the moment, which makes the `Builder` API cumbersome and noisy to use
for constructing the trees.

Using a tree-based IR - where each node stores all its transitive child
nodes - makes construction much easier, at the cost of more allocator
activity (since each node with subnodes allocates its own `seq`). The
IR also handles some additional details, like packing numeric values
and wrapping lvalue expression, further simplifying construction.

The tree-based IR only covers the statements and expressions, not
things like procedures and types. Various procedures are provided for
constructing common tree shapes (assignments, if statements, etc.).

In order to prevent bugs (due to shared ownership) and improve memory
locality, no `ref`s are used. Copying a node therefore means creating a
full copy of the subtree, which makes it important for performance that
`sink` is used when passing nodes to construction procedures.

---

## Notes For Reviewers
* meant to assist with #79
* once lowering has largely moved out of `source2il`, the IR should be removed again