### PR TITLE
assembler: add the `.import` directive

### DIFF
--- a/tests/vm/runner.nim
+++ b/tests/vm/runner.nim
@@ -17,7 +17,7 @@ import
   ]
 
 proc test(env: var VmEnv, args: openArray[Value], _: RootRef): CallbackResult =
-  ## A VM callback.
+  ## A VM callback, created for the purpose of testing.
   CallbackResult(code: cecValue, value: args[0])
 
 # 1MB max memory for the VM should be plenty enough for the tests

--- a/tests/vm/runner.nim
+++ b/tests/vm/runner.nim
@@ -16,6 +16,10 @@ import
     vmvalidation
   ]
 
+proc test(env: var VmEnv, args: openArray[Value], _: RootRef): CallbackResult =
+  ## A VM callback.
+  CallbackResult(code: cecValue, value: args[0])
+
 # 1MB max memory for the VM should be plenty enough for the tests
 var
   env   = initVm(1024, 1024 * 1024)
@@ -51,7 +55,7 @@ if errors.len > 0:
     stderr.writeLine(it)
   quit(1)
 
-link(env, default(Table[string, VmCallback]), [module])
+link(env, toTable({"test": test}), [module])
 
 var
   res: YieldReason

--- a/tests/vm/t03_import.test
+++ b/tests/vm/t03_import.test
@@ -1,0 +1,11 @@
+discard """
+  output: "(Done 1)"
+"""
+.type P1 (int) -> int
+.type P2 () -> int
+.import P1 imported "test"
+.start P2 main
+  LdImmInt 1
+  Call imported 1
+  Ret
+.end

--- a/vm/assembler.nim
+++ b/vm/assembler.nim
@@ -348,6 +348,8 @@ proc process*(a: var AssemblerState, line: sink string) =
       let name = s.ident()
       s.space()
       prc.code.a = a.module.host.len.uint32
+      expect name notin a.procs:
+        "a procedure with the given name already exists"
       a.procs[name] = a.module.procs.len.ProcIndex
       a.module.procs.add prc
       a.module.host.add s.parseInterface()

--- a/vm/assembler.nim
+++ b/vm/assembler.nim
@@ -181,9 +181,9 @@ proc parseType(s: Stream, env: var TypeEnv, a: AssemblerState): TypeId =
   s.space()
   result = env.add(s.parseTypeName(), params)
 
-proc parseQuoted(s: Stream): string =
-  ## Parses a quoted name.
-  # quoated names don't need to support the whole ASCII range
+proc parseInterface(s: Stream): string =
+  ## Parses an interface name.
+  # interface names don't need to support the whole ASCII range
   const Allowed = {'A'..'Z', 'a'..'z', '0'..'9', '_', '.', '#', '(', ')'}
   expect s.readChar() == '"', "expected '\"'"
   var c: char
@@ -350,7 +350,7 @@ proc process*(a: var AssemblerState, line: sink string) =
       prc.code.a = a.module.host.len.uint32
       a.procs[name] = a.module.procs.len.ProcIndex
       a.module.procs.add prc
-      a.module.host.add parseQuoted(s)
+      a.module.host.add s.parseInterface()
     of dirLocal:
       # .local <name> <type>
       expect a.stack.len > 0, "only allowed in procedure"


### PR DESCRIPTION
## Summary

Add the `.import` directive to the assembler, which makes it possible
to express imported/foreign procedures in assembler code.

## Details

The import name uses double-quotes, even though the currently
supported character set doesn't require quotation. This is only
for reasons of style and readability, to highlight that the name
isn't a normal identifier.

---

## Notes For Reviewers

A blocker for #70. The upcoming test for skully needs to disassemble and reassemble a VM module, and imported/foreign procedures don't roundtrip at the moment.