### PR TITLE
source2il: implement a simple allocator

### DIFF
--- a/common/vmexec.nim
+++ b/common/vmexec.nim
@@ -2,6 +2,9 @@
 ## runners.
 
 import
+  std/[
+    options
+  ],
   phy/[
     type_rendering,
     types
@@ -9,11 +12,19 @@ import
   vm/[
     vmalloc,
     vmenv,
+    vmmodules,
     vm,
     utils
   ]
 
 import vm/vmtypes except tkVoid, tkInt, tkFloat, tkProc
+
+type
+  MemoryConfig* = object
+    ## The guest memory configuration.
+    total*: uint
+    stackStart*: uint
+    stackSize*: uint
 
 proc readInt(p: HostPointer, size: range[1..8]): int64 =
   copyMem(addr result, p, size)
@@ -83,17 +94,47 @@ proc valueToString(env: var VmEnv, a: VirtualAddr, typ: SemType): string =
   of tkVoid, tkError:
     unreachable()
 
-proc run*(env: var VmEnv, prc: ProcIndex, typ: SemType): string =
+proc readMemConfig*(m: VmModule): Option[MemoryConfig] =
+  ## Reads the guest memory configuration from `m` by looking for the
+  ## `stack_start`, `stack_size`, and `total_memory` global variables.
+  ## A default is used for the values where the respective global is
+  ## not present. If the configuration is invalid, ``none`` is returned.
+  var
+    stackStart = 0'u64
+    stackSize  = 1024'u64
+    total      = stackSize
+
+  for it in m.exports.items:
+    if it.kind == expGlobal and m.globals[it.id].typ == vtInt:
+      case m.names[it.name]
+      of "stack_start":
+        stackStart = m.globals[it.id].val.uintVal
+      of "stack_size":
+        stackSize = m.globals[it.id].val.uintVal
+      of "total_memory":
+        total = m.globals[it.id].val.uintVal
+
+  if stackStart >= total or stackStart + stackSize > total or
+      stackStart + stackSize < stackStart or
+      total > high(uint):
+    none MemoryConfig
+  else:
+    some MemoryConfig(total: uint(total),
+                      stackStart: uint(stackStart),
+                      stackSize: uint(stackSize))
+
+proc run*(env: var VmEnv, stack: HOslice[uint], prc: ProcIndex,
+          typ: SemType): string =
   ## Runs the nullary procedure with index `prc`, and returns the result
   ## rendered as a string. `typ` is the type of the resulting value.
   var thread: VmThread
   if typ.kind in AggregateTypes:
-    # reserve enough stack space:
-    let start = uint size(typ)
+    # reserve enough stack space for the result:
+    let modified = hoSlice(stack.a + uint(size(typ)), stack.b)
     # pass the address of the destination as the first parameter
-    thread = vm.initThread(env, prc, hoSlice(start, 1024), @[Value(toVirt 0)])
+    thread = vm.initThread(env, prc, modified, @[Value(toVirt stack.a)])
   else:
-    thread = vm.initThread(env, prc, 1024, @[])
+    thread = vm.initThread(env, prc, stack, @[])
 
   let res = run(env, thread, nil)
   env.dispose(thread)
@@ -117,10 +158,10 @@ proc run*(env: var VmEnv, prc: ProcIndex, typ: SemType): string =
   of yrkStubCalled, yrkUser:
     unreachable() # shouldn't happen
 
-proc run*(env: var VmEnv, prc: ProcIndex): string =
+proc run*(env: var VmEnv, stack: HOslice[uint], prc: ProcIndex): string =
   ## Runs the nullary procedure with index `prc` and returns the VM's result
   ## formatted as an S-expression.
-  var thread = vm.initThread(env, prc, 1024, @[])
+  var thread = vm.initThread(env, prc, stack, @[])
 
   let res = run(env, thread, nil)
   env.dispose(thread)

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -938,6 +938,15 @@ proc open*(reporter: sink(ref ReportContext[string])): ModuleCtx =
     c.globals.add Node(kind: UInt, val: 8)
     c.globals.add Node(kind: IntVal, val: HeapStart - 8)
 
+  c.exports.subTree Export:
+    c.exports.add Node(kind: StringVal, val: c.literals.pack("stack_size"))
+    c.exports.add Node(kind: Global, val: 0)
+  # the end-of-heap pointer is taken to also represent the amount of total
+  # guest memory (which is not entirely correct, due to the address bias)
+  c.exports.subTree Export:
+    c.exports.add Node(kind: StringVal, val: c.literals.pack("total_memory"))
+    c.exports.add Node(kind: Global, val: 2)
+
   # add the built-in allocator and seq procedures
   # XXX: these need to be provided by a system-like module in the future
 

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -59,6 +59,8 @@ type
     procList*: seq[ProcInfo]
     globals: Builder[NodeKind]
       ## the in-progress global variable section
+    exports: Builder[NodeKind]
+      ## the in-progress export section
 
     procTypeCache: Table[SemType, uint32]
       ## caches the ID of IL signature types generated for procedure types.
@@ -898,6 +900,7 @@ proc open*(reporter: sink(ref ReportContext[string])): ModuleCtx =
                      types: initBuilder[NodeKind](TypeDefs),
                      procs: initBuilder[NodeKind](ProcDefs),
                      globals: initBuilder[NodeKind](GlobalDefs),
+                     exports: initBuilder[NodeKind](List),
                      # start with the top-level scope
                      scopes: @[default(Scope)])
 
@@ -1012,6 +1015,9 @@ proc close*(c: sink ModuleCtx): PackedTree[NodeKind] =
     bu.add finish(move c.types)
     bu.add finish(move c.globals)
     bu.add finish(move c.procs)
+    let exports = finish(move c.exports)
+    if exports.len > 1: # don't add an empty export list
+      bu.add exports
 
   initTree[NodeKind](finish(bu), c.literals)
 

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -9,10 +9,11 @@
 import
   std/[algorithm, sequtils, tables],
   passes/[builders, ir, spec, trees],
-  phy/[reporting, type_rendering, types],
+  phy/[reporting, tree_parser, type_rendering, types],
   vm/[utils]
 
 from std/strutils import `%`
+from vm/vmalloc import AddressBias
 
 import passes/spec_source except NodeKind
 
@@ -56,6 +57,8 @@ type
     procs: Builder[NodeKind]
       ## the in-progress procedure section
     procList*: seq[ProcInfo]
+    globals: Builder[NodeKind]
+      ## the in-progress global variable section
 
     procTypeCache: Table[SemType, uint32]
       ## caches the ID of IL signature types generated for procedure types.
@@ -110,7 +113,7 @@ const
   unitExpr = Expr(expr: UnitNode, typ: prim(tkUnit))
     ## the expression evaluating to the unitary value
 
-  pointerType {.used.} = prim(tkInt)
+  pointerType = prim(tkInt)
     ## the type inhabited by pointer values. The constant is used as a
     ## placeholder until a dedicated pointer type is introduced
 
@@ -340,6 +343,13 @@ proc genProcType(c; typ: SemType): uint32 =
   do:
     result = rawGenProcType(c, typ)
     c.procTypeCache[typ] = result
+
+proc addProc(c; typ: sink SemType, def: seq[Node]): int =
+  ## Adds a procedure with signature `typ` and definition `def` to the
+  ## context, returning the ID to address it with.
+  c.procs.add def
+  c.procList.add ProcInfo(typ: typ)
+  result = c.procList.high
 
 proc resetProcContext(c) =
   c.locals.setLen(0) # re-use the memory
@@ -872,18 +882,123 @@ proc exprToIL(c; t: InTree, n: NodeIndex, expr, stmts): ExprType =
 
 proc open*(reporter: sink(ref ReportContext[string])): ModuleCtx =
   ## Creates a new empty module translation/analysis context.
-  ModuleCtx(reporter: reporter,
-            types: initBuilder[NodeKind](TypeDefs),
-            procs: initBuilder[NodeKind](ProcDefs),
-            scopes: @[default(Scope)]) # start with the top-level scope
+  result = ModuleCtx(reporter: reporter,
+                     types: initBuilder[NodeKind](TypeDefs),
+                     procs: initBuilder[NodeKind](ProcDefs),
+                     globals: initBuilder[NodeKind](GlobalDefs),
+                     # start with the top-level scope
+                     scopes: @[default(Scope)])
+
+  template c: untyped = result
+
+  # XXX: the maximum amount of heap memory is currently static and allocated
+  #      up-front
+  const
+    StackSize = 1024 * 4        # 4 KiB
+    HeapSize  = 1024 * 1024 * 4 # 4 MiB
+    HeapStart = AddressBias + StackSize + 8
+
+  # note: the virtual address range below ``AddressBias`` is reserved.
+  # Memory layout:
+  # +----------+-------+------+------+
+  # | reserved | stack | mgmt | heap |
+  # +----------+-------+------+------+
+  # The 'mgmt' section stores the data necessary for managing the heap.
+
+  # globals and their meaning:
+  # * 0: size of the stack size
+  # * 1: address of the start of the heap
+  # * 2: address of the end of the heap
+  # * 3: address of the heap management data
+  c.globals.subTree GlobalDef:
+    c.globals.add Node(kind: UInt, val: 8)
+    c.globals.add Node(kind: IntVal, val: StackSize)
+  c.globals.subTree GlobalDef:
+    c.globals.add Node(kind: UInt, val: 8)
+    c.globals.add Node(kind: IntVal, val: HeapStart)
+  c.globals.subTree GlobalDef:
+    c.globals.add Node(kind: UInt, val: 8)
+    c.globals.add Node(kind: IntVal, val: HeapStart + HeapSize)
+  c.globals.subTree GlobalDef:
+    c.globals.add Node(kind: UInt, val: 8)
+    c.globals.add Node(kind: IntVal, val: HeapStart - 8)
+
+  # add the built-in allocator and seq procedures
+  # XXX: these need to be provided by a system-like module in the future
+
+  template addProc(typ: SemType, body: string, args: untyped) =
+    discard addProc(result, typ, parseSexp[NodeKind](body % args, c.literals))
+
+  # the allocator uses a simple bump-pointer allocation scheme where memory
+  # is never freed for re-use. When the heap memory is exhausted, an
+  # exception/panic is raised
+  const AllocBody = """
+    (ProcDef (Type $1)
+      (Params (Local 0))
+      (Locals (Type $2) (Type $2))
+      (Stmts
+        (If (Eq (Type $2) (Load (Type $2) (Copy (Global 3))) (IntVal 0))
+          (Asgn (Local 1) (Copy (Global 1)))
+          (Asgn (Local 1) (Load (Type $2) (Copy (Global 3)))))
+        (If
+          (Le (Type $2)
+            (Add (Type $2)
+              (Copy (Local 0))
+              (Copy (Local 1)))
+            (Copy (Global 2)))
+          (Stmts
+            (Store (Type $2)
+              (Copy (Global 3))
+              (Add (Type $2)
+                (Copy (Local 1))
+                (Copy (Local 0))))
+            (Return (Copy (Local 1))))
+          (Raise (IntVal 0)))))
+  """
+  var procTy = SemType(kind: tkProc, elems: @[pointerType, prim(tkInt)])
+  addProc procTy, AllocBody,
+          [$c.genProcType(procTy), $c.typeToIL(prim(tkInt))]
+
+  const DeallocBody = """
+    (ProcDef (Type $1)
+      (Params (Local 0))
+      (Locals (Type $2))
+      (Return (IntVal 0)))
+  """
+  procTy = SemType(kind: tkProc, elems: @[prim(tkUnit), pointerType])
+  addProc procTy, DeallocBody,
+          [$c.genProcType(procTy), $c.typeToIL(prim(tkInt))]
+
+  # realloc(ptr: pointer, oldsize: int, newsize: int) -> pointer
+  const ReallocBody = """
+    (ProcDef (Type $1)
+      (Params (Local 0) (Local 1) (Local 2))
+      (Locals (Type $2) (Type $2) (Type $2) (Type $2))
+      (If
+        (Eq (Type $2)
+          (Copy (Local 0))
+          (IntVal 0))
+        (Return (Call (Proc 0) (Copy (Local 2))))
+        (Stmts
+          (Asgn (Local 3) (Call (Proc 0) (Copy (Local 2))))
+          (Blit (Copy (Local 3)) (Copy (Local 0)) (Copy (Local 1)))
+          (Drop (Call (Proc 1) (Copy (Local 0))))
+          (Return (Copy (Local 3))))
+        )
+      )
+  """
+  procTy = SemType(kind: tkProc,
+                   elems: @[pointerType, pointerType, prim(tkInt),
+                            prim(tkInt)])
+  addProc procTy, ReallocBody,
+          [$c.genProcType(procTy), $c.typeToIL(prim(tkInt))]
 
 proc close*(c: sink ModuleCtx): PackedTree[NodeKind] =
   ## Closes the module context and returns the accumulated translated code.
   var bu = initBuilder[NodeKind]()
   bu.subTree Module:
     bu.add finish(move c.types)
-    bu.subTree GlobalDefs:
-      discard
+    bu.add finish(move c.globals)
     bu.add finish(move c.procs)
 
   initTree[NodeKind](finish(bu), c.literals)

--- a/phy/phy.nim
+++ b/phy/phy.nim
@@ -371,7 +371,19 @@ proc main(args: openArray[string]) =
       else:
         error "invalid memory configuration"
 
-      if module.procs.len == 0:
+      # look for the procedure to start evaluation with:
+      var entry = none ProcIndex
+      if source == langSource:
+        # use the last exported procedure, if any
+        for i in countdown(module.exports.high, 0):
+          if module.exports[i].kind == expProc:
+            entry = some module.exports[i].id.ProcIndex
+            break
+      elif module.procs.len > 0:
+        # simply use the last procedure
+        entry = some module.procs.high.ProcIndex
+
+      if entry.isNone:
         if gRunner:
           discard "okay, silently ignore"
           return
@@ -385,9 +397,9 @@ proc main(args: openArray[string]) =
 
       if source == langSource:
         # we have type high-level type information
-        stdout.write run(env, stack, env.procs.high.ProcIndex, typ)
+        stdout.write run(env, stack, entry.unsafeGet, typ)
       else:
         # we don't have high-level type information
-        stdout.write run(env, stack, env.procs.high.ProcIndex)
+        stdout.write run(env, stack, entry.unsafeGet)
 
 main(getExecArgs())

--- a/tools/repl.nim
+++ b/tools/repl.nim
@@ -160,8 +160,7 @@ proc process(ctx: var ModuleCtx, reporter: Reporter,
     if (let v = readMemConfig(module); v.isSome):
       mem = v.unsafeGet
     else:
-      # if reached, there's a bug in either source2il or the lowering passes
-      unreachable()
+      unreachable("memory config invalid; there's probably a bug in source2il")
 
     var env = initVm(mem.total, mem.total)
     link(env, hostProcedures(includeTest = false), [module])

--- a/tools/repl.nim
+++ b/tools/repl.nim
@@ -2,6 +2,7 @@
 
 import
   std/[
+    options,
     streams,
     strutils
   ],
@@ -38,6 +39,7 @@ import
     vmexec
   ],
   vm/[
+    utils,
     vmenv,
     vmmodules,
     vmvalidation
@@ -154,11 +156,19 @@ proc process(ctx: var ModuleCtx, reporter: Reporter,
       echo "validation failure"
       return
 
-    var env = initVm(1024, 1024 * 1024)
+    var mem: MemoryConfig
+    if (let v = readMemConfig(module); v.isSome):
+      mem = v.unsafeGet
+    else:
+      # if reached, there's a bug in either source2il or the lowering passes
+      unreachable()
+
+    var env = initVm(mem.total, mem.total)
     link(env, hostProcedures(includeTest = false), [module])
 
     # eval and print:
-    echo run(env, ProcIndex(env.procs.high), typ)
+    echo run(env, hoSlice(mem.stackStart, mem.stackStart + mem.stackSize),
+             ProcIndex(env.procs.high), typ)
   else:
     echo "Error: unexpected node: ", tree[NodeIndex(0)].kind
 


### PR DESCRIPTION
## Summary

Implement an allocator for internal use by the `source2il`, for
implementing language features that require heap locations (e.g.,
dynamic arrays).

## Details

The allocator is a simple bump-pointer allocator backed by a static
memory region. It consists of three procedures: `alloc`, `dealloc`, and
`realloc`. Since the source language doesn't support the features
necessary for implementing the allocator, the aforementioned procedures
are implemented in `L30` code provided via inline strings.

`dealloc` is currently a no-op, meaning that memory is never freed.
Upon exhausting the available heap memory, an exception is raised,
which currently results in undefined behaviour (as `CheckedCall` isn't
used for call expressions).

To reduce implementation complexity, the allocator procedures are
always added to the IL module, even if not used. Since this interferes
with the previous entry procedure selection (the last procedure in the
IL module was picked), all user-defined procedures are now marked as
exported, and for programs originating from source-language code, the
last *exported* procedure is now picked to be the entry procedure.

Finally, to be able to configure the guest memory from the outside via
modules, instead of it being hardcoded, the `phy` program now retrieves
the stack size, stack start, and total amount of memory from globals
with the interface names `stack_size`, `stack_start`, and
`total_memory`, respectively. This also means that the VM module is no
longer linked when not evaluating the program.


---

## To-Do
* [x] implement exports; needed for designating a main procedure (separate PR)
* [x] update the stack setup to use the size and position provided by the globals
* [x] write a proper commit message

## Notes For Reviewers
* split out from and a prerequisite of #79
* the memory configuration through exported globals is also needed for #70
* the allocator is not exposed to the source language, so it cannot be tested as part of this PR