### PR TITLE
source2il: fix calls used as `FieldAccess` operand

### DIFF
--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -373,6 +373,18 @@ proc capture(c; e: sink Expr; stmts): IrNode =
   stmts.add e.stmts
   stmts.add newAsgn(result, e.expr)
 
+proc inlineLvalue(c; e: sink Expr; stmts): IrNode =
+  ## Returns `e` as an l-value IL expression, committing `e` to a temporary
+  ## first if needed.
+  case e.expr.kind
+  of Local, At, Field, Deref:
+    stmts.add e.stmts
+    result = e.expr
+  else:
+    # IL r-value expressions cannot be used where an l-value expression is
+    # expected; going through a temporary solves this
+    result = c.capture(e, stmts)
+
 proc fitExpr(c; e: sink Expr, target: SemType): Expr =
   ## Makes sure `e` fits into the `target` type, returning the expression
   ## with the appropriate conversion operation applied. If the type of `e`
@@ -788,7 +800,7 @@ proc exprToIL(c; t: InTree, n: NodeIndex, expr, stmts): ExprType =
       let idx = t.getInt(b)
       if idx >= 0 and idx < tup.typ.elems.len:
         result = tup.typ.elems[idx] + tup.attribs
-        expr = newFieldExpr(inline(tup, stmts), idx.int)
+        expr = newFieldExpr(inlineLvalue(c, tup, stmts), idx.int)
       else:
         c.error("tuple has no element with index " & $idx)
         result = errorType() + {Lvalue, Mutable}

--- a/tests/expr/t06_call_result_field_access.test
+++ b/tests/expr/t06_call_result_field_access.test
@@ -1,0 +1,12 @@
+discard """
+  description: "
+    A call expression can be used directly as a field access operand
+  "
+  output: "1: int"
+"""
+(Module
+  (ProcDecl p (TupleTy (IntTy)) (Params)
+    (Return (TupleCons 1)))
+  (ProcDecl main (IntTy) (Params)
+    (Return
+      (FieldAccess (Call p) 0))))


### PR DESCRIPTION
## Summary

Fix `source2il` crashing for call expressions used as the `FieldAccess`
operand.

## Details

Add the `inlineLvalue` procedure, which commits `L30` r-value
expressions to a temporary and then return the temporary. Since the
`FieldAccess` translation wants an `L30` l-value, it now uses the
new `inlineLvalue`.

With the removal of the aggregate return value lowering from
`source2il`, call expressions that return a tuple no longer use a
temporary. This resulted in `(Field (Call ...) ...)` `L30` trees,
which are not allowed by the `L30` grammar.

---

## Notes For Reviewers
* a regression introduced by #90