### PR TITLE
vmmodules: support exported procs/globals

### DIFF
--- a/passes/pass0.nim
+++ b/passes/pass0.nim
@@ -660,8 +660,8 @@ proc translate*(module: PackedTree[NodeKind]): VmModule =
       result.ehTable.add prc.ehTable
     else:
       # must be a host procedure
-      result.host.add module.getString(module.child(def, 1))
+      result.names.add module.getString(module.child(def, 1))
 
       result.procs.add ProcHeader(kind: pkCallback,
                                   typ: module[def, 0].typ)
-      result.procs[i].code.a = result.host.high.uint32
+      result.procs[i].code.a = result.names.high.uint32

--- a/tests/vm/runner.nim
+++ b/tests/vm/runner.nim
@@ -53,6 +53,11 @@ if errors.len > 0:
 
 link(env, default(Table[string, VmCallback]), [module])
 
+if env.procs.len == 0:
+  # there's nothing to execute, but don't treat this as an error
+  stdout.write("<no procedures>")
+  quit(0)
+
 var
   res: YieldReason
   # use 1KB for the in-memory stack

--- a/tests/vm/t06_export_global.test
+++ b/tests/vm/t06_export_global.test
@@ -1,0 +1,5 @@
+discard """
+  output: "<no procedures>"
+"""
+.global g int 1
+.export global g "test.global"

--- a/tests/vm/t06_export_procedure.test
+++ b/tests/vm/t06_export_procedure.test
@@ -1,0 +1,8 @@
+discard """
+  output: "(Done)"
+"""
+.type P1 () -> void
+.start P1 p
+  Ret
+.end
+.export proc p "main"

--- a/tests/vm/t07_export_import_procedure.test
+++ b/tests/vm/t07_export_import_procedure.test
@@ -1,0 +1,20 @@
+discard """
+  description: "
+    Ensure that procedure imports for which an exported procedure exist are
+    resolved properly
+  "
+  output: "(Done 1)"
+"""
+.type P1 () -> int
+.start P1 p
+  LdImmInt 1
+  Ret
+.end
+
+.export proc p "p.exported"
+.import P1 imported "p.exported"
+
+.start P1 main
+  Call imported 0
+  Ret
+.end

--- a/vm/assembler.nim
+++ b/vm/assembler.nim
@@ -11,7 +11,6 @@
 
 import
   std/[
-    packedsets,
     parseutils,
     strutils,
     streams,
@@ -53,7 +52,6 @@ type
     consts: Table[string, int32]
     globals: Table[string, int32]
     types: Table[string, TypeId]
-    exports: array[ExportKind, PackedSet[uint32]]
 
   Directive = enum
     dirStart  = "start"  ## start a new procedure
@@ -350,7 +348,6 @@ proc process*(a: var AssemblerState, line: sink string) =
         case kind
         of expProc:   a.procs[s.ident()].uint32
         of expGlobal: a.globals[s.ident()].uint32
-      expect id notin a.exports[kind], "entity was already exported"
       s.space()
       a.module.exports.add:
         Export(kind: kind, id: id, name: a.module.names.len.uint32)

--- a/vm/assembler.nim
+++ b/vm/assembler.nim
@@ -350,9 +350,11 @@ proc process*(a: var AssemblerState, line: sink string) =
         of expProc:   a.procs[s.ident()].uint32
         of expGlobal: a.globals[s.ident()].uint32
       s.space()
+      let iface = s.parseInterface()
+      # parse the interface name *before* modifying the module
       a.module.exports.add:
         Export(kind: kind, id: id, name: a.module.names.len.uint32)
-      a.module.names.add s.parseInterface()
+      a.module.names.add iface
     of dirImport:
       # .import <type> <name> <interface>
       var prc = ProcHeader(kind: pkCallback)
@@ -365,8 +367,10 @@ proc process*(a: var AssemblerState, line: sink string) =
       expect name notin a.procs:
         "a procedure with the given name already exists"
       a.procs[name] = a.module.procs.len.ProcIndex
+      let iface = s.parseInterface()
+      # parse the interface name *before* modifying the module
       a.module.procs.add prc
-      a.module.names.add s.parseInterface()
+      a.module.names.add iface
     of dirLocal:
       # .local <name> <type>
       s.space()

--- a/vm/vmmodules.nim
+++ b/vm/vmmodules.nim
@@ -25,9 +25,8 @@ type
     types*: TypeEnv
     # ---- end of core fields
 
-    host*: seq[string]
-      ## names of host procedures. Callback procedure entries reference
-      ## elements in this lsit
+    names*: seq[string]
+      ## interface names stored out-of-place
 
   HostMap = Table[string, int]
     ## maps foreign procedure names to the index of the callback implementing

--- a/vm/vmmodules.nim
+++ b/vm/vmmodules.nim
@@ -179,7 +179,7 @@ proc link*(env: var VmEnv, host: Table[string, VmCallback],
 
       inc i
 
-  reset lookup # free the memory already, it's not needed anymore
+  reset lookup # free the memory eagerly, it's not needed anymore
 
   for m in modules.items:
     append(env, tab, m)

--- a/vm/vmmodules.nim
+++ b/vm/vmmodules.nim
@@ -19,11 +19,10 @@ type
     id*: uint32
     name*: uint32
       ## the external name under which the entity is exported. An index into
-      ## the module's name list
+      ## the module's `names` list
 
   VmModule* = object
-    ## A module is code plus information about imports, exports, and host
-    ## procedures.
+    ## A module is code plus information about imports and exports.
 
     # ---- core fields
     # these fields mirror the ones from ``VmEnv``
@@ -45,7 +44,7 @@ type
     lkKeep       ## keep the procedure entry
     lkRedirect   ## redirect to another entry
     lkImportHost ## turn into a host procedure entry
-    lkStub       ## turn into a stub
+    lkStub       ## turn into a stub entry
 
   LinkTable = seq[tuple[action: LinkAction, val: uint32]]
 
@@ -162,7 +161,7 @@ proc link*(env: var VmEnv, host: Table[string, VmCallback],
       if p.kind == pkCallback:
         let name {.cursor.} = m.names[p.code.a]
         if name in exported:
-          # the import imports an regular procedure
+          # the import imports a regular procedure
           tab[i] = (lkRedirect, exported[name])
         elif name in host:
           # the import imports a host procedure
@@ -180,7 +179,7 @@ proc link*(env: var VmEnv, host: Table[string, VmCallback],
 
       inc i
 
-  reset lookup # free the memory already
+  reset lookup # free the memory already, it's not needed anymore
 
   for m in modules.items:
     append(env, tab, m)

--- a/vm/vmmodules.nim
+++ b/vm/vmmodules.nim
@@ -94,6 +94,15 @@ proc append(env: var VmEnv, tab: LinkTable, m: VmModule) =
       if it.opcode == opcIndCall:
         it = patchInstr(it, int32(it.imm32 + typeOffset))
 
+  # patch all references to procedures
+  for it in env.code.toOpenArray(codeOffset, env.code.high).mitems:
+    # FIXME: this is ignoring procedure *values*, which are currently
+    #        indistinguishable from normal integers. A new
+    if it.opcode == opcCall:
+      let (action, pos) = tab[it.imm32 + procOffset]
+      if action == lkRedirect:
+        it = patchInstr(it, int32(pos))
+
   appendAndModify env.ehTable, m.ehTable:
     it.src += codeOffset.uint32
     it.dst += codeOffset.uint32

--- a/vm/vmmodules.nim
+++ b/vm/vmmodules.nim
@@ -97,7 +97,8 @@ proc append(env: var VmEnv, tab: LinkTable, m: VmModule) =
   # patch all references to procedures
   for it in env.code.toOpenArray(codeOffset, env.code.high).mitems:
     # FIXME: this is ignoring procedure *values*, which are currently
-    #        indistinguishable from normal integers. A new
+    #        indistinguishable from normal integers. A new opcode for
+    #        loading a procedure handle is needed
     if it.opcode == opcCall:
       let (action, pos) = tab[it.imm32 + procOffset]
       if action == lkRedirect:

--- a/vm/vmvalidation.nim
+++ b/vm/vmvalidation.nim
@@ -356,3 +356,16 @@ proc validate*(m: VmModule): seq[string] =
     if it.kind == pkDefault:
       handle verify(m, ProcIndex(i),
                     m.code.toOpenArray(it.code.a.int, it.code.b.int))
+
+  # check the export table:
+  for i, it in m.exports.pairs:
+    if not test(m.names, it.name):
+      result.add fmt"invalid export {i}: interface name doesn't exist"
+
+    case it.kind
+    of expGlobal:
+      if not test(m.globals, it.id):
+        result.add fmt"invalid export {i}: global {it.id} doesn't exist"
+    of expProc:
+      if not test(m.procs, it.id):
+        result.add fmt"invalid export {i}: procedure {it.id} doesn't exist"

--- a/vm/vmvalidation.nim
+++ b/vm/vmvalidation.nim
@@ -284,7 +284,7 @@ proc verify*(hdr: ProcHeader, env: VmModule): CheckResult =
             Error
     # the EH table is checked later
   of pkCallback:
-    check test(env.host, hdr.code.a), Error
+    check test(env.names, hdr.code.a), Error
   of pkStub:
     discard
 

--- a/vm/vmvalidation.nim
+++ b/vm/vmvalidation.nim
@@ -286,7 +286,7 @@ proc verify*(hdr: ProcHeader, env: VmModule): CheckResult =
   of pkCallback:
     check test(env.names, hdr.code.a), Error
   of pkStub:
-    discard
+    result = CheckResult.err("stub procedures are not allowed in modules")
 
   check test(env.types.types, hdr.typ.uint32), "signature type is missing"
   result.initSuccess()


### PR DESCRIPTION
## Summary

* add support for exported procedures and globals to VM modules
* implement procedure import resolution for `vmmodules.link`

## Details

Procedures and global variables can now be marked as exported, by
adding them to the `export` table; the assembler provides this
functionality through the new `.export` directive. The same global
variable or procedure can be exported multiple times.

Exported procedures are used to resolve procedure imports, which
the `pkCallback` entries are repurposed to represent prior to
linking. The host procedure table is now only tried when a
procedure import doesn't resolve to an exported procedure; if
that fails too, the procedure is turned into a stub.

Global variables cannot be imported at the moment, but being able
to export them is still useful for looking them up from the
outside via an interface name.

Finally, since procedure stubs serve no purpose prior to linking, the
validator now reports an errors on  encountering them.

### Misc

The assembler was left in an invalid state when parsing the interface
name for the `.import` directive failed. This fixed by only modifying
the assembler after parsing the interface name.
 
---

## Note For Reviewers

This PR further develops the VM module support, which provides the foundation for the later IL / source-language module support. In the short-term, exports are required for making globals and procedures available to `phy`'s VM runner, which is needed by both #70 and #92. 