### PR TITLE
disasm: disassemble `VmModule` instead of `VmEnv`

### DIFF
--- a/phy/phy.nim
+++ b/phy/phy.nim
@@ -154,9 +154,9 @@ proc print(tree: PackedTree[spec.NodeKind], lang: Language) =
     stdout.writeLine(pretty(tree, tree.child(1)))
     stdout.writeLine(pretty(tree, tree.child(2)))
 
-proc print(env: VmEnv) =
+proc print(m: VmModule) =
   genericPrint(langBytecode):
-    stdout.write(disassemble(env))
+    stdout.write(disassemble(m))
 
 proc sourceToIL(text: string): (PackedTree[spec.NodeKind], SemType) =
   ## Given an S-expression representation of the source language (`text`),
@@ -360,9 +360,10 @@ proc main(args: openArray[string]) =
         echo "Error: ", it
       quit(1)
 
+    print(module)
+
     var env = initVm(1024, 1024 * 1024) # 1 MiB max memory
     link(env, hostProcedures(gRunner), [module])
-    print(env)
 
     # handle the eval command:
     if cmd == Eval:

--- a/tests/pass0/t05_foreign_procedure.expected
+++ b/tests/pass0/t05_foreign_procedure.expected
@@ -1,6 +1,6 @@
 .type t0 (int) -> int
 .type t1 () -> int
-.host t0 p0
+.import t0 p0 "core.test"
 .start t1 p1
   LdImmInt 100
   Call p0 1


### PR DESCRIPTION
## Summmary

Change `disassemble` to take a VM module as input instead of a VM
instance (`VmEnv`), restoring the symmetry between the disassembler and
assembler (the latter which produces a `VmModule`).

## Details

* change the parameters in `disasm` from `VmEnv` to `VmModule`
* add rendering for module exports to `disassemble` 
* update the `pass0/t05_foreign_procedure.test` expected output, which
  now shows the imported procedure

---

## Notes For Reviewers
* this completes the move to making `VmEnv` the internal-only execution environment representation