### PR TITLE
vm: remove undefined behaviour

### DIFF
--- a/tests/vm/t03_neg_int_overflow.test
+++ b/tests/vm/t03_neg_int_overflow.test
@@ -1,0 +1,13 @@
+discard """
+  description: "
+    NegInt behaves like MulInt with a factor -1 in the overflow case
+  "
+  output: "(Done (9223372036854775808 or -9223372036854775808))"
+"""
+.type P1 () -> int
+.const low int 0x8000_0000_0000_0000
+.start P1 main
+  LdConst low
+  NegInt
+  Ret
+.end

--- a/tests/vm/t05_div_int_div_by_zero.test
+++ b/tests/vm/t05_div_int_div_by_zero.test
@@ -1,0 +1,10 @@
+discard """
+  output: "(Error ecDivByZero)"
+"""
+.type P1 () -> int
+.start P1 main
+  LdImmInt 0
+  LdImmInt 0
+  DivInt
+  Ret
+.end

--- a/tests/vm/t05_div_int_overflow.test
+++ b/tests/vm/t05_div_int_overflow.test
@@ -1,0 +1,14 @@
+discard """
+  description: "
+    DivInt with a divisor of -1 behaves the same as MulInt with a factor -1
+  "
+  output: "(Done (9223372036854775808 or -9223372036854775808))"
+"""
+.type P1 () -> int
+.const low int 0x8000_0000_0000_0000
+.start P1 main
+  LdConst low
+  LdImmInt -1
+  DivInt
+  Ret
+.end

--- a/tests/vm/t05_divu_div_by_zero.test
+++ b/tests/vm/t05_divu_div_by_zero.test
@@ -1,0 +1,10 @@
+discard """
+  output: "(Error ecDivByZero)"
+"""
+.type P1 () -> int
+.start P1 main
+  LdImmInt 0
+  LdImmInt 0
+  DivU
+  Ret
+.end

--- a/tests/vm/t05_float_to_sint_1.test
+++ b/tests/vm/t05_float_to_sint_1.test
@@ -1,0 +1,12 @@
+discard """
+  description: "NaN is converted to 0"
+  output: "(Done 0)"
+"""
+.type P1 () -> int
+.start P1 main
+  LdImmFloat 0.0
+  LdImmFloat 0.0
+  DivFloat       # 0.0 / 0.0 produces a NaN value
+  FloatToSInt 32
+  Ret
+.end

--- a/tests/vm/t05_float_to_sint_2.test
+++ b/tests/vm/t05_float_to_sint_2.test
@@ -1,0 +1,10 @@
+discard """
+  description: ""
+  output: "(Done 127)"
+"""
+.type P1 () -> int
+.start P1 main
+  LdImmFloat 200
+  FloatToSInt 8
+  Ret
+.end

--- a/tests/vm/t05_float_to_sint_3.test
+++ b/tests/vm/t05_float_to_sint_3.test
@@ -1,0 +1,9 @@
+discard """
+  output: "(Done (18446744073709551488 or -128))"
+"""
+.type P1 () -> int
+.start P1 main
+  LdImmFloat -400
+  FloatToSInt 8
+  Ret
+.end

--- a/tests/vm/t05_float_to_sint_4.test
+++ b/tests/vm/t05_float_to_sint_4.test
@@ -1,0 +1,9 @@
+discard """
+  output: "(Done 65536)"
+"""
+.type P1 () -> int
+.start P1 main
+  LdImmFloat 65536.0
+  FloatToSInt 32
+  Ret
+.end

--- a/tests/vm/t05_float_to_uint_1.test
+++ b/tests/vm/t05_float_to_uint_1.test
@@ -1,0 +1,12 @@
+discard """
+  description: "NaN is converted to 0"
+  output: "(Done 0)"
+"""
+.type P1 () -> int
+.start P1 main
+  LdImmFloat 0.0
+  LdImmFloat 0.0
+  DivFloat
+  FloatToUInt 32
+  Ret
+.end

--- a/tests/vm/t05_float_to_uint_2.test
+++ b/tests/vm/t05_float_to_uint_2.test
@@ -1,0 +1,9 @@
+discard """
+  output: "(Done 255)"
+"""
+.type P1 () -> int
+.start P1 main
+  LdImmFloat 300
+  FloatToUInt 8
+  Ret
+.end

--- a/tests/vm/t05_float_to_uint_3.test
+++ b/tests/vm/t05_float_to_uint_3.test
@@ -1,0 +1,9 @@
+discard """
+  output: "(Done 0)"
+"""
+.type P1 () -> int
+.start P1 main
+  LdImmFloat -1
+  FloatToUInt 8
+  Ret
+.end

--- a/tests/vm/t05_float_to_uint_4.test
+++ b/tests/vm/t05_float_to_uint_4.test
@@ -1,0 +1,9 @@
+discard """
+  output: "(Done 65536)"
+"""
+.type P1 () -> int
+.start P1 main
+  LdImmFloat 65536
+  FloatToUInt 32
+  Ret
+.end

--- a/tests/vm/t05_mod_int_div_by_zero.test
+++ b/tests/vm/t05_mod_int_div_by_zero.test
@@ -1,0 +1,10 @@
+discard """
+  output: "(Error ecDivByZero)"
+"""
+.type P1 () -> int
+.start P1 main
+  LdImmInt 0
+  LdImmInt 0
+  ModInt
+  Ret
+.end

--- a/tests/vm/t05_modu_div_by_zero.test
+++ b/tests/vm/t05_modu_div_by_zero.test
@@ -1,0 +1,10 @@
+discard """
+  output: "(Error ecDivByZero)"
+"""
+.type P1 () -> int
+.start P1 main
+  LdImmInt 0
+  LdImmInt 0
+  ModU
+  Ret
+.end

--- a/vm/assembler.nim
+++ b/vm/assembler.nim
@@ -234,7 +234,7 @@ proc parseOp(s: Stream, op: Opcode, a: var AssemblerState): Instr =
      opcReinterpF32, opcReinterpF64, opcReinterpI32, opcReinterpI64,
      opcExcept, opcUnreachable, opcRaise, opcMemCopy, opcMemClear, opcGrow:
     Instr(op) # instruction with no immediate operands
-  of opcAddImm, opcLdConst, opcLdImmInt, opcOffset,
+  of opcAddImm, opcLdImmInt, opcOffset,
      opcLdInt8, opcLdInt16, opcLdInt32, opcLdInt64, opcLdFlt32, opcLdFlt64,
      opcWrInt8, opcWrInt16, opcWrInt32, opcWrInt64, opcWrFlt32, opcWrFlt64,
      opcWrRef, opcStackAlloc, opcStackFree:
@@ -244,6 +244,8 @@ proc parseOp(s: Stream, op: Opcode, a: var AssemblerState): Instr =
   of opcMask, opcSignExtend, opcAddChck, opcSubChck, opcUIntToFloat,
      opcFloatToUint, opcSIntToFloat, opcFloatToSInt:
     instrC()
+  of opcLdConst:
+    makeInstr(a.consts[s.ident()])
   of opcBranch:
     makeInstr(s.parseLabel(a), c = (s.space(); s.parseIntLike(int8)))
   of opcJmp:

--- a/vm/assembler.nim
+++ b/vm/assembler.nim
@@ -107,6 +107,8 @@ proc parseIntLike[T](s: Stream, _: typedesc[T]): T =
   while (let c = s.peekChar(); c notin {' ', '\t', '\n', '\r', '\0'}):
     str.add s.readChar()
 
+  expect str.len > 0, "expected integer value"
+
   var temp: BiggestInt
   if parseBiggestInt(str, temp) != str.len:
     # error; might be an integer in hex format

--- a/vm/assembler.nim
+++ b/vm/assembler.nim
@@ -145,6 +145,7 @@ proc parseValue(s: Stream, typ: ValueType): Value =
 
 proc parseTypedVal(s: Stream): TypedValue =
   let typ = parseEnum[ValueType]("vt" & s.ident())
+  s.space()
   TypedValue(typ: typ, val: s.parseValue(typ))
 
 proc parseType(s: Stream, env: var TypeEnv, a: AssemblerState): TypeId =

--- a/vm/vm.nim
+++ b/vm/vm.nim
@@ -278,6 +278,9 @@ proc run*(c: var VmEnv, t: var VmThread, cl: RootRef): YieldReason {.raises: [].
       let divisor = pop(uint64)
       check divisor != 0, ecDivByZero
       asgn 1, operand(1).uintVal mod divisor
+    of opcNegInt:
+      # overflow-safe two's complement integer negation
+      asgn 1, (not operand(1).uintVal) + 1
     of opcOffset:
       # use unsigned integers, for overflow-safe arithmetic
       let idx = pop(uint64)

--- a/vm/vmvalidation.nim
+++ b/vm/vmvalidation.nim
@@ -168,7 +168,11 @@ proc run(ctx: var ValidationState, env: VmModule, pos: PrgCtr, instr: Instr
   of opcUIntToFloat, opcSIntToFloat:
     pop(vtInt)
     push(vtFloat)
-  of opcFloatToSInt, opcFloatToUint, opcReinterpI32, opcReinterpI64:
+  of opcFloatToSInt, opcFloatToUInt:
+    check imm8(instr) in 1..64, "width out of range"
+    pop(vtFloat)
+    push(vtInt)
+  of opcReinterpI32, opcReinterpI64:
     pop(vtFloat)
     push(vtInt)
   of opcLdInt8, opcLdInt16, opcLdInt32, opcLdInt64:


### PR DESCRIPTION
## Summary

Make the behaviour of all operations well-defined for all inputs and
fix the implementation of some operations exhibiting undefined
behaviour for some inputs.

## Details

The implementation of some opcodes used unchecked signed integer
arithmetic or conversions, thus triggering defects when building with
checks and undefined behaviour otherwise.

### Division By Zero

There's no sensible to value that can be returned for a integer
division by zero, so the `MulU`, `DivU`, `DivInt`, and `ModInt`
operations all trap (raise a run-time error) now.

### Float To Int Conversion

The `FloatToSInt` and `FloatToUInt` operations now perform a saturating
conversion, clamping the float value to the specified integer range.
NaNs are always converted to 0. The validator now also makes sure that
their immediate operand is a legal value.

### Negation

For `low(int64)`, `NegInt` and `DivInt` with a divisor of -1 overflow.
This could be resolved by trapping, but for consistency with `MulInt`
(which never traps on multiplication with -1), and to get around
branching control-flow for `Neg`, `NegInt` and `DivInt` with a divisor
of -1 now behave exactly like `MulInt` with a factor of -1.

### Address Computation

Computing the final address for `LdX` and `WrX` operations now uses
unsigned integer arithmetic, fixing the overflow issues the previous
code had. Behaviour in the non-overflow case doesn't change.

### Assembler

* the assembler now expects the name of a constant for `LdConst`
* fix integer-like values missing not being reported as an error
* fix parsing for typed value; the required space between the type and
  value wasn't skipped

---

## Notes For Reviewers
* unless I missed something, this should fix all UB in the VM
* this is also a preparation for fixing some `pass0` bugs for arithmetic operations