### PR TITLE
lang0: support exporting procedures/globals

### DIFF
--- a/passes/lang0.md
+++ b/passes/lang0.md
@@ -125,22 +125,35 @@ If `stack` is greater than 0, `stack` bytes are allocated from the stack on
 procedure entry, and the frame pointer is stored in the local specified last
 in the entry parameter block parameter list.
 
-### Foreign Procedures
+### Imported Procedures
 
 ```grammar
-procdef += (Foreign <type_id> (StringVal <string>))
+procdef += (Import typ:<type_id> name:(StringVal <string>))
 ```
 
-Foreign procedures are procedures that have an external implementation. How the
-identifier is interpreted is up to the code generator / linker to decide.
+Procedure imports declare procedures whose implementation is provided
+externally. The `name` provides the interface name that the implementation is
+provided under, and `typ` must be equal to the signature type of the
+implementation.
+
+### Exports
+
+```grammar
+export_id ::= (Proc <int>)
+           |  (Global <int>)
+export    ::= (Export name:(StringVal <string>) id:<export_id>)
+```
+
+An export makes a procedure or global variable available to the outside under
+the given `name`.
 
 ### Module
 
-All relevant entities (types, globals, and procedures) are stored under the
-top-level node, in dedicated sections, to allow for easy and fast access to
-them.
+All relevant entities (types, globals, procedures, and exports) are stored
+under the top-level node, in dedicated sections, to allow for easy and fast
+access to them.
 
 ```grammar
-module ::= (Module (TypeDefs <typedesc>*) (GlobalDefs <globaldef>*) (ProcDefs <procdef>*))
+module ::= (Module (TypeDefs <typedesc>*) (GlobalDefs <globaldef>*) (ProcDefs <procdef>*) (List <export>+)?)
 top ::= <module>
 ```

--- a/passes/pass0.nim
+++ b/passes/pass0.nim
@@ -665,3 +665,18 @@ proc translate*(module: PackedTree[NodeKind]): VmModule =
       result.procs.add ProcHeader(kind: pkCallback,
                                   typ: module[def, 0].typ)
       result.procs[i].code.a = result.names.high.uint32
+
+  # add the exports, if any:
+  if module.len(NodeIndex 0) == 4: # is there an export list?
+    let exports = module.next(procs)
+    for it in module.items(exports):
+      var ex = Export(name: result.names.len.uint32,
+                      id:   module[it, 1].id.uint32)
+      ex.kind =
+        case module[it, 1].kind
+        of Proc:   expProc
+        of Global: expGlobal
+        else:      unreachable()
+
+      result.exports.add ex
+      result.names.add module.getString(module.child(it, 0))

--- a/passes/spec.nim
+++ b/passes/spec.nim
@@ -38,7 +38,7 @@ type
     CheckedCall, CheckedCallAsgn, Unwind, Choice
 
     Module, TypeDefs, ProcDefs, ProcDef, Locals,
-    Except, Params, GlobalDefs, GlobalDef, Foreign
+    Except, Params, GlobalDefs, GlobalDef, Import, Export
 
     Break, Return, Case, If, Block, Stmts
 

--- a/tests/pass0/t03_basic_global.expected
+++ b/tests/pass0/t03_basic_global.expected
@@ -1,5 +1,5 @@
 .type t0 () -> int
-.global g0 1
+.global g0 int 1
 .start t0 p0
   GetGlobal g0
   Ret

--- a/tests/pass0/t05_export_global.expected
+++ b/tests/pass0/t05_export_global.expected
@@ -1,0 +1,7 @@
+.type t0 () -> int
+.global g0 int 100
+.start t0 p0
+  LdImmInt 100
+  Ret
+.end
+.export global g0 "exported"

--- a/tests/pass0/t05_export_global.expected
+++ b/tests/pass0/t05_export_global.expected
@@ -1,7 +1,3 @@
 .type t0 () -> int
 .global g0 int 100
-.start t0 p0
-  LdImmInt 100
-  Ret
-.end
 .export global g0 "exported"

--- a/tests/pass0/t05_export_global.test
+++ b/tests/pass0/t05_export_global.test
@@ -1,5 +1,5 @@
 discard """
-  output: "(Done 100)"
+  output: "(Done 200)"
 """
 (TypeDefs
   (ProcTy (Int 8)))
@@ -9,6 +9,6 @@ discard """
   (ProcDef (Type 0) 0 (Locals)
     (List
       (Block (Params)
-        (Return (IntVal 100))))))
+        (Return (IntVal 200))))))
 (List
   (Export "exported" (Global 0)))

--- a/tests/pass0/t05_export_global.test
+++ b/tests/pass0/t05_export_global.test
@@ -1,0 +1,14 @@
+discard """
+  output: "(Done 100)"
+"""
+(TypeDefs
+  (ProcTy (Int 8)))
+(GlobalDefs
+  (GlobalDef (Int 8) (IntVal 100)))
+(ProcDefs
+  (ProcDef (Type 0) 0 (Locals)
+    (List
+      (Block (Params)
+        (Return (IntVal 100))))))
+(List
+  (Export "exported" (Global 0)))

--- a/tests/pass0/t05_export_global.test
+++ b/tests/pass0/t05_export_global.test
@@ -1,14 +1,10 @@
 discard """
-  output: "(Done 200)"
+  output: ""
 """
 (TypeDefs
   (ProcTy (Int 8)))
 (GlobalDefs
   (GlobalDef (Int 8) (IntVal 100)))
-(ProcDefs
-  (ProcDef (Type 0) 0 (Locals)
-    (List
-      (Block (Params)
-        (Return (IntVal 200))))))
+(ProcDefs)
 (List
   (Export "exported" (Global 0)))

--- a/tests/pass0/t05_export_procedure.expected
+++ b/tests/pass0/t05_export_procedure.expected
@@ -1,0 +1,6 @@
+.type t0 () -> int
+.start t0 p0
+  LdImmInt 100
+  Ret
+.end
+.export proc p0 "exported"

--- a/tests/pass0/t05_export_procedure.test
+++ b/tests/pass0/t05_export_procedure.test
@@ -1,0 +1,13 @@
+discard """
+  output: "(Done 100)"
+"""
+(TypeDefs
+  (ProcTy (Int 8)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 0) 0 (Locals)
+    (List
+      (Block (Params)
+        (Return (IntVal 100))))))
+(List
+  (Export "exported" (Proc 0)))

--- a/tests/pass0/t05_foreign_procedure.test
+++ b/tests/pass0/t05_foreign_procedure.test
@@ -6,7 +6,7 @@ discard """
   (ProcTy (Int 8)))
 (GlobalDefs)
 (ProcDefs
-  (Foreign (Type 0) "core.test")
+  (Import (Type 0) "core.test")
   (ProcDef (Type 1) 0 (Locals)
     (List
       (Block (Params)

--- a/vm/disasm.nim
+++ b/vm/disasm.nim
@@ -136,7 +136,7 @@ proc disassemble*(m: VmModule): string =
 
   # emit the globals:
   for i, val in m.globals.pairs:
-    result.add &".global g{i} {val}\n"
+    result.add &".global g{i} {val.typ} {val}\n"
 
   # emit the procedures:
   for i, prc in m.procs.pairs:


### PR DESCRIPTION
## Summary

Add export lists - for exporting procedures and globals - to the `L0`
and all ILs extending it. The concept of *foreign procedures* is
changed into the more general *imported procedure* one.

## Details

A `Module` sub-tree may now have an optional trailing `List` sub-tree
containing a list of `Export` trees, which are translated directly into
VM module exports.

The `Foreign` node kind is renamed to `Import`. No further change is
required, as `L0` `Foreign` procedures are translated to `pkCallback`
procedure headers, which already represent procedure imports.

In addition, the disassembler output for global variables not being
valid assembler code is fixed.

---

## Notes For Reviewers
* further progress towards multi-module support
* support for exported globals in the ILs is a prerequisite for the allocator