### PR TITLE
ci: pin the NimSkull version

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -56,10 +56,10 @@ jobs:
           fetch-depth: 0
           filter: tree:0
 
-      # always use the most recent NimSkull version
+      # use a pinned version in order to make CI runs reproducible
       - uses: nim-works/setup-nimskull@0.1.2
         with:
-          nimskull-version: "*"
+          nimskull-version: "0.1.0-dev.21431"
 
       - name: Build koch
         run: nim c -d:nimStrictMode --outdir:bin koch.nim
@@ -85,10 +85,10 @@ jobs:
           fetch-depth: 0
           filter: tree:0
 
-      # always use the most recent NimSkull version
+      # use a pinned version in order to make CI runs reproducible
       - uses: nim-works/setup-nimskull@0.1.2
         with:
-          nimskull-version: "*"
+          nimskull-version: "0.1.0-dev.21431"
 
       - name: Build koch
         run: nim c -d:nimStrictMode --outdir:bin koch.nim


### PR DESCRIPTION
## Summary

Pin the NimSkull version used to the most recent working one
(0.1.0-dev.21431), making it the official minimum supported version of
NimSkull to compile the various Phy programs with.

---

## Notes For Reviewers
* this fixes the CI failures caused by the most-recent broken NimSkull release
* [skully](https://github.com/nim-works/phy/pull/70) also needs a pinned version, as it imports compiler modules directly 