### PR TITLE
lang: use more structured scoping rules

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -144,6 +144,9 @@ There is always a *current* scope.
 
 *Closing a scope* means replacing the current scope with its parent.
 
+Unless explicitly noted otherwise, by default, an expression always opens a
+new scope for itself and its sub-expressions.
+
 ### Expressions
 
 At the moment, a few names are automatically part of a scope: `+`, `-`, `==`,
@@ -195,14 +198,13 @@ expr += (If cond:<expr> body:<expr> else:<expr>?)
 the `body` expression, otherwise the `else` expression -- if there's no `else`
 expression, it is assumed to be `unit`.
 
-For both `body` and `else`, a new scope is opened for the expressions and
-closed afterwards.
+The `cond` expression doesn't open a new scope for itself.
 
 Let `A` be the type of `body` and `B` be type of `else` (which is `unit`, if
 there's no `else`). An error is reported if:
 * `cond` is a not a boolean expression, or
 * `A` is not the same type as `B`, and `A` is not a subtype of `B` nor is `B` a
-  subtype of `A` 
+  subtype of `A`
 
 The type of the `If` expression is the common type between `A` and `B`.
 
@@ -362,6 +364,9 @@ expression is any type outside of `unit` or `void`.
 
 The type of the expression list is inferred as `void` if any non-trailing
 expression is `void`, otherwise the type is that of the trailing expression.
+
+Expressions appearing as an *immediate* sub-expression of the expression list
+do not open a new scope for themselves.
 
 **Expression kind**: same as that of the trailing expression
 **Uses**: nothing

--- a/tests/expr/t09_decl_decl_with_same_name_in_initializer.test
+++ b/tests/expr/t09_decl_decl_with_same_name_in_initializer.test
@@ -1,5 +1,5 @@
 discard """
-  reject: true
+  output: "200: int"
 """
 (Exprs
   (Decl (Ident "x")

--- a/tests/expr/t12_and_scoping_1.test
+++ b/tests/expr/t12_and_scoping_1.test
@@ -1,0 +1,13 @@
+discard """
+  description: "
+    Declarations in the first operand expression are visible to the second
+    operand.
+  "
+  output: "true: bool"
+"""
+(Exprs
+  (And
+    (Exprs
+      (Decl b true)
+      true)
+    b))

--- a/tests/expr/t12_and_scoping_2_error.test
+++ b/tests/expr/t12_and_scoping_2_error.test
@@ -1,14 +1,14 @@
 discard """
   description: "
     Declarations in the second operand expression are *not* part of the
-    surrounding scope.
+    `And`'s surrounding scope.
   "
   reject: true
 """
 (Exprs
   (Decl (Ident "a")
-    (Or
-      (Ident "false")
+    (And
+      (Ident "true")
       (Exprs
         (Decl (Ident "b") (IntVal 100))
         (Ident "true"))))

--- a/tests/expr/t12_and_scoping_3_error.test
+++ b/tests/expr/t12_and_scoping_3_error.test
@@ -1,13 +1,13 @@
 discard """
   description: "
-    Declarations in the first operand expression are part of the surrounding
-    scope.
+    Declarations in the first operand expression are not part of the
+    `And`'s surrounding scope.
   "
-  output: "100: int"
+  reject: true
 """
 (Exprs
   (Decl (Ident "a")
-    (Or
+    (And
       (Exprs
         (Decl (Ident "b") (IntVal 100))
         (Ident "true"))

--- a/tests/expr/t12_or_scoping_1.test
+++ b/tests/expr/t12_or_scoping_1.test
@@ -1,0 +1,13 @@
+discard """
+  description: "
+    Declarations in the first operand expression are visible to the `Or`s
+    second operand.
+  "
+  output: "true: bool"
+"""
+(Exprs
+  (Or
+    (Exprs
+      (Decl x true)
+      false)
+    x))

--- a/tests/expr/t12_or_scoping_2_error.test
+++ b/tests/expr/t12_or_scoping_2_error.test
@@ -1,15 +1,15 @@
 discard """
   description: "
-    Declarations in the first operand expression are part of the surrounding
-    scope.
+    Declarations in the first operand expression are *not* part of the
+    `Or`'s surrounding scope.
   "
-  output: "100: int"
+  reject: true
 """
 (Exprs
   (Decl (Ident "a")
-    (And
+    (Or
       (Exprs
         (Decl (Ident "b") (IntVal 100))
         (Ident "true"))
-      (Ident "true")))
+      (Ident "false")))
   (Ident "b"))

--- a/tests/expr/t12_or_scoping_3_error.test
+++ b/tests/expr/t12_or_scoping_3_error.test
@@ -1,14 +1,14 @@
 discard """
   description: "
     Declarations in the second operand expression are *not* part of the
-    surrounding scope.
+    `Or`'s surrounding scope.
   "
   reject: true
 """
 (Exprs
   (Decl (Ident "a")
-    (And
-      (Ident "true")
+    (Or
+      (Ident "false")
       (Exprs
         (Decl (Ident "b") (IntVal 100))
         (Ident "true"))))

--- a/tests/expr/t15_while_scoping_1_error.test
+++ b/tests/expr/t15_while_scoping_1_error.test
@@ -1,8 +1,8 @@
 discard """
   description: "
-    Declarations within the `While` condition are visible to the body
+    Declarations within the `While` condition are not visible to the body
   "
-  output: "(): unit"
+  reject: true
 """
 (While
   (Exprs


### PR DESCRIPTION
## Summary

By default, expressions now always open a new scope for themselves and
their sub-expression, except for the first operand of `And`/`Or`,
expressions in `Exprs`, and `If` conditions.

## Details

The new scoping rules are much easier to formalize, as a `(Decl a b)`
expressions can now be viewed as `(Let a b trailing)`, where `trailing`
are the following expressions in the enclosing `Exprs`.

The rules arguably also make reasoning about code slightly easier to
the reader, as declarations within some nested sub-expression don't
"escape" outwards anymore.

For the implementation, `scopedExprToIL` is renamed to `exprToIL` and
the former `exprToIL` is renamed to `openExprToIL`.

The change is a preparation for formalizing the language definition.
In the future, some of the previous scoping rules might be restored.

---

## Notes For Reviewers

The simplifications are only really visible when attempting to formalize the rules. The "symbol bleeding" semantics is not easy to model when using conventional outside-to-inside syntax typing judgments, whereas it's easy to judge `(Let x y e)`:
```
C |- y: T   C, x: T |- e: T_2
-----------------------------
    C |- (Let x y e): T_2
```

Operational semantics regarding location lifetimes (and thus cleanup/destruction, once added) also becomes simpler with `Let`, as the LIFO behaviour of locals is encoded directly in the abstract syntax.

The "symbol bleeding" semantics is not impossible to model formally, of course, and it could be worthwhile to attempt doing so in the future.

`Let` is only a theoretical construct at the moment, though it could also be added to the source language.