### PR TITLE
pass0: fix `BitNot` for signed integers

### DIFF
--- a/passes/pass0.nim
+++ b/passes/pass0.nim
@@ -282,7 +282,8 @@ proc genExpr(c; tree; val: NodeIndex) =
     let typ = parseType(tree, tree.child(val, 0))
     c.genExpr(tree, tree.child(val, 1))
     c.instr(opcBitNot)
-    c.mask(typ) # discard the unused higher bits
+    if typ.kind == t0kUInt:
+      c.mask(typ)
   of BitAnd:
     let (_, a, b) = tree.triplet(val)
     c.genExpr(tree, a)

--- a/passes/pass0.nim
+++ b/passes/pass0.nim
@@ -295,16 +295,17 @@ proc genExpr(c; tree; val: NodeIndex) =
     c.genExpr(tree, b)
     c.instr(opcBitOr)
   of BitXor:
-    c.genBinaryArithOp(tree, val, opcBitXor, opcBitXor, opcNop)
+    c.genBinaryOp(tree, val, opcBitXor, opcBitXor, opcNop)
   of Shl:
     let (typ, a, b) = triplet(tree, val)
     c.genExpr(tree, a)
     c.genExpr(tree, b)
     c.instr(opcShl)
     let t = parseType(tree, typ)
-    c.mask(t) # also cut off the upper bits for signed integers
-    if t.kind == t0kInt:
-      c.signExtend(t)
+    case t.kind
+    of t0kInt:  c.signExtend(t)
+    of t0kUInt: c.mask(t)
+    else:       unreachable()
   of Shr:
     let (typ, a, b) = triplet(tree, val)
     c.genExpr(tree, a)

--- a/tests/pass0/t03_bitnot.expected
+++ b/tests/pass0/t03_bitnot.expected
@@ -1,0 +1,17 @@
+.type t0 () -> void
+.start t0 p0
+  LdImmInt 0
+  BitNot
+  Drop
+  LdImmInt 0
+  BitNot
+  Drop
+  LdImmInt 0
+  BitNot
+  Drop
+  LdImmInt 0
+  BitNot
+  Mask 32
+  Drop
+  Ret
+.end

--- a/tests/pass0/t03_bitnot.test
+++ b/tests/pass0/t03_bitnot.test
@@ -1,0 +1,19 @@
+discard """
+  output: "(Done)"
+"""
+(TypeDefs
+  (ProcTy (Void)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 0) 0 (Locals)
+    (List
+      (Block (Params)
+        (Drop
+          (BitNot (Int 8) (IntVal 0)))
+        (Drop
+          (BitNot (UInt 8) (IntVal 0)))
+        (Drop
+          (BitNot (Int 4) (IntVal 0)))
+        (Drop
+          (BitNot (UInt 4) (IntVal 0)))
+        (Return)))))

--- a/tests/pass0/t03_bitxor.expected
+++ b/tests/pass0/t03_bitxor.expected
@@ -1,0 +1,12 @@
+.type t0 () -> void
+.start t0 p0
+  LdImmInt 0
+  LdImmInt 0
+  BitXor
+  Drop
+  LdImmInt 0
+  LdImmInt 0
+  BitXor
+  Drop
+  Ret
+.end

--- a/tests/pass0/t03_bitxor.test
+++ b/tests/pass0/t03_bitxor.test
@@ -1,0 +1,15 @@
+discard """
+  output: "(Done)"
+"""
+(TypeDefs
+  (ProcTy (Void)))
+(GlobalDefs)
+(ProcDefs
+  (ProcDef (Type 0) 0 (Locals)
+    (List
+      (Block (Params)
+        (Drop
+          (BitXor (Int 4) (IntVal 0) (IntVal 0)))
+        (Drop
+          (BitXor (UInt 8) (IntVal 0) (IntVal 0)))
+        (Return)))))


### PR DESCRIPTION
## Summary

Fix the translation of `BitNot` to bytecode resulting in incorrect
results for non-64-bit signed integers.

## Details

The result of the `opcBitNot` instruction was always masked, even for
signed integers, which is incorrect, as it invalidates the two's
complement representation. For example, `not 2'u32` should be -3,
but with the subsequent 32-bit masking it was 4,294,967,293‬
(`0xFF_FF_FF_FD`).

A mask instruction is now only emitted for unsigned integers. In
addition, an unnecessary but otherwise harmless `opcMask` instruction
was emitted for both `BitXor` (uint) and `Shl` (int), which is also
fixed.

---

## Notes For Reviewers
* discovered with #70 (and also a blocker thereof)