### PR TITLE
fix bug in linker's import resolution

### DIFF
--- a/tests/vm/t03_import_bug.test
+++ b/tests/vm/t03_import_bug.test
@@ -1,0 +1,15 @@
+discard """
+  description: "Regression test for a linker bug"
+  output: "(Done 100)"
+"""
+.type P1 (int) -> int
+.type P2 () -> int
+.start P2 p
+  LdImmInt 100
+  Ret
+.end
+.import P1 imported "test"
+.start P2 main
+  Call p 0
+  Ret
+.end

--- a/vm/vmmodules.nim
+++ b/vm/vmmodules.nim
@@ -165,11 +165,11 @@ proc link*(env: var VmEnv, host: Table[string, VmCallback],
           tab[i] = (lkRedirect, exported[name])
         elif name in host:
           # the import imports a host procedure
-          let i = lookup.mgetOrPut(name, env.callbacks.len)
-          if i == env.callbacks.len: # is it a new table entry?
+          let cb = lookup.mgetOrPut(name, env.callbacks.len)
+          if cb == env.callbacks.len: # is it a new table entry?
             env.callbacks.add host[name]
 
-          tab[i] = (lkImportHost, i.uint32)
+          tab[i] = (lkImportHost, cb.uint32)
         else:
           # the import cannot be resolved, turn the procedure entry into
           # a stub


### PR DESCRIPTION
## Summary

Fix a bug with computing the link table, which resulted in faulty VM
environments for non-trivial VM modules using imports.

## Details

The `i` variable in the inner `for` loop of the link-table computation
was incorrectly shadowed, leading to the wrong table entry being set.
This, in turn, could lead to the entry of a non-imported procedure being
turned into a callback entry.

---

## Notes For Reviewers
* discovered with #70 (and also a blocker thereof)