### PR TITLE
lang: add string constructors

### DIFF
--- a/common/vmexec.nim
+++ b/common/vmexec.nim
@@ -3,7 +3,8 @@
 
 import
   std/[
-    options
+    options,
+    strutils
   ],
   phy/[
     type_rendering,
@@ -46,6 +47,16 @@ proc primToString(v: Value, typ: SemType): string =
     of 0: "false"
     of 1: "true"
     else: "unknown(" & $v.intVal & ")"
+  of tkChar:
+    case v.intVal
+    of ord('\n'):       "'\\n'"
+    of ord('\r'):       "'\\r'"
+    of ord('\''):       "'\\''"
+    of ord('\\'):       "'\\\\'"
+    of 32..38, 40..91, 93..127:
+      "'" & $char(v.intVal) & "'"
+    else:
+      "'\\x" & toHex(v.intVal, 2) & "'"
   of tkInt:
     $v.intVal
   of tkFloat:
@@ -64,6 +75,8 @@ proc valueToString(env: var VmEnv, a: VirtualAddr, typ: SemType): string =
   of tkUnit:
     result = "()"
   of tkBool:
+    result = primToString(Value(readInt(p, 1)), typ)
+  of tkChar:
     result = primToString(Value(readInt(p, 1)), typ)
   of tkInt:
     result = $readInt(p, 8)

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -298,6 +298,8 @@ proc typeToIL(c; typ: SemType): uint32 =
     c.addType Node(kind: Int, val: 1)
   of tkBool:
     c.addType Node(kind: Int, val: 1)
+  of tkChar:
+    c.addType Node(kind: UInt, val: 1)
   of tkInt, tkError:
     c.addType Node(kind: Int, val: 8)
   of tkFloat:

--- a/passes/spec_source.nim
+++ b/passes/spec_source.nim
@@ -9,9 +9,10 @@ import
 
 type
   NodeKind* {.pure.} = enum
-    IntVal, FloatVal
+    IntVal, FloatVal, StringVal
     Ident,
-    VoidTy, UnitTy, BoolTy, IntTy, FloatTy, TupleTy, UnionTy, ProcTy, SeqTy
+    VoidTy, UnitTy, BoolTy, CharTy, IntTy, FloatTy, TupleTy, UnionTy, ProcTy,
+    SeqTy
     And, Or
     If
     While
@@ -48,6 +49,7 @@ proc toSexp*(tree: PackedTree[NodeKind], idx: NodeIndex,
   case n.kind
   of IntVal:    sexp([newSSymbol("IntVal"), sexp tree.getInt(idx)])
   of FloatVal:  sexp([newSSymbol("FloatVal"), sexp tree.getFloat(idx)])
+  of StringVal: sexp([newSSymbol("StringVal"), sexp tree.getString(idx)])
   of Ident:     sexp([newSSymbol("Ident"), sexp tree.getString(idx)])
   else:         unreachable()
 
@@ -73,7 +75,7 @@ proc fromSexp*(_: typedesc[NodeKind], val: BiggestFloat, lit): Node =
   Node(kind: FloatVal, val: lit.pack(val))
 
 proc fromSexp*(_: typedesc[NodeKind], val: string, lit): Node =
-  raise ValueError.newException("standalone strings are not supported")
+  Node(kind: StringVal, val: lit.pack(val))
 
 proc fromSexpSym*(_: typedesc[NodeKind], val: string, lit): Node =
   Node(kind: Ident, val: lit.pack(val))

--- a/phy/type_rendering.nim
+++ b/phy/type_rendering.nim
@@ -13,6 +13,7 @@ proc typeToString*(typ: SemType): string =
   of tkVoid:  "void"
   of tkUnit:  "unit"
   of tkBool:  "bool"
+  of tkChar:  "char"
   of tkInt:   "int"
   of tkFloat: "float"
   of tkTuple:

--- a/phy/types.nim
+++ b/phy/types.nim
@@ -21,6 +21,7 @@ type
     tkVoid
     tkUnit
     tkBool
+    tkChar  ## UTF-8 byte
     tkInt
     tkFloat
     tkTuple ## an anonymous product type
@@ -32,7 +33,7 @@ type
     ## Represents a source-language type. The "Sem" prefix is there to prevent
     ## name conflicts with other types named `Type`.
     case kind*: TypeKind
-    of tkError, tkVoid, tkUnit, tkBool, tkInt, tkFloat:
+    of tkError, tkVoid, tkUnit, tkBool, tkChar, tkInt, tkFloat:
       discard
     of tkTuple, tkUnion, tkProc, tkSeq:
       elems*: seq[SemType]
@@ -52,7 +53,7 @@ proc cmp*(a, b: SemType): int =
 
   # same kind, compare operands
   case a.kind
-  of tkError, tkVoid, tkUnit, tkBool, tkInt, tkFloat:
+  of tkError, tkVoid, tkUnit, tkBool, tkChar, tkInt, tkFloat:
     result = 0 # equal
   of tkTuple, tkUnion, tkProc, tkSeq:
     result = a.elems.len - b.elems.len
@@ -83,7 +84,7 @@ proc `==`*(a, b: SemType): bool =
     return false
 
   case a.kind
-  of tkError, tkVoid, tkUnit, tkBool, tkInt, tkFloat:
+  of tkError, tkVoid, tkUnit, tkBool, tkChar, tkInt, tkFloat:
     result = true
   of tkTuple, tkUnion, tkProc, tkSeq:
     result = a.elems == b.elems
@@ -105,7 +106,7 @@ proc size*(t: SemType): int =
   case t.kind
   of tkVoid: unreachable()
   of tkError: 8 # TODO: return a value indicating "unknown"
-  of tkUnit, tkBool: 1
+  of tkUnit, tkBool, tkChar: 1
   of tkInt, tkFloat: 8
   of tkProc: 8 # size of a pointer
   of tkTuple:
@@ -134,7 +135,7 @@ proc isTriviallyCopyable*(typ: SemType): bool =
   ## Whether a value of `typ` can be trivially copied (that is, via a
   ## single block copy).
   case typ.kind
-  of tkError, tkUnit, tkBool, tkInt, tkFloat, tkProc:
+  of tkError, tkUnit, tkBool, tkChar, tkInt, tkFloat, tkProc:
     true
   of tkSeq:
     false

--- a/tests/expr/t18_seq_character_string_1.test
+++ b/tests/expr/t18_seq_character_string_1.test
@@ -1,0 +1,4 @@
+discard """
+  output: "['a', 'b', 'c']: seq(char)"
+"""
+(Seq "abc")

--- a/tests/expr/t18_seq_character_string_2.test
+++ b/tests/expr/t18_seq_character_string_2.test
@@ -1,0 +1,4 @@
+discard """
+  output: "['a', '\\xCE', '\\xB2', 'c']: seq(char)"
+"""
+(Seq "aβc")


### PR DESCRIPTION
## Summary

Add string constructors (`(Seq "...")`) and the `CharTy` type to the
source language. Both are meant as an interim solution to making
working with text easier.

## Details

* add the static and dynamic semantics for string constructors. A
  "character" is considered a UTF-8 byte, with the `(Seq "...")`
  constructing a dynamic array with the UTF-8 bytes of the given
  unicode string
* S-expression strings are automatically translated to
  `(StringVal ...)` during parsing
* add the `tkChar` type kind and implement the associated logic (type/
  value rendering, IL translation)

A `(StringVal ...)` is a static array (i.e., an array of statically
known size), and thus it's not considered to be a string constructor
itself.

---

## Notes For Reviewers
* meant as a preparation for adding some basic I/O procedures
* my current plan is for `(StringVal ...)` to be typed as `(ArrayTy ... (CharTy))` in the future, with `Seq` then accepting any array, thus generalizing the current special case