### PR TITLE
lang: add `write` and `writeErr`

### DIFF
--- a/phy/host_impl.nim
+++ b/phy/host_impl.nim
@@ -2,7 +2,32 @@
 
 import
   std/tables,
-  vm/vmenv
+  vm/[
+    vmalloc,
+    vmenv
+  ]
+
+template trap() =
+  return CallbackResult(code: cecError)
+
+proc writeToFile(env: var VmEnv, file: File, data: VirtualAddr, len: int
+                ): CallbackResult =
+  if len < 0: trap() # guard against misuse
+
+  var p: HostPointer
+  if checkmem(env.allocator, data, len.uint64, p):
+    return CallbackResult(code: cecError)
+
+  let chars = cast[ptr UncheckedArray[char]](p)
+  try:
+    discard stdout.writeChars(toOpenArray(chars, 0, len - 1), 0, len)
+    result = CallbackResult(code: cecNothing)
+  except IOError:
+    # TODO: I/O errors need to be turned into either exceptions (very hard) or
+    #       error codes that the callsite then turns into exception (or
+    #       something else; easy). Trapping is a temporary solution to at
+    #       least not ignore the error
+    trap()
 
 proc hostProcedures*(includeTest: bool): Table[string, VmCallback] =
   ## If `includeTest` is true, some host procedures only meant for testing are
@@ -15,3 +40,10 @@ proc hostProcedures*(includeTest: bool): Table[string, VmCallback] =
   if includeTest:
     hostProc "core.test":
       CallbackResult(code: cecValue, value: args[0])
+
+  # TODO: the streams to write to need to be configurable from
+  #       the outside, through the ref object passed to the callbacks
+  hostProc "core.write":
+    writeToFile(env, stdout, args[0].addrVal, args[1].intVal.int)
+  hostProc "core.writeErr":
+    writeToFile(env, stderr, args[0].addrVal, args[1].intVal.int)

--- a/tests/expr/t19_write.test
+++ b/tests/expr/t19_write.test
@@ -1,0 +1,4 @@
+discard """
+  output: "test\n(): unit"
+"""
+(Call write (Seq "test\n"))

--- a/tests/expr/t19_writeErr.test
+++ b/tests/expr/t19_writeErr.test
@@ -1,0 +1,4 @@
+discard """
+  output: "test\n(): unit"
+"""
+(Call writeErr (Seq "test\n"))


### PR DESCRIPTION
## Summary

Add support for writing to the standard output and error output to the
source language, via the built-in `write` and `writeErr` procedures.

## Details

For convenience, both output procedures take a `(SeqTy (CharTy))` value
as input. Internally, the built-ins invoke their corresponding external
procedure, which takes a data pointer and length as input.

Same as the allocator procedures, both new built-in procedures are
always added to a module, even if not used.

The operational semantics of both output procedures is modeled as
appending to an array stored in the context.

---

## Notes For Reviewers
* in the future, both `write` and `writeErr` should become non-built-in procedures (somehow)