### PR TITLE
host_impl: make output streams configurable

### DIFF
--- a/phy/phy.nim
+++ b/phy/phy.nim
@@ -399,8 +399,10 @@ proc main(args: openArray[string]) =
       let stack = hoSlice(mem.stackStart, mem.stackStart + mem.stackSize)
 
       if source == langSource:
+        let cl = HostEnv(outStream: newFileStream(stdout),
+                         errStream: newFileStream(stderr))
         # we have type high-level type information
-        stdout.write run(env, stack, entry.unsafeGet, typ)
+        stdout.write run(env, stack, entry.unsafeGet, typ, cl)
       else:
         # program arguments are only supported for non-source-language
         # programs at the moment

--- a/phy/repl.nim
+++ b/phy/repl.nim
@@ -164,9 +164,11 @@ proc process(ctx: var ModuleCtx, reporter: Reporter,
     var env = initVm(mem.total, mem.total)
     link(env, hostProcedures(includeTest = false), [module])
 
+    let cl = HostEnv(outStream: newFileStream(stdout),
+                     errStream: newFileStream(stderr))
     # eval and print:
     echo run(env, hoSlice(mem.stackStart, mem.stackStart + mem.stackSize),
-             ProcIndex(entry), typ)
+             ProcIndex(entry), typ, cl)
   else:
     echo "Error: unexpected node: ", tree[NodeIndex(0)].kind
 

--- a/phy/vmexec.nim
+++ b/phy/vmexec.nim
@@ -148,7 +148,7 @@ proc readMemConfig*(m: VmModule): Option[MemoryConfig] =
                       stackSize: uint(stackSize))
 
 proc run*(env: var VmEnv, stack: HOslice[uint], prc: ProcIndex,
-          typ: SemType): string =
+          typ: SemType, cl: RootRef): string =
   ## Runs the nullary procedure with index `prc`, and returns the result
   ## rendered as a string. `typ` is the type of the resulting value.
   var thread: VmThread
@@ -160,7 +160,7 @@ proc run*(env: var VmEnv, stack: HOslice[uint], prc: ProcIndex,
   else:
     thread = vm.initThread(env, prc, stack, @[])
 
-  let res = run(env, thread, nil)
+  let res = run(env, thread, cl)
   env.dispose(thread)
 
   case res.kind


### PR DESCRIPTION
## Summary

Allow for configuring at run-time where to write the output and error
text for the VM host procedures. This is an internal change aimed at
making debugging and testing easier.

## Details

* require providing the output and error streams to use for
  `core.write` and `core.writeErr` via the `HostEnv` instance
* support passing an environment closure (`RootRef`) to the VM via the
  type-information `vmexec.run` overload
* rename `writeToFile` to `writeToStream` and have it take a `Stream`
  as the destination rather than a file

This also fixes `core.writeErr` always writing to the standard output
stream (`writeToFile` always used `stdout`, ignoring the file
argument).

---

## Notes For Reviewers
* a small improvement unrelated to any other ongoing work