### PR TITLE
source2il: implement alignment support

### DIFF
--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -150,8 +150,7 @@ using
   stmts: var seq[IrNode]
 
 func align(val: SizeUnit, to: SizeUnit): SizeUnit =
-  ## Rounds `val` to the multiple of `to`, the latter which must be a power of
-  ## two.
+  ## Rounds `val` to the multiple of `to`, the latter must be a power of two.
   let mask = val - 1
   (val + mask) and not mask
 

--- a/phy/types.nim
+++ b/phy/types.nim
@@ -149,6 +149,20 @@ proc alignment*(t: SemType): SizeUnit =
   of tkSeq:
     alignment(prim(tkInt))
 
+proc innerSize*(t: SemType): SizeUnit =
+  ## Computes the size without padding of a union (`t`) without the tag.
+  assert t.kind == tkUnion
+  result = 0
+  for it in t.elems.items:
+    result = max(size(it), result)
+
+proc innerAlignment*(t: SemType): SizeUnit =
+  ## Computes the size without padding of a union (`t`) without the tag.
+  assert t.kind == tkUnion
+  result = 0
+  for it in t.elems.items:
+    result = max(alignment(it), result)
+
 proc paddedSize*(t: SemType): SizeUnit =
   ## Computes the size of an array element of type `t`.
   let mask = alignment(t) - 1

--- a/phy/types.nim
+++ b/phy/types.nim
@@ -16,6 +16,11 @@ import
   ]
 
 type
+  SizeUnit* = int
+    ## Used for numbers that represent size and alignment values.
+    ## 1 size-unit = 1 byte.
+  # TODO: make the type a distinct unsigned type
+
   TypeKind* = enum
     tkError
     tkVoid
@@ -101,8 +106,8 @@ proc isSubtypeOf*(a, b: SemType): bool =
   else:
     false
 
-proc size*(t: SemType): int =
-  ## Computes the size-in-bytes that an instance of `t` occupies in memory.
+proc size*(t: SemType): SizeUnit =
+  ## Computes the size without padding of a location of type `t`.
   case t.kind
   of tkVoid: unreachable()
   of tkError: 8 # TODO: return a value indicating "unknown"
@@ -121,6 +126,33 @@ proc size*(t: SemType): int =
     s + 8 # +8 for the tag
   of tkSeq:
     size(prim(tkInt)) * 2 # length + pointer
+
+proc alignment*(t: SemType): SizeUnit =
+  ## Computes the alignment requirement for a location of type `t`.
+  case t.kind
+  of tkVoid: unreachable()
+  of tkError: 8
+  of tkUnit, tkBool, tkChar: 1
+  of tkInt, tkFloat: 8
+  of tkProc: 8
+  of tkTuple:
+    var a = 0
+    for it in t.elems.items:
+      a = max(a, alignment(it))
+    a
+  of tkUnion:
+    var a = 0
+    for it in t.elems.items:
+      a = max(a, alignment(it))
+    # the tag also contributes to the alignment
+    max(a, alignment(prim(tkInt)))
+  of tkSeq:
+    alignment(prim(tkInt))
+
+proc paddedSize*(t: SemType): SizeUnit =
+  ## Computes the size of an array element of type `t`.
+  let mask = alignment(t) - 1
+  (size(t) + mask) and not mask
 
 proc commonType*(a, b: SemType): SemType =
   ## Finds the common type between `a` and `b`, or produces an error.


### PR DESCRIPTION
## Summary

Implement internal support for locations with an alignment requirement
greater than 1 byte. This is a preparation for the source language
gaining type alignment requirements.

## Details

The alignment for numeric types (int and float) is equal to their size,
while for aggregate types (other than `seq`) it's that of their most
aligned constituent type.

The size of aggregate types is padded to be a multiple of their
alignment. This is so that their size matches the space they would take
up within an array, while still allowing copying `size` bytes from a
pointer to a location of said type to be valid, regardless of where the
location is located. Record fields are placed such that their relative
offset is a multiple of their alignment requirement.

The allocator procedures `alloc` and `realloc` take an additional 
parameter specifying the allocation's required alignment. `grow` and
`preparedAdd` also take an additional parameter, which specifies the
alignment of the dynamic array's element type. The callsites of all
four procedures are updated accordingly.

Finally, the value rendering in `vmexec` is updated to take the new
object layout into account.

---

## Notes For Reviewers
* memory access of numeric types being well-aligned also eases implementation of the `asm.js` translation pass, as `asm.js` doesn't have native support for misaligned memory access