### PR TITLE
phy: use structured output formatting

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -145,4 +145,4 @@ jobs:
           fi
         env:
           TEST_FILE: tests/expr/t06_call_proc_with_tuple_return_type.test
-          TEST_OUTPUT: "(100, 200): (int, int)(Done 0)"
+          TEST_OUTPUT: "(TupleCons 100 200) : (TupleTy (IntTy) (IntTy))(Done 0)"

--- a/phy/phy.nim
+++ b/phy/phy.nim
@@ -10,6 +10,9 @@ import
     streams,
     strutils
   ],
+  experimental/[
+    sexp
+  ],
   generated/[
     lang0_checks,
     lang1_checks,
@@ -41,6 +44,7 @@ import
     default_reporting,
     host_impl,
     tree_parser,
+    type_rendering,
     types,
     vmexec
   ],
@@ -402,7 +406,9 @@ proc main(args: openArray[string]) =
         let cl = HostEnv(outStream: newFileStream(stdout),
                          errStream: newFileStream(stderr))
         # we have type high-level type information
-        stdout.write run(env, stack, entry.unsafeGet, typ, cl)
+        stdout.write $run(env, stack, entry.unsafeGet, typ, cl)
+        stdout.write " : "
+        stdout.write $typeToSexp(typ)
       else:
         # program arguments are only supported for non-source-language
         # programs at the moment

--- a/phy/type_rendering.nim
+++ b/phy/type_rendering.nim
@@ -1,6 +1,9 @@
 ## Implements pretty-printing for source-language types.
 
 import
+  experimental/[
+    sexp
+  ],
   phy/[
     types
   ],
@@ -55,3 +58,33 @@ proc typeToString*(typ: SemType): string =
 proc `$`*(typ: SemType): string =
   ## A shortcut for `typeToString <#typeToString,SemType>`_.
   typeToString(typ)
+
+proc typeToSexp*(typ: SemType): SexpNode =
+  ## Returns the S-expression of the AST representing the type construction
+  ## for `typ`.
+  case typ.kind
+  of tkVoid:  newSList(newSSymbol("VoidTy"))
+  of tkUnit:  newSList(newSSymbol("UnitTy"))
+  of tkBool:  newSList(newSSymbol("BoolTy"))
+  of tkChar:  newSList(newSSymbol("CharTy"))
+  of tkInt:   newSList(newSSymbol("IntTy"))
+  of tkFloat: newSList(newSSymbol("FloatTy"))
+  of tkTuple:
+    var res = newSList(newSSymbol("TupleTy"))
+    for it in typ.elems.items:
+      res.add typeToSexp(it)
+    res
+  of tkUnion:
+    var res = newSList(newSSymbol("UnionTy"))
+    for it in typ.elems.items:
+      res.add typeToSexp(it)
+    res
+  of tkProc:
+    var res = newSList(newSSymbol("ProcTy"))
+    for it in typ.elems.items:
+      res.add typeToSexp(it)
+    res
+  of tkSeq:
+    newSList(newSSymbol("SeqTy"), typeToSexp(typ.elems[0]))
+  of tkError:
+    unreachable()

--- a/phy/vmexec.nim
+++ b/phy/vmexec.nim
@@ -41,7 +41,7 @@ proc readFloat64(p: HostPointer): float64 =
   copyMem(addr result, p, 8)
 
 proc primToSexp(v: Value, typ: SemType): SexpNode =
-  ## Renders the primitive value `v` of `typ` type to an S-expression.
+  ## Renders the primitive value `v` of type `typ` to an S-expression.
   case typ.kind
   of tkUnit:
     newCons("TupleCons")

--- a/tests/expr/t01_literal_false.test
+++ b/tests/expr/t01_literal_false.test
@@ -1,4 +1,4 @@
 discard """
-  output: "false: bool"
+  output: "(False) : (BoolTy)"
 """
 (Ident "false")

--- a/tests/expr/t01_literal_true.test
+++ b/tests/expr/t01_literal_true.test
@@ -1,4 +1,4 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Ident "true")

--- a/tests/expr/t01_negative_float_value.test
+++ b/tests/expr/t01_negative_float_value.test
@@ -1,4 +1,4 @@
 discard """
-  output: "-1.5: float"
+  output: "-1.5 : (FloatTy)"
 """
 (FloatVal -1.5)

--- a/tests/expr/t01_negative_integer_value.test
+++ b/tests/expr/t01_negative_integer_value.test
@@ -1,4 +1,4 @@
 discard """
-  output: "-1: int"
+  output: "-1 : (IntTy)"
 """
 (IntVal -1)

--- a/tests/expr/t01_positive_float_value.test
+++ b/tests/expr/t01_positive_float_value.test
@@ -1,4 +1,4 @@
 discard """
-  output: "1.5: float"
+  output: "1.5 : (FloatTy)"
 """
 (FloatVal 1.5)

--- a/tests/expr/t01_positive_integer_value.test
+++ b/tests/expr/t01_positive_integer_value.test
@@ -1,4 +1,4 @@
 discard """
-  output: "1: int"
+  output: "1 : (IntTy)"
 """
 (IntVal 1)

--- a/tests/expr/t02_add_float_values.test
+++ b/tests/expr/t02_add_float_values.test
@@ -1,4 +1,4 @@
 discard """
-  output: "4.0: float"
+  output: "4.0 : (FloatTy)"
 """
 (Call (Ident "+") (FloatVal 1.5) (FloatVal 2.5))

--- a/tests/expr/t02_add_integer_values.test
+++ b/tests/expr/t02_add_integer_values.test
@@ -1,4 +1,4 @@
 discard """
-  output: "3: int"
+  output: "3 : (IntTy)"
 """
 (Call (Ident "+") (IntVal 1) (IntVal 2))

--- a/tests/expr/t02_add_integer_values_overflow.test
+++ b/tests/expr/t02_add_integer_values_overflow.test
@@ -1,4 +1,4 @@
 discard """
-  output: "runtime error: ecUnreachable"
+  output: "(Unreachable) : (IntTy)"
 """
 (Call (Ident "+") (IntVal 9223372036854775807) (IntVal 1))

--- a/tests/expr/t02_div_integer_values_1.test
+++ b/tests/expr/t02_div_integer_values_1.test
@@ -1,4 +1,4 @@
 discard """
-  output: "2: int"
+  output: "2 : (IntTy)"
 """
 (Call (Ident "div") (IntVal 6) (IntVal 3))

--- a/tests/expr/t02_div_integer_values_2.test
+++ b/tests/expr/t02_div_integer_values_2.test
@@ -1,5 +1,5 @@
 discard """
   description: "'div' rounds towards zero"
-  output: "2: int"
+  output: "2 : (IntTy)"
 """
 (Call (Ident "div") (IntVal 7) (IntVal 3))

--- a/tests/expr/t02_div_integer_values_3.test
+++ b/tests/expr/t02_div_integer_values_3.test
@@ -1,5 +1,5 @@
 discard """
   description: "'div' rounds towards zero"
-  output: "-2: int"
+  output: "-2 : (IntTy)"
 """
 (Call (Ident "div") (IntVal -7) (IntVal 3))

--- a/tests/expr/t02_div_integer_values_div_by_zero.test
+++ b/tests/expr/t02_div_integer_values_div_by_zero.test
@@ -1,4 +1,4 @@
 discard """
-  output: "runtime error: ecUnreachable"
+  output: "(Unreachable) : (IntTy)"
 """
 (Call (Ident "div") (IntVal 1) (IntVal 0))

--- a/tests/expr/t02_div_integer_values_overflow.test
+++ b/tests/expr/t02_div_integer_values_overflow.test
@@ -1,4 +1,4 @@
 discard """
-  output: "runtime error: ecUnreachable"
+  output: "(Unreachable) : (IntTy)"
 """
 (Call (Ident "div") (IntVal -9223372036854775808) (IntVal -1))

--- a/tests/expr/t02_eq_bool_1.test
+++ b/tests/expr/t02_eq_bool_1.test
@@ -1,4 +1,4 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Call (Ident "==") (Ident "true") (Ident "true"))

--- a/tests/expr/t02_eq_bool_2.test
+++ b/tests/expr/t02_eq_bool_2.test
@@ -1,4 +1,4 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Call (Ident "==") (Ident "false") (Ident "false"))

--- a/tests/expr/t02_eq_bool_3.test
+++ b/tests/expr/t02_eq_bool_3.test
@@ -1,4 +1,4 @@
 discard """
-  output: "false: bool"
+  output: "(False) : (BoolTy)"
 """
 (Call (Ident "==") (Ident "false") (Ident "true"))

--- a/tests/expr/t02_eq_float_1.test
+++ b/tests/expr/t02_eq_float_1.test
@@ -1,4 +1,4 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Call (Ident "==") (FloatVal 10.0) (FloatVal 10.0))

--- a/tests/expr/t02_eq_float_2.test
+++ b/tests/expr/t02_eq_float_2.test
@@ -1,4 +1,4 @@
 discard """
-  output: "false: bool"
+  output: "(False) : (BoolTy)"
 """
 (Call (Ident "==") (FloatVal 10.0) (FloatVal 10.5))

--- a/tests/expr/t02_eq_int_1.test
+++ b/tests/expr/t02_eq_int_1.test
@@ -1,4 +1,4 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Call (Ident "==") (IntVal 10) (IntVal 10))

--- a/tests/expr/t02_eq_int_2.test
+++ b/tests/expr/t02_eq_int_2.test
@@ -1,4 +1,4 @@
 discard """
-  output: "false: bool"
+  output: "(False) : (BoolTy)"
 """
 (Call (Ident "==") (IntVal 10) (IntVal 11))

--- a/tests/expr/t02_less_eq_float_1.test
+++ b/tests/expr/t02_less_eq_float_1.test
@@ -1,4 +1,4 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Call (Ident "<=") (FloatVal 10.0) (FloatVal 10.0))

--- a/tests/expr/t02_less_eq_float_2.test
+++ b/tests/expr/t02_less_eq_float_2.test
@@ -1,4 +1,4 @@
 discard """
-  output: "false: bool"
+  output: "(False) : (BoolTy)"
 """
 (Call (Ident "<=") (FloatVal 10.0) (FloatVal 9.0))

--- a/tests/expr/t02_less_eq_float_3.test
+++ b/tests/expr/t02_less_eq_float_3.test
@@ -1,4 +1,4 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Call (Ident "<=") (FloatVal 10.0) (FloatVal 11.0))

--- a/tests/expr/t02_less_eq_int_1.test
+++ b/tests/expr/t02_less_eq_int_1.test
@@ -1,4 +1,4 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Call (Ident "<=") (IntVal 10) (IntVal 10))

--- a/tests/expr/t02_less_eq_int_2.test
+++ b/tests/expr/t02_less_eq_int_2.test
@@ -1,4 +1,4 @@
 discard """
-  output: "false: bool"
+  output: "(False) : (BoolTy)"
 """
 (Call (Ident "<=") (IntVal 10) (IntVal 9))

--- a/tests/expr/t02_less_eq_int_3.test
+++ b/tests/expr/t02_less_eq_int_3.test
@@ -1,4 +1,4 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Call (Ident "<=") (IntVal 10) (IntVal 11))

--- a/tests/expr/t02_less_than_float_1.test
+++ b/tests/expr/t02_less_than_float_1.test
@@ -1,4 +1,4 @@
 discard """
-  output: "false: bool"
+  output: "(False) : (BoolTy)"
 """
 (Call (Ident "<") (FloatVal 10.0) (FloatVal 10.0))

--- a/tests/expr/t02_less_than_float_2.test
+++ b/tests/expr/t02_less_than_float_2.test
@@ -1,4 +1,4 @@
 discard """
-  output: "false: bool"
+  output: "(False) : (BoolTy)"
 """
 (Call (Ident "<") (FloatVal 10.0) (FloatVal 9.0))

--- a/tests/expr/t02_less_than_float_3.test
+++ b/tests/expr/t02_less_than_float_3.test
@@ -1,4 +1,4 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Call (Ident "<") (FloatVal 10.0) (FloatVal 11.0))

--- a/tests/expr/t02_less_than_int_1.test
+++ b/tests/expr/t02_less_than_int_1.test
@@ -1,4 +1,4 @@
 discard """
-  output: "false: bool"
+  output: "(False) : (BoolTy)"
 """
 (Call (Ident "<") (IntVal 10) (IntVal 10))

--- a/tests/expr/t02_less_than_int_2.test
+++ b/tests/expr/t02_less_than_int_2.test
@@ -1,4 +1,4 @@
 discard """
-  output: "false: bool"
+  output: "(False) : (BoolTy)"
 """
 (Call (Ident "<") (IntVal 10) (IntVal 9))

--- a/tests/expr/t02_less_than_int_3.test
+++ b/tests/expr/t02_less_than_int_3.test
@@ -1,4 +1,4 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Call (Ident "<") (IntVal 10) (IntVal 11))

--- a/tests/expr/t02_mod_integer_values_1.test
+++ b/tests/expr/t02_mod_integer_values_1.test
@@ -1,4 +1,4 @@
 discard """
-  output: "4: int"
+  output: "4 : (IntTy)"
 """
 (Call (Ident "mod") (IntVal 4) (IntVal 5))

--- a/tests/expr/t02_mod_integer_values_2.test
+++ b/tests/expr/t02_mod_integer_values_2.test
@@ -1,4 +1,4 @@
 discard """
-  output: "0: int"
+  output: "0 : (IntTy)"
 """
 (Call (Ident "mod") (IntVal 10) (IntVal 5))

--- a/tests/expr/t02_mod_integer_values_3.test
+++ b/tests/expr/t02_mod_integer_values_3.test
@@ -1,5 +1,5 @@
 discard """
   description: "'mod' uses truncated division"
-  output: "-4: int"
+  output: "-4 : (IntTy)"
 """
 (Call (Ident "mod") (IntVal -4) (IntVal 5))

--- a/tests/expr/t02_mod_integer_values_4.test
+++ b/tests/expr/t02_mod_integer_values_4.test
@@ -1,5 +1,5 @@
 discard """
   description: "'mod' uses truncated division"
-  output: "4: int"
+  output: "4 : (IntTy)"
 """
 (Call (Ident "mod") (IntVal 4) (IntVal -5))

--- a/tests/expr/t02_mod_integer_values_div_by_zero.test
+++ b/tests/expr/t02_mod_integer_values_div_by_zero.test
@@ -1,4 +1,4 @@
 discard """
-  output: "runtime error: ecUnreachable"
+  output: "(Unreachable) : (IntTy)"
 """
 (Call (Ident "mod") (IntVal 1) (IntVal 0))

--- a/tests/expr/t02_mul_integer_values.test
+++ b/tests/expr/t02_mul_integer_values.test
@@ -1,4 +1,4 @@
 discard """
-  output: "6: int"
+  output: "6 : (IntTy)"
 """
 (Call (Ident "*") (IntVal 2) (IntVal 3))

--- a/tests/expr/t02_mul_integer_values_overflow_1.test
+++ b/tests/expr/t02_mul_integer_values_overflow_1.test
@@ -1,4 +1,4 @@
 discard """
-  output: "runtime error: ecUnreachable"
+  output: "(Unreachable) : (IntTy)"
 """
 (Call (Ident "*") (IntVal -9223372036854775808) (IntVal -1))

--- a/tests/expr/t02_mul_integer_values_overflow_2.test
+++ b/tests/expr/t02_mul_integer_values_overflow_2.test
@@ -1,4 +1,4 @@
 discard """
-  output: "runtime error: ecUnreachable"
+  output: "(Unreachable) : (IntTy)"
 """
 (Call (Ident "*") (IntVal 3037000500) (IntVal 3037000500))

--- a/tests/expr/t02_not_false.test
+++ b/tests/expr/t02_not_false.test
@@ -1,4 +1,4 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Call (Ident "not") (Ident "false"))

--- a/tests/expr/t02_not_true.test
+++ b/tests/expr/t02_not_true.test
@@ -1,4 +1,4 @@
 discard """
-  output: "false: bool"
+  output: "(False) : (BoolTy)"
 """
 (Call (Ident "not") (Ident "true"))

--- a/tests/expr/t02_sub_float_values.test
+++ b/tests/expr/t02_sub_float_values.test
@@ -1,4 +1,4 @@
 discard """
-  output: "-1.0: float"
+  output: "-1.0 : (FloatTy)"
 """
 (Call (Ident "-") (FloatVal 1.5) (FloatVal 2.5))

--- a/tests/expr/t02_sub_integer_values.test
+++ b/tests/expr/t02_sub_integer_values.test
@@ -1,4 +1,4 @@
 discard """
-  output: "-1: int"
+  output: "-1 : (IntTy)"
 """
 (Call (Ident "-") (IntVal 1) (IntVal 2))

--- a/tests/expr/t02_sub_integer_values_overflow.test
+++ b/tests/expr/t02_sub_integer_values_overflow.test
@@ -1,4 +1,4 @@
 discard """
-  output: "runtime error: ecUnreachable"
+  output: "(Unreachable) : (IntTy)"
 """
 (Call (Ident "-") (IntVal -9223372036854775808) (IntVal 1))

--- a/tests/expr/t02_tuple_constructor_1.test
+++ b/tests/expr/t02_tuple_constructor_1.test
@@ -1,4 +1,4 @@
 discard """
-  output: "(100,): (int,)"
+  output: "(TupleCons 100) : (TupleTy (IntTy))"
 """
 (TupleCons (IntVal 100))

--- a/tests/expr/t02_tuple_constructor_2.test
+++ b/tests/expr/t02_tuple_constructor_2.test
@@ -1,4 +1,4 @@
 discard """
-  output: "(100, 100): (int, int)"
+  output: "(TupleCons 100 100) : (TupleTy (IntTy) (IntTy))"
 """
 (TupleCons (IntVal 100) (IntVal 100))

--- a/tests/expr/t02_tuple_constructor_3.test
+++ b/tests/expr/t02_tuple_constructor_3.test
@@ -1,4 +1,4 @@
 discard """
-  output: "(100, (100,)): (int, (int,))"
+  output: "(TupleCons 100 (TupleCons 100)) : (TupleTy (IntTy) (TupleTy (IntTy)))"
 """
 (TupleCons (IntVal 100) (TupleCons (IntVal 100)))

--- a/tests/expr/t02_unit_constructor.test
+++ b/tests/expr/t02_unit_constructor.test
@@ -1,4 +1,4 @@
 discard """
-  output: "(): unit"
+  output: "(TupleCons) : (UnitTy)"
 """
 (TupleCons)

--- a/tests/expr/t02_unreachable.test
+++ b/tests/expr/t02_unreachable.test
@@ -1,4 +1,4 @@
 discard """
-  output: "runtime error: ecUnreachable"
+  output: "(Unreachable) : (VoidTy)"
 """
 (Unreachable)

--- a/tests/expr/t03_nested_calls.test
+++ b/tests/expr/t03_nested_calls.test
@@ -1,5 +1,5 @@
 discard """
-  output: "10: int"
+  output: "10 : (IntTy)"
 """
 (Call (Ident "+")
   (Call (Ident "+") (IntVal 1) (IntVal 2))

--- a/tests/expr/t03_tuple_access_1.test
+++ b/tests/expr/t03_tuple_access_1.test
@@ -1,5 +1,5 @@
 discard """
-  output: "100: int"
+  output: "100 : (IntTy)"
 """
 (FieldAccess
   (TupleCons (IntVal 100))

--- a/tests/expr/t03_tuple_access_2.test
+++ b/tests/expr/t03_tuple_access_2.test
@@ -1,5 +1,5 @@
 discard """
-  output: "10.5: float"
+  output: "10.5 : (FloatTy)"
 """
 (FieldAccess
   (TupleCons (IntVal 100) (FloatVal 10.5))

--- a/tests/expr/t03_tuple_access_3.test
+++ b/tests/expr/t03_tuple_access_3.test
@@ -1,5 +1,5 @@
 discard """
-  output: "(100,): (int,)"
+  output: "(TupleCons 100) : (TupleTy (IntTy))"
 """
 (FieldAccess
   (TupleCons

--- a/tests/expr/t03_unit_in_tuple.test
+++ b/tests/expr/t03_unit_in_tuple.test
@@ -1,4 +1,4 @@
 discard """
-  output: "((),): (unit,)"
+  output: "(TupleCons (TupleCons)) : (TupleTy (UnitTy))"
 """
 (TupleCons (TupleCons))

--- a/tests/expr/t04_proc_declaration.test
+++ b/tests/expr/t04_proc_declaration.test
@@ -1,5 +1,5 @@
 discard """
-  output: "(): unit"
+  output: "(TupleCons) : (UnitTy)"
 """
 (ProcDecl (Ident "a") (UnitTy) (Params)
   (Return))

--- a/tests/expr/t05_proc_with_bool_return_type.test
+++ b/tests/expr/t05_proc_with_bool_return_type.test
@@ -1,5 +1,5 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (ProcDecl (Ident "a") (BoolTy) (Params)
   (Return (Ident "true")))

--- a/tests/expr/t05_proc_with_float_return_type.test
+++ b/tests/expr/t05_proc_with_float_return_type.test
@@ -1,5 +1,5 @@
 discard """
-  output: "1.0: float"
+  output: "1.0 : (FloatTy)"
 """
 (ProcDecl (Ident "a") (FloatTy) (Params)
   (Return (FloatVal 1.0)))

--- a/tests/expr/t05_proc_with_int_return_type.test
+++ b/tests/expr/t05_proc_with_int_return_type.test
@@ -1,5 +1,5 @@
 discard """
-  output: "1: int"
+  output: "1 : (IntTy)"
 """
 (ProcDecl (Ident "a") (IntTy) (Params)
   (Return (IntVal 1)))

--- a/tests/expr/t05_proc_with_union_return_type.test
+++ b/tests/expr/t05_proc_with_union_return_type.test
@@ -1,5 +1,5 @@
 discard """
-  output: "(): union(unit, int)"
+  output: "(TupleCons) : (UnionTy (UnitTy) (IntTy))"
 """
 (ProcDecl (Ident "a") (UnionTy (UnitTy) (IntTy)) (Params)
   (Return))

--- a/tests/expr/t05_union_type_1.test
+++ b/tests/expr/t05_union_type_1.test
@@ -1,5 +1,5 @@
 discard """
-  output: "100: union(int, float)"
+  output: "100 : (UnionTy (IntTy) (FloatTy))"
 """
 (ProcDecl (Ident "a") (UnionTy (IntTy) (FloatTy)) (Params)
   (Return (IntVal 100)))

--- a/tests/expr/t05_union_type_2.test
+++ b/tests/expr/t05_union_type_2.test
@@ -1,5 +1,5 @@
 discard """
-  output: "1.5: union(int, float)"
+  output: "1.5 : (UnionTy (IntTy) (FloatTy))"
 """
 (ProcDecl (Ident "a") (UnionTy (IntTy) (FloatTy)) (Params)
   (Return (FloatVal 1.5)))

--- a/tests/expr/t05_union_type_of_single_type.test
+++ b/tests/expr/t05_union_type_of_single_type.test
@@ -1,5 +1,5 @@
 discard """
-  output: "100: union(int)"
+  output: "100 : (UnionTy (IntTy))"
 """
 (ProcDecl (Ident "a") (UnionTy (IntTy)) (Params)
   (Return (IntVal 100)))

--- a/tests/expr/t05_unreachable_is_void.test
+++ b/tests/expr/t05_unreachable_is_void.test
@@ -1,6 +1,6 @@
 discard """
   description: "Ensure that `Unreachable` is a void expression"
-  output: "runtime error: ecUnreachable"
+  output: "(Unreachable) : (VoidTy)"
 """
 (ProcDecl (Ident "a") (VoidTy) (Params)
   (Unreachable))

--- a/tests/expr/t06_call_proc_with_bool_return_type.test
+++ b/tests/expr/t06_call_proc_with_bool_return_type.test
@@ -1,5 +1,5 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Module
   (ProcDecl (Ident "a") (BoolTy) (Params)

--- a/tests/expr/t06_call_proc_with_float_return_type.test
+++ b/tests/expr/t06_call_proc_with_float_return_type.test
@@ -1,5 +1,5 @@
 discard """
-  output: "1.0: float"
+  output: "1.0 : (FloatTy)"
 """
 (Module
   (ProcDecl (Ident "a") (FloatTy) (Params)

--- a/tests/expr/t06_call_proc_with_int_return_type.test
+++ b/tests/expr/t06_call_proc_with_int_return_type.test
@@ -1,5 +1,5 @@
 discard """
-  output: "1: int"
+  output: "1 : (IntTy)"
 """
 (Module
   (ProcDecl (Ident "a") (IntTy) (Params)

--- a/tests/expr/t06_call_proc_with_tuple_return_type.test
+++ b/tests/expr/t06_call_proc_with_tuple_return_type.test
@@ -1,5 +1,5 @@
 discard """
-  output: "(100, 200): (int, int)"
+  output: "(TupleCons 100 200) : (TupleTy (IntTy) (IntTy))"
 """
 (Module
   (ProcDecl (Ident "a") (TupleTy (IntTy) (IntTy)) (Params)

--- a/tests/expr/t06_call_proc_with_unit_return_type.test
+++ b/tests/expr/t06_call_proc_with_unit_return_type.test
@@ -1,5 +1,5 @@
 discard """
-  output: "(): unit"
+  output: "(TupleCons) : (UnitTy)"
 """
 (Module
   (ProcDecl (Ident "a") (UnitTy) (Params)

--- a/tests/expr/t06_call_proc_with_void_return_type.test
+++ b/tests/expr/t06_call_proc_with_void_return_type.test
@@ -1,5 +1,5 @@
 discard """
-  output: "runtime error: ecUnreachable"
+  output: "(Unreachable) : (VoidTy)"
 """
 (Module
   (ProcDecl (Ident "a") (VoidTy) (Params)

--- a/tests/expr/t06_call_result_field_access.test
+++ b/tests/expr/t06_call_result_field_access.test
@@ -2,7 +2,7 @@ discard """
   description: "
     A call expression can be used directly as a field access operand
   "
-  output: "1: int"
+  output: "1 : (IntTy)"
 """
 (Module
   (ProcDecl p (TupleTy (IntTy)) (Params)

--- a/tests/expr/t06_declared_type_usage.test
+++ b/tests/expr/t06_declared_type_usage.test
@@ -1,5 +1,5 @@
 discard """
-  output: "100: int"
+  output: "100 : (IntTy)"
 """
 (Module
   (TypeDecl (Ident "int") (IntTy))

--- a/tests/expr/t08_if_expr_both_void.test
+++ b/tests/expr/t08_if_expr_both_void.test
@@ -1,4 +1,4 @@
 discard """
-  output: "runtime error: ecUnreachable"
+  output: "(Unreachable) : (VoidTy)"
 """
 (If (Ident "true") (Unreachable) (Unreachable))

--- a/tests/expr/t08_if_expr_else_void.test
+++ b/tests/expr/t08_if_expr_else_void.test
@@ -1,4 +1,4 @@
 discard """
-  output: "1: int"
+  output: "1 : (IntTy)"
 """
 (If (Ident "true") (IntVal 1) (Unreachable))

--- a/tests/expr/t08_if_expr_then_void.test
+++ b/tests/expr/t08_if_expr_then_void.test
@@ -1,4 +1,4 @@
 discard """
-  output: "-1: int"
+  output: "-1 : (IntTy)"
 """
 (If (Ident "false") (Unreachable) (IntVal -1))

--- a/tests/expr/t08_if_false.test
+++ b/tests/expr/t08_if_false.test
@@ -1,4 +1,4 @@
 discard """
-  output: "-1: int"
+  output: "-1 : (IntTy)"
 """
 (If (Ident "false") (IntVal 1) (IntVal -1))

--- a/tests/expr/t08_if_only_body_unit.test
+++ b/tests/expr/t08_if_only_body_unit.test
@@ -1,4 +1,4 @@
 discard """
-  output: "(): unit" 
+  output: "(TupleCons) : (UnitTy)"
 """
 (If (Ident "true") (TupleCons))

--- a/tests/expr/t08_if_only_body_void.test
+++ b/tests/expr/t08_if_only_body_void.test
@@ -1,5 +1,5 @@
 discard """
   description: "An if-then with void typed body is still a unit"
-  output: "(): unit"
+  output: "(TupleCons) : (UnitTy)"
 """
 (If (Ident "false") (Unreachable))

--- a/tests/expr/t08_if_true.test
+++ b/tests/expr/t08_if_true.test
@@ -1,4 +1,4 @@
 discard """
-  output: "1: int"
+  output: "1 : (IntTy)"
 """
 (If (Ident "true") (IntVal 1) (IntVal -1))

--- a/tests/expr/t09_asgn_compatible_type.test
+++ b/tests/expr/t09_asgn_compatible_type.test
@@ -1,5 +1,5 @@
 discard """
-  output: "1.5: union(int, float)"
+  output: "1.5 : (UnionTy (IntTy) (FloatTy))"
 """
 (Module
   (ProcDecl (Ident "union") (UnionTy (IntTy) (FloatTy)) (Params)

--- a/tests/expr/t09_asgn_field.test
+++ b/tests/expr/t09_asgn_field.test
@@ -1,5 +1,5 @@
 discard """
-  output: "(1,): (int,)"
+  output: "(TupleCons 1) : (TupleTy (IntTy))"
 """
 (Exprs
   (Decl (Ident "x") (TupleCons (IntVal 0)))

--- a/tests/expr/t09_asgn_local.test
+++ b/tests/expr/t09_asgn_local.test
@@ -1,5 +1,5 @@
 discard """
-  output: "1: int"
+  output: "1 : (IntTy)"
 """
 (Exprs
   (Decl (Ident "x") (IntVal 0))

--- a/tests/expr/t09_decl.test
+++ b/tests/expr/t09_decl.test
@@ -1,5 +1,5 @@
 discard """
-  output: "1: int"
+  output: "1 : (IntTy)"
 """
 (Exprs
   (Decl (Ident "x") (IntVal 1))

--- a/tests/expr/t09_decl_decl_with_same_name_in_initializer.test
+++ b/tests/expr/t09_decl_decl_with_same_name_in_initializer.test
@@ -1,5 +1,5 @@
 discard """
-  output: "200: int"
+  output: "200 : (IntTy)"
 """
 (Exprs
   (Decl (Ident "x")

--- a/tests/expr/t09_exprs_eval_order_1.test
+++ b/tests/expr/t09_exprs_eval_order_1.test
@@ -3,7 +3,7 @@ discard """
     The first expression in a list has its effects computed first, then the
     second, etc.
   "
-  output: "104: int"
+  output: "104 : (IntTy)"
 """
 (Exprs
   (Decl (Ident "x") (IntVal 100))

--- a/tests/expr/t09_exprs_eval_order_2.test
+++ b/tests/expr/t09_exprs_eval_order_2.test
@@ -3,7 +3,7 @@ discard """
     The first expression in a list has its effects computed first, then the
     second, etc.
   "
-  output: "4: int"
+  output: "4 : (IntTy)"
 """
 (Exprs
   (Decl (Ident "x") (IntVal 100))

--- a/tests/expr/t09_exprs_nested.test
+++ b/tests/expr/t09_exprs_nested.test
@@ -1,6 +1,6 @@
 discard """
   description: "correctly unwrap nested expressions"
-  output: "10: int"
+  output: "10 : (IntTy)"
 """
 
 (Exprs (Exprs (IntVal 10)))

--- a/tests/expr/t09_exprs_single_1.test
+++ b/tests/expr/t09_exprs_single_1.test
@@ -1,5 +1,5 @@
 discard """
-  output: "10: int"
+  output: "10 : (IntTy)"
 """
 
 (Exprs (IntVal 10))

--- a/tests/expr/t09_exprs_single_2.test
+++ b/tests/expr/t09_exprs_single_2.test
@@ -1,5 +1,5 @@
 discard """
-  output: "(): unit"
+  output: "(TupleCons) : (UnitTy)"
 """
 
 (Exprs (TupleCons))

--- a/tests/expr/t09_exprs_single_void.test
+++ b/tests/expr/t09_exprs_single_void.test
@@ -1,6 +1,6 @@
 discard """
   description: "An expression list can end in a `void` expression"
-  output: "runtime error: ecUnreachable"
+  output: "(Unreachable) : (VoidTy)"
 """
 
 (Exprs (Unreachable))

--- a/tests/expr/t09_exprs_trailing_void.test
+++ b/tests/expr/t09_exprs_trailing_void.test
@@ -1,6 +1,6 @@
 discard """
   description: "An expression list can end in a `void` expression"
-  output: "runtime error: ecUnreachable"
+  output: "(Unreachable) : (VoidTy)"
 """
 
 (Exprs (TupleCons) (Unreachable))

--- a/tests/expr/t09_exprs_valid_nonvoid.test
+++ b/tests/expr/t09_exprs_valid_nonvoid.test
@@ -1,6 +1,6 @@
 discard """
   description: "valid multi-item expression list"
-  output: "1.0: float"
+  output: "1.0 : (FloatTy)"
 """
 
 (Exprs (TupleCons) (FloatVal 1.0))

--- a/tests/expr/t09_exprs_valid_void.test
+++ b/tests/expr/t09_exprs_valid_void.test
@@ -1,6 +1,6 @@
 discard """
   description: "Valid expression list with a `void` earlier"
-  output: "runtime error: ecUnreachable"
+  output: "(Unreachable) : (VoidTy)"
 """
 
 (Exprs (Unreachable) (TupleCons) (FloatVal 1.0))

--- a/tests/expr/t10_asgn_eval_order_1.test
+++ b/tests/expr/t10_asgn_eval_order_1.test
@@ -3,7 +3,7 @@ discard """
     The actual assignment happens after both expressions had their effects
     computed.
   "
-  output: "6: int"
+  output: "6 : (IntTy)"
 """
 (Exprs
   (Decl (Ident "x") (IntVal 0))

--- a/tests/expr/t10_asgn_eval_order_2.test
+++ b/tests/expr/t10_asgn_eval_order_2.test
@@ -3,7 +3,7 @@ discard """
     The actual assignment happens after both expressions had their effects
     computed.
   "
-  output: "6: int"
+  output: "6 : (IntTy)"
 """
 (Exprs
   (Decl (Ident "x") (IntVal 0))

--- a/tests/expr/t10_asgn_eval_order_3.test
+++ b/tests/expr/t10_asgn_eval_order_3.test
@@ -2,7 +2,7 @@ discard """
   description: "
     The lhs expression has its effects computed before the rhs is evaluated
   "
-  output: "6: int"
+  output: "6 : (IntTy)"
 """
 (Exprs
   (Decl (Ident "x") (IntVal 0))

--- a/tests/expr/t10_asgn_lhs_must_be_lvalue_1.test
+++ b/tests/expr/t10_asgn_lhs_must_be_lvalue_1.test
@@ -1,6 +1,6 @@
 discard """
   description: "The name of a local is an l-value expression"
-  output: "(): unit"
+  output: "(TupleCons) : (UnitTy)"
 """
 (Exprs
   (Decl (Ident "x") (IntVal 1))

--- a/tests/expr/t10_asgn_lhs_must_be_lvalue_2.test
+++ b/tests/expr/t10_asgn_lhs_must_be_lvalue_2.test
@@ -3,7 +3,7 @@ discard """
     An expression list with a trailing l-value expression is an l-value
     expression
   "
-  output: "(): unit"
+  output: "(TupleCons) : (UnitTy)"
 """
 (Exprs
   (Decl (Ident "x") (IntVal 1))

--- a/tests/expr/t10_asgn_lhs_must_be_lvalue_3.test
+++ b/tests/expr/t10_asgn_lhs_must_be_lvalue_3.test
@@ -1,6 +1,6 @@
 discard """
   description: "A projection from an l-value is an l-value expression"
-  output: "(): unit"
+  output: "(TupleCons) : (UnitTy)"
 """
 (Exprs
   (Decl (Ident "x") (TupleCons (IntVal 1)))

--- a/tests/expr/t10_asgn_lhs_must_be_lvalue_8.test
+++ b/tests/expr/t10_asgn_lhs_must_be_lvalue_8.test
@@ -1,6 +1,6 @@
 discard """
   description: "A projection from an l-value is an l-value expression"
-  output: "(): unit"
+  output: "(TupleCons) : (UnitTy)"
 """
 (Exprs
   (Decl x (Seq (IntTy) 1 2 3))

--- a/tests/expr/t11_scopes_if_1.test
+++ b/tests/expr/t11_scopes_if_1.test
@@ -1,6 +1,6 @@
 discard """
   description: "Both If branches are part of their own scope"
-  output: "100: int"
+  output: "100 : (IntTy)"
 """
 (If (Ident "true")
   (Exprs

--- a/tests/expr/t12_and_result_1.test
+++ b/tests/expr/t12_and_result_1.test
@@ -1,4 +1,4 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (And (Ident "true") (Ident "true"))

--- a/tests/expr/t12_and_result_2.test
+++ b/tests/expr/t12_and_result_2.test
@@ -1,4 +1,4 @@
 discard """
-  output: "false: bool"
+  output: "(False) : (BoolTy)"
 """
 (And (Ident "true") (Ident "false"))

--- a/tests/expr/t12_and_result_3.test
+++ b/tests/expr/t12_and_result_3.test
@@ -1,4 +1,4 @@
 discard """
-  output: "false: bool"
+  output: "(False) : (BoolTy)"
 """
 (And (Ident "false") (Ident "true"))

--- a/tests/expr/t12_and_result_4.test
+++ b/tests/expr/t12_and_result_4.test
@@ -1,4 +1,4 @@
 discard """
-  output: "false: bool"
+  output: "(False) : (BoolTy)"
 """
 (And (Ident "false") (Ident "false"))

--- a/tests/expr/t12_and_scoping_1.test
+++ b/tests/expr/t12_and_scoping_1.test
@@ -3,7 +3,7 @@ discard """
     Declarations in the first operand expression are visible to the second
     operand.
   "
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Exprs
   (And

--- a/tests/expr/t12_and_short_circuit.test
+++ b/tests/expr/t12_and_short_circuit.test
@@ -3,7 +3,7 @@ discard """
     The second `And` operand expression is not evaluated when the first one
     evaluates to false.
   "
-  output: "100: int"
+  output: "100 : (IntTy)"
 """
 (Exprs
   (Decl (Ident "a") (IntVal 100))

--- a/tests/expr/t12_or_result_1.test
+++ b/tests/expr/t12_or_result_1.test
@@ -1,4 +1,4 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Or (Ident "true") (Ident "true"))

--- a/tests/expr/t12_or_result_2.test
+++ b/tests/expr/t12_or_result_2.test
@@ -1,4 +1,4 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Or (Ident "true") (Ident "false"))

--- a/tests/expr/t12_or_result_3.test
+++ b/tests/expr/t12_or_result_3.test
@@ -1,4 +1,4 @@
 discard """
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Or (Ident "false") (Ident "true"))

--- a/tests/expr/t12_or_result_4.test
+++ b/tests/expr/t12_or_result_4.test
@@ -1,4 +1,4 @@
 discard """
-  output: "false: bool"
+  output: "(False) : (BoolTy)"
 """
 (Or (Ident "false") (Ident "false"))

--- a/tests/expr/t12_or_scoping_1.test
+++ b/tests/expr/t12_or_scoping_1.test
@@ -3,7 +3,7 @@ discard """
     Declarations in the first operand expression are visible to the `Or`s
     second operand.
   "
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Exprs
   (Or

--- a/tests/expr/t12_or_short_circuit.test
+++ b/tests/expr/t12_or_short_circuit.test
@@ -3,7 +3,7 @@ discard """
     The second `Or` operand expression is not evaluated when the first one
     evaluates to true.
   "
-  output: "100: int"
+  output: "100 : (IntTy)"
 """
 (Exprs
   (Decl (Ident "a") (IntVal 100))

--- a/tests/expr/t13_proc_value_1.test
+++ b/tests/expr/t13_proc_value_1.test
@@ -1,5 +1,5 @@
 discard """
-  output: "...: proc() -> int"
+  output: "(proc ...) : (ProcTy (IntTy))"
 """
 (Module
   (ProcDecl (Ident "p") (IntTy) (Params)

--- a/tests/expr/t13_proc_value_2.test
+++ b/tests/expr/t13_proc_value_2.test
@@ -1,5 +1,5 @@
 discard """
-  output: "...: proc() -> void"
+  output: "(proc ...) : (ProcTy (VoidTy))"
 """
 (Module
   (ProcDecl (Ident "p") (VoidTy) (Params)

--- a/tests/expr/t13_proc_value_3.test
+++ b/tests/expr/t13_proc_value_3.test
@@ -1,5 +1,5 @@
 discard """
-  output: "100: int"
+  output: "100 : (IntTy)"
 """
 (Module
   (ProcDecl (Ident "p") (IntTy) (Params)

--- a/tests/expr/t13_usage_in_and.test
+++ b/tests/expr/t13_usage_in_and.test
@@ -1,6 +1,6 @@
 discard """
   description: "Make sure a local can be used as both `And` operands"
-  output: "false: bool"
+  output: "(False) : (BoolTy)"
 """
 (Exprs
   (Decl (Ident "a") (Ident "false"))

--- a/tests/expr/t13_usage_in_if_cond.test
+++ b/tests/expr/t13_usage_in_if_cond.test
@@ -1,6 +1,6 @@
 discard """
   description: "Make sure a local can be used as the `If` condition"
-  output: "(): unit"
+  output: "(TupleCons) : (UnitTy)"
 """
 (Exprs
   (Decl (Ident "a") (Ident "false"))

--- a/tests/expr/t13_usage_in_not.test
+++ b/tests/expr/t13_usage_in_not.test
@@ -1,6 +1,6 @@
 discard """
   description: "Make sure a local can be used as the `not` operand"
-  output: "true: bool"
+  output: "(True) : (BoolTy)"
 """
 (Exprs
   (Decl (Ident "a") (Ident "false"))

--- a/tests/expr/t13_usage_in_or.test
+++ b/tests/expr/t13_usage_in_or.test
@@ -1,6 +1,6 @@
 discard """
   description: "Make sure a local can be used as both `Or` operands"
-  output: "false: bool"
+  output: "(False) : (BoolTy)"
 """
 (Exprs
   (Decl (Ident "a") (Ident "false"))

--- a/tests/expr/t13_usage_in_return.test
+++ b/tests/expr/t13_usage_in_return.test
@@ -1,6 +1,6 @@
 discard """
   description: "Make sure a local can be used as the `Return` operand"
-  output: "100: int"
+  output: "100 : (IntTy)"
 """
 (ProcDecl (Ident "man") (IntTy) (Params)
   (Exprs

--- a/tests/expr/t14_parameters_aggregate_1.test
+++ b/tests/expr/t14_parameters_aggregate_1.test
@@ -1,6 +1,6 @@
 discard """
   description: "Make sure a procedure with a single aggregate parameter runs"
-  output: "(): unit"
+  output: "(TupleCons) : (UnitTy)"
 """
 (Module
   (ProcDecl (Ident "p") (UnitTy)

--- a/tests/expr/t14_parameters_aggregate_2.test
+++ b/tests/expr/t14_parameters_aggregate_2.test
@@ -3,7 +3,7 @@ discard """
     Make sure a procedure with an aggregate return value and aggregate
     parameter works
   "
-  output: "(30,): (int,)"
+  output: "(TupleCons 30) : (TupleTy (IntTy))"
 """
 (Module
   (ProcDecl (Ident "p") (TupleTy (IntTy))

--- a/tests/expr/t14_parameters_aggregate_3.test
+++ b/tests/expr/t14_parameters_aggregate_3.test
@@ -1,6 +1,6 @@
 discard """
   description: "Make sure a tuple parameter's field is accessible"
-  output: "30: int"
+  output: "30 : (IntTy)"
 """
 (Module
   (ProcDecl (Ident "p") (IntTy)

--- a/tests/expr/t14_parameters_eval_order_1.test
+++ b/tests/expr/t14_parameters_eval_order_1.test
@@ -3,7 +3,7 @@ discard """
     Make sure arguments are evaluated and bound to parameters in the correct
     order (left to right)
   "
-  output: "100: int"
+  output: "100 : (IntTy)"
 """
 (Module
   (ProcDecl (Ident "p") (IntTy)

--- a/tests/expr/t14_parameters_eval_order_2.test
+++ b/tests/expr/t14_parameters_eval_order_2.test
@@ -3,7 +3,7 @@ discard """
     Make sure arguments are evaluated and bound to parameters in the correct
     order (left to right)
   "
-  output: "200: int"
+  output: "200 : (IntTy)"
 """
 (Module
   (ProcDecl (Ident "p") (IntTy)

--- a/tests/expr/t14_parameters_primitive_1.test
+++ b/tests/expr/t14_parameters_primitive_1.test
@@ -1,5 +1,5 @@
 discard """
-  output: "100: int"
+  output: "100 : (IntTy)"
 """
 (Module
   (ProcDecl (Ident "p") (IntTy)

--- a/tests/expr/t14_parameters_primitive_2.test
+++ b/tests/expr/t14_parameters_primitive_2.test
@@ -1,5 +1,5 @@
 discard """
-  output: "200: int"
+  output: "200 : (IntTy)"
 """
 (Module
   (ProcDecl (Ident "p") (IntTy)

--- a/tests/expr/t14_parameters_scoping.test
+++ b/tests/expr/t14_parameters_scoping.test
@@ -3,7 +3,7 @@ discard """
     Parameter declarations are not visible outside of the procedures they're
     part of
   "
-  output: "(): unit"
+  output: "(TupleCons) : (UnitTy)"
 """
 (Module
   (ProcDecl (Ident "p") (UnitTy)

--- a/tests/expr/t15_while_1.test
+++ b/tests/expr/t15_while_1.test
@@ -3,7 +3,7 @@ discard """
     The body is evaluated repeatedly, as long as the condition evaluates
     to true
   "
-  output: "10: int"
+  output: "10 : (IntTy)"
 """
 (Exprs
   (Decl (Ident "repeat") (Ident "true"))

--- a/tests/expr/t15_while_2.test
+++ b/tests/expr/t15_while_2.test
@@ -1,6 +1,6 @@
 discard """
   description: "The condition expression is always evaluated at least once"
-  output: "10: int"
+  output: "10 : (IntTy)"
 """
 (Exprs
   (Decl (Ident "x") (IntVal 0))

--- a/tests/expr/t15_while_unit_body.test
+++ b/tests/expr/t15_while_unit_body.test
@@ -1,5 +1,5 @@
 discard """
-  output: "(): unit"
+  output: "(TupleCons) : (UnitTy)"
 """
 (While (Ident "false")
   (TupleCons))

--- a/tests/expr/t15_while_void_body.test
+++ b/tests/expr/t15_while_void_body.test
@@ -1,5 +1,5 @@
 discard """
-  output: "(): unit"
+  output: "(TupleCons) : (UnitTy)"
 """
 (While (Ident "false")
   (Unreachable))

--- a/tests/expr/t16_seq_construct_empty.test
+++ b/tests/expr/t16_seq_construct_empty.test
@@ -1,4 +1,4 @@
 discard """
-  output: "[]: seq(int)"
+  output: "(array) : (SeqTy (IntTy))"
 """
 (Seq (IntTy))

--- a/tests/expr/t16_seq_construct_non_empty.test
+++ b/tests/expr/t16_seq_construct_non_empty.test
@@ -1,4 +1,4 @@
 discard """
-  output: "[1, 2, 3]: seq(int)"
+  output: "(array 1 2 3) : (SeqTy (IntTy))"
 """
 (Seq (IntTy) 1 2 3)

--- a/tests/expr/t16_seq_construct_with_subtype.test
+++ b/tests/expr/t16_seq_construct_with_subtype.test
@@ -1,4 +1,4 @@
 discard """
-  output: "[1, 2.5, 3]: seq(union(int, float))"
+  output: "(array 1 2.5 3) : (SeqTy (UnionTy (IntTy) (FloatTy)))"
 """
 (Seq (UnionTy (IntTy) (FloatTy)) 1 2.5 3)

--- a/tests/expr/t16_seq_construct_with_unit.test
+++ b/tests/expr/t16_seq_construct_with_unit.test
@@ -1,4 +1,4 @@
 discard """
-  output: "[()]: seq(unit)"
+  output: "(array (TupleCons)) : (SeqTy (UnitTy))"
 """
 (Seq (UnitTy) (TupleCons))

--- a/tests/expr/t17_seq_at.test
+++ b/tests/expr/t17_seq_at.test
@@ -1,5 +1,5 @@
 discard """
-  output: "26: int"
+  output: "26 : (IntTy)"
 """
 (Exprs
   (Decl x (Seq (IntTy) 1 5 20))

--- a/tests/expr/t17_seq_at_eval_order_1.test
+++ b/tests/expr/t17_seq_at_eval_order_1.test
@@ -3,7 +3,7 @@ discard """
     The dynamic array access and index check happen after all non-lvalue
     operands in the enclosing lvalue expression were evaluated
   "
-  output: "2: int"
+  output: "2 : (IntTy)"
 """
 (Exprs
   (Decl x (Seq (IntTy)))

--- a/tests/expr/t17_seq_at_eval_order_2.test
+++ b/tests/expr/t17_seq_at_eval_order_2.test
@@ -3,7 +3,7 @@ discard """
     The dynamic array access and index check happen after all non-lvalue
     operands in the enclosing lvalue expression were evaluated
   "
-  output: "2: int"
+  output: "2 : (IntTy)"
 """
 (Exprs
   (Decl x (Seq (SeqTy (IntTy))))

--- a/tests/expr/t17_seq_at_out_of_bounds_1.test
+++ b/tests/expr/t17_seq_at_out_of_bounds_1.test
@@ -1,4 +1,4 @@
 discard """
-  output: "runtime error: ecUnreachable"
+  output: "(Unreachable) : (IntTy)"
 """
 (At (Seq (IntTy) 1) -1)

--- a/tests/expr/t17_seq_at_out_of_bounds_2.test
+++ b/tests/expr/t17_seq_at_out_of_bounds_2.test
@@ -1,4 +1,4 @@
 discard """
-  output: "runtime error: ecUnreachable"
+  output: "(Unreachable) : (IntTy)"
 """
 (At (Seq (IntTy) 1) 2)

--- a/tests/expr/t17_seq_concat_to_empty.test
+++ b/tests/expr/t17_seq_concat_to_empty.test
@@ -1,5 +1,5 @@
 discard """
-  output: "[1]: seq(int)"
+  output: "(array 1) : (SeqTy (IntTy))"
 """
 (Exprs
   (Decl x (Seq (IntTy)))

--- a/tests/expr/t17_seq_concat_to_non_empty.test
+++ b/tests/expr/t17_seq_concat_to_non_empty.test
@@ -1,5 +1,5 @@
 discard """
-  output: "[1, 2, 3, 4]: seq(int)"
+  output: "(array 1 2 3 4) : (SeqTy (IntTy))"
 """
 (Exprs
   (Decl x (Seq (IntTy) 1 2 3))

--- a/tests/expr/t17_seq_copy_1.test
+++ b/tests/expr/t17_seq_copy_1.test
@@ -1,5 +1,5 @@
 discard """
-  output: "[1, 2, 3]: seq(int)"
+  output: "(array 1 2 3) : (SeqTy (IntTy))"
 """
 (Exprs
   (Decl x (Seq (IntTy) 1 2 3))

--- a/tests/expr/t17_seq_copy_2.test
+++ b/tests/expr/t17_seq_copy_2.test
@@ -1,5 +1,5 @@
 discard """
-  output: "([1, 2, 3],): (seq(int),)"
+  output: "(TupleCons (array 1 2 3)) : (TupleTy (SeqTy (IntTy)))"
 """
 (Exprs
   (Decl x (Seq (IntTy) 1 2 3))

--- a/tests/expr/t17_seq_copy_3.test
+++ b/tests/expr/t17_seq_copy_3.test
@@ -1,5 +1,5 @@
 discard """
-  output: "[1, 2, 3]: union(int, seq(int))"
+  output: "(array 1 2 3) : (UnionTy (IntTy) (SeqTy (IntTy)))"
 """
 (Module
   (ProcDecl union (UnionTy (IntTy) (SeqTy (IntTy))) (Params)

--- a/tests/expr/t17_seq_copy_4.test
+++ b/tests/expr/t17_seq_copy_4.test
@@ -1,5 +1,5 @@
 discard """
-  output: "[[1, 2, 3]]: seq(seq(int))"
+  output: "(array (array 1 2 3)) : (SeqTy (SeqTy (IntTy)))"
 """
 (Exprs
   (Decl x (Seq (IntTy) 1 2 3))

--- a/tests/expr/t17_seq_len_empty.test
+++ b/tests/expr/t17_seq_len_empty.test
@@ -1,4 +1,4 @@
 discard """
-  output: "0: int"
+  output: "0 : (IntTy)"
 """
 (Call len (Seq (IntTy)))

--- a/tests/expr/t17_seq_len_non_empty.test
+++ b/tests/expr/t17_seq_len_non_empty.test
@@ -1,4 +1,4 @@
 discard """
-  output: "3: int"
+  output: "3 : (IntTy)"
 """
 (Call len (Seq (IntTy) 1 2 3))

--- a/tests/expr/t17_seq_nested_copy_1.test
+++ b/tests/expr/t17_seq_nested_copy_1.test
@@ -1,6 +1,6 @@
 discard """
   description: "Sequences part of tuples are fully copied when the tuple is"
-  output: "([1, 2, 3],): (seq(int),)"
+  output: "(TupleCons (array 1 2 3)) : (TupleTy (SeqTy (IntTy)))"
 """
 (Exprs
   (Decl x (TupleCons (Seq (IntTy) 1 2 3)))

--- a/tests/expr/t17_seq_nested_copy_2.test
+++ b/tests/expr/t17_seq_nested_copy_2.test
@@ -2,7 +2,7 @@ discard """
   description: "
     Sequences part of sequences are fully copied when the enclosing sequence is
   "
-  output: "[[1, 2, 3]]: seq(seq(int))"
+  output: "(array (array 1 2 3)) : (SeqTy (SeqTy (IntTy)))"
 """
 (Exprs
   (Decl x (Seq (SeqTy (IntTy)) (Seq (IntTy) 1 2 3)))

--- a/tests/expr/t17_seq_nested_copy_3.test
+++ b/tests/expr/t17_seq_nested_copy_3.test
@@ -1,6 +1,6 @@
 discard """
   description: "Sequences part of unions are fully copied when the union is"
-  output: "[1, 2, 3]: union(int, seq(int))"
+  output: "(array 1 2 3) : (UnionTy (IntTy) (SeqTy (IntTy)))"
 """
 (Module
   (ProcDecl union (UnionTy (IntTy) (SeqTy (IntTy))) (Params)

--- a/tests/expr/t18_seq_character_string_1.test
+++ b/tests/expr/t18_seq_character_string_1.test
@@ -1,4 +1,4 @@
 discard """
-  output: "['a', 'b', 'c']: seq(char)"
+  output: "(array (char 97) (char 98) (char 99)) : (SeqTy (CharTy))"
 """
 (Seq "abc")

--- a/tests/expr/t18_seq_character_string_2.test
+++ b/tests/expr/t18_seq_character_string_2.test
@@ -1,4 +1,4 @@
 discard """
-  output: "['a', '\\xCE', '\\xB2', 'c']: seq(char)"
+  output: "(array (char 97) (char 206) (char 178) (char 99)) : (SeqTy (CharTy))"
 """
 (Seq "aβc")

--- a/tests/expr/t19_write.test
+++ b/tests/expr/t19_write.test
@@ -1,4 +1,5 @@
 discard """
-  output: "test\n(): unit"
+  output.0: "test\n"
+  output.1: "(TupleCons) : (UnitTy)"
 """
 (Call write (Seq "test\n"))

--- a/tests/expr/t19_writeErr.test
+++ b/tests/expr/t19_writeErr.test
@@ -1,4 +1,5 @@
 discard """
-  output: "test\n(): unit"
+  output.0: "test\n"
+  output.1: "(TupleCons) : (UnitTy)"
 """
 (Call writeErr (Seq "test\n"))

--- a/tests/expr/t20_readFile.test
+++ b/tests/expr/t20_readFile.test
@@ -1,4 +1,4 @@
 discard """
-  output: "['a', 'b', '\\n', 'c', 'd', 'e']: seq(char)"
+  output: "(array (char 97) (char 98) (char 10) (char 99) (char 100) (char 101)) : (SeqTy (CharTy))"
 """
 (Call readFile (Seq "tests/expr/t20_file.txt"))

--- a/tests/expr/t20_readFile_missing.test
+++ b/tests/expr/t20_readFile_missing.test
@@ -1,5 +1,5 @@
 discard """
   description: "Reading from a non-existent file produces an empty sequence"
-  output: "[]: seq(char)"
+  output: "(array) : (SeqTy (CharTy))"
 """
 (Call readFile (Seq "doesn't exist"))

--- a/tools/tester.nim
+++ b/tools/tester.nim
@@ -403,6 +403,8 @@ proc runTest(desc: RunnerDesc, file: string): bool =
         break
     s.close()
 
+    var usesPositional = false
+      ## whether a positional output specification is used
     var parser: CfgParser
     open(parser, newStringStream(lines), file, 1)
     while true:
@@ -414,14 +416,33 @@ proc runTest(desc: RunnerDesc, file: string): bool =
           discard "ignored; only exists for informative purposes"
         of "knownIssue":
           spec.knownIssue = some evt.value
-        of "output":
-          spec.expected.add:
-            OutputSpec(fromFile: false,
-                       output: strip(evt.value, leading=true, trailing=false))
         of "arguments":
           spec.arguments = split(evt.value, ' ')
         of "reject":
           spec.reject = parseBool(evt.value)
+        elif evt.key.startsWith("output"):
+          let output =
+            OutputSpec(fromFile: false,
+                       output: strip(evt.value, leading=true, trailing=false))
+          if evt.key == "output":
+            if usesPositional:
+              echo "cannot mix positional and non-positional 'output'"
+              return false
+            spec.expected.add output
+          else:
+            let i = find(evt.key, '.')
+            if i == -1:
+              echo "illformed 'output' key"
+              return false
+            elif not usesPositional and spec.expected.len > 0:
+              echo "cannot mix positional and non-positional 'output'"
+              return false
+
+            let at = parseInt(evt.key[(i + 1)..^1])
+            if at >= spec.expected.len:
+              spec.expected.grow(at + 1, OutputSpec())
+            spec.expected[at] = output
+            usesPositional = true
         else:
           echo "unknown key: ", evt.key
           return false

--- a/tools/tester.nim
+++ b/tools/tester.nim
@@ -434,6 +434,9 @@ proc runTest(desc: RunnerDesc, file: string): bool =
             if i == -1:
               echo "illformed 'output' key"
               return false
+            elif i == evt.key.high:
+              echo "illformed 'output' key: dot must be followed by number"
+              return false
             elif not usesPositional and spec.expected.len > 0:
               echo "cannot mix positional and non-positional 'output'"
               return false

--- a/tools/tester.nim
+++ b/tools/tester.nim
@@ -441,7 +441,11 @@ proc runTest(desc: RunnerDesc, file: string): bool =
               echo "cannot mix positional and non-positional 'output'"
               return false
 
-            let at = parseInt(evt.key[(i + 1)..^1])
+            let at =
+              try: parseInt(evt.key[(i + 1)..^1])
+              except ValueError:
+                echo "illformed 'output' key: not a number"
+                return false
             if at >= spec.expected.len:
               spec.expected.grow(at + 1, OutputSpec())
             spec.expected[at] = output


### PR DESCRIPTION
## Summary

* show program result value and its type as S-expression (easier to
  process)
* support positional output specs (e.g., `output.0: ...`) in test
  specification
* separate program output from `phy` output when in runner mode

## Details

* return an S-expression-based representation of the result (value and
  type) from `vmexec.run`. It matches how the value would be represented
  in the source language definition
* when in runner mode, separate the program output (i.e., text written
  to the output and error stream) from the value + type, so that both
  count as separate fragments for the tester and can be compared
  independently
* support positional output specs in test specification to make it
  possible to provide the expected string for leading fragments
  directly, without the need to use `.expected` files
* update the `expr` tests' `output` specifications

The output is now much easier to parse programmatically.

---

## Notes For Reviewers
* a preparation for the source language specification tests