### PR TITLE
langdefs: improve function syntax

### DIFF
--- a/languages/source.nim
+++ b/languages/source.nim
@@ -102,9 +102,9 @@ const lang* = language:
     FieldAccess(le, IntVal(n))
     At(le, IntVal(n))
 
-  function desugar, expr -> e:
+  func desugar(a: expr) -> e =
     # FIXME: the sub-expressions need to be desugared too!
-    case _
+    case a
     of And(expr_1, expr_2):
       If(expr_1, expr_2, Ident("false"))
     of Or(expr_1, expr_2):
@@ -137,9 +137,9 @@ const lang* = language:
       condition typ_1 in typ_2
       conclusion typ_1, UnionTy(+typ_2)
 
-  function `==`, (typ, typ) -> bool:
+  func `==`(a, b: typ) -> bool =
     ## Except for union types, all type equality uses *structural equality*.
-    case _
+    case (a, b)
     of UnionTy(+typ_1), UnionTy(+typ_2):
       if (for typ_3 in typ_1: contains(typ_2, typ_3)):
         if (for typ_3 in typ_2: contains(typ_1, typ_3)):
@@ -148,13 +148,10 @@ const lang* = language:
           false
       else:
         false
-    of typ_1, typ_2:
-      same(typ_1, typ_2) # same structure, equal type
+    else:
+      same(a, b) # same structure -> equivalent type
 
-  function `!=`, (typ, typ) -> bool:
-    case _
-    of typ_1, typ_2:
-      not(typ_1 == typ_2)
+  func `!=`(a, b: typ) -> bool = not(a == b)
 
   inductive `<:=`(inp typ, inp typ):
     ## :math:`<:=` is the "sub or equal type" operator.
@@ -174,17 +171,15 @@ const lang* = language:
   record C, (symbols: (string -> typ), ret: typ)
   ## :math:`C` is the symbol environment.
 
-  function common, (typ, typ) -> typ:
+  func common(a, b: typ) -> typ =
     ## Computes the closest common ancestor type for a type pair. The function
     ## is not total, as not all two types have a common ancestor type.
-    case _
-    of typ_1, typ_2:
-      if typ_1 == typ_2:     typ_1
+    if a == b:     a
+    else:
+      if a <: b:   b
       else:
-        if typ_1 <: typ_2:   typ_2
-        else:
-          if typ_2 <: typ_1: typ_1
-          else:              fail # no common type
+        if b <: a: a
+        else:      fail # no common type
 
   inductive ttypes(inp C, inp texpr, out typ):
     axiom "S-void-type",        C, VoidTy(),  VoidTy()
@@ -226,8 +221,8 @@ const lang* = language:
     {"==", "<=", "<", "+", "-", "*", "div", "mod", "true", "false", "write",
      "writeErr", "readFile"}
 
-  function stripMut, typ -> typ:
-    case _
+  func stripMut(t: typ) -> typ =
+    case t
     of mut(typ_1): typ_1
     of typ_1:      typ_1
 
@@ -237,8 +232,8 @@ const lang* = language:
       premise types(C_1, e_1, typ_1)
       conclusion C_1, e_1, stripMut(typ_1)
 
-  function isType, typ -> bool:
-    case _
+  func isType(t: typ) -> bool =
+    case t
     of type(typ): true
     of typ:       false
 
@@ -506,82 +501,76 @@ const lang* = language:
   ## Auxiliary Functions
   ## ~~~~~~~~~~~~~~~~~~~
 
-  function substitute, (e, (string -> e)) -> e:
+  func substitute(a: expr, with: string -> e) -> e =
     ## The substitution function, which handles binding values/expressions to
     ## identifiers. Identifiers cannot be shadowed.
-    case _
-    of Exprs(+e_1), any_1:
-      Exprs(...(substitute(e_1, any_1)))
-    of Let(ident_1, e_1, e_2), any_1:
-      Let(ident_1, substitute(e_1, any_1), substitute(e_2, any_1))
-    of If(e_1, e_2, e_3), any_1:
-      If(substitute(e_1, any_1), substitute(e_2, any_1), substitute(e_3, any_1))
-    of Call(+e_1), any_1:
-      Call(...substitute(e_1, any_1))
-    of Asgn(e_1, e_2), any_1:
-      Asgn(substitute(e_1, any_1), substitute(e_2, any_1))
-    of TupleCons(*e_1), any_1:
-      TupleCons(...substitute(e_1, any_1))
-    of Seq(texpr, *e_1), any_1:
-      Seq(texpr, ...substitute(e_1, any_1))
-    of FieldAccess(e_1, IntVal(z_1)), any_1:
-      FieldAccess(substitute(e_1, any_1), IntVal(z_1))
-    of At(e_1, e_2), any_1:
-      At(substitute(e_1, any_1), substitute(e_2, any_1))
-    of While(e_1, e_2), any_1:
-      While(substitute(e_1, any_1), substitute(e_2, any_1))
-    of Return(e_1), any_1:
-      Return(substitute(e_1, any_1))
-    of Ident(string_1), any_1:
+    case a
+    of Exprs(+e_1):
+      Exprs(...(substitute(e_1, with)))
+    of Let(ident_1, e_1, e_2):
+      Let(ident_1, substitute(e_1, with), substitute(e_2, with))
+    of If(e_1, e_2, e_3):
+      If(substitute(e_1, with), substitute(e_2, with), substitute(e_3, with))
+    of Call(+e_1):
+      Call(...substitute(e_1, with))
+    of Asgn(e_1, e_2):
+      Asgn(substitute(e_1, with), substitute(e_2, with))
+    of TupleCons(*e_1):
+      TupleCons(...substitute(e_1, with))
+    of Seq(texpr_1, *e_1):
+      Seq(texpr_1, ...substitute(e_1, with))
+    of FieldAccess(e_1, IntVal(z_1)):
+      FieldAccess(substitute(e_1, with), IntVal(z_1))
+    of At(e_1, e_2):
+      At(substitute(e_1, with), substitute(e_2, with))
+    of While(e_1, e_2):
+      While(substitute(e_1, with), substitute(e_2, with))
+    of Return(e_1):
+      Return(substitute(e_1, with))
+    of Ident(string_1):
       # the actual substitution
-      if string_1 in any_1:
-        any_1(string_1)
+      if string_1 in with:
+        with(string_1)
       else:
         Ident(string_1)
-    of e_1, _:
+    of e_1:
       e_1 # nothing to replace
 
-  function trunc, r -> n:
+  func trunc(a : r) -> n
     ## Round towards zero.
 
-  function intAdd, (n, n) -> n:
-    case _
-    of n_1, n_2:
-      let n_3 = n_1 + n_2
-      if n_3 <= (2 ^ 63):
-        if n_3 < (2 ^ 63):
-          n_3
-        else:
-          fail
+  func intAdd(a, b: n) -> n =
+    let n_3 = a + b
+    if n_3 <= (2 ^ 63):
+      if n_3 < (2 ^ 63):
+        n_3
       else:
         fail
+    else:
+      fail
 
-  function intSub, (n, n) -> n:
-    case _
-    of n_1, n_2:
-      let n_3 = n_1 - n_2
-      if n_3 <= (2 ^ 63):
-        if n_3 < (2 ^ 63):
-          n_3
-        else:
-          fail
+  func intSub(a, b: n) -> n =
+    let n_3 = a - b
+    if n_3 <= (2 ^ 63):
+      if n_3 < (2 ^ 63):
+        n_3
       else:
         fail
+    else:
+      fail
 
-  function intMul, (n, n) -> n:
-    case _
-    of n_1, n_2:
-      let n_3 = n_1 * n_2
-      if n_3 <= (2 ^ 63):
-        if n_3 < (2 ^ 63):
-          n_3
-        else:
-          fail
+  func intMul(a, b: n) -> n =
+    let n_3 = a * b
+    if n_3 <= (2 ^ 63):
+      if n_3 < (2 ^ 63):
+        n_3
       else:
         fail
+    else:
+      fail
 
-  function intDiv, (n, n) -> n:
-    case _
+  func intDiv(a, b: n) -> n =
+    case (a, b)
     of n_1, 0: fail
     of n_1, n_2:
       if same(n_1, (-2 ^ 63)):
@@ -592,26 +581,24 @@ const lang* = language:
       else:
         trunc(n_1 / n_2)
 
-  function intMod, (n, n) -> n:
-    case _
+  func intMod(a, b: n) -> n =
+    case (a, b)
     of n_1, 0: fail
     of n_1, n_2: n_1 - (n_2 * trunc(n_1 / n_2))
 
-  function floatAdd, (r, r) -> r:
+  func floatAdd(a, b: r) -> r
     ## XXX: not defined
-  function floatSub, (r, r) -> r:
+  func floatSub(a, b: r) -> r
     ## XXX: not defined
 
-  function valEq, (val, val) -> val:
-    case _
-    of val_1, val_2:
-      if same(val_1, val_2):
-        True
-      else:
-        False
+  func valEq(a, b: val) -> val =
+    if same(a, b):
+      True
+    else:
+      False
 
-  function lt, (val, val) -> val:
-    case _
+  func lt(a, b: val) -> val =
+    case (a, b)
     of IntVal(n_1), IntVal(n_2):
       if n_1 < n_2: True
       else:         False
@@ -619,13 +606,11 @@ const lang* = language:
       if r_1 < r_2: True
       else:         False
 
-  function lessEqual, (val, val) -> val:
-    case _
-    of val_1, val_2:
-      if same(valEq(val_1, val_2), True):
-        True
-      else:
-        lt(val_1, val_2)
+  func lessEqual(a, b: val) -> val =
+    if same(valEq(a, b), True):
+      True
+    else:
+      lt(a, b)
 
   # TODO: the floating-point operations need to be defined according to the
   #       IEEE 754.2008 standard
@@ -638,14 +623,14 @@ const lang* = language:
               files: ((string, z) -> val)} # name + time -> content
   ## `DC` is the dynamic context
 
-  function copy, (DC, val) -> val:
+  func copy(c: DC, v: val) -> val =
     ## The `copy` function takes a context and value and maps them to a value
     ## that is neither a location nor contains any.
-    case _
-    of DC_1, loc(z_1): copy(DC_1, DC_1.locs(z_1))
-    of DC, val_1:      val_1
+    case v
+    of loc(z_1): copy(c, c.locs(z_1))
+    of val_1:    val_1
 
-  function utf8Bytes, string -> *z:
+  func utf8Bytes(_: string) -> *z
     # TODO: the function is mostly self-explanatory, but it should be defined in
     #       a bit more detail nonetheless
     ##
@@ -903,26 +888,26 @@ const lang* = language:
   # ------------
   # boilerplate functions that should rather not exist
 
-  function `not`, bool -> bool:
-    case _
+  func `not`(b: bool) -> bool =
+    case b
     of true: false
     of false: true
 
   # XXX: the built-in `in` function should consider the custom equality
   #      operator, which would render `contains` obsolete
-  function contains, (*typ, typ) -> bool:
-    case _
-    of [typ_1, *typ_2], typ_3:
-      if typ_1 == typ_3:
+  func contains(list: *typ, t: typ) -> bool =
+    case list
+    of [typ_1, *typ_2]:
+      if typ_1 == t:
         true
       else:
-        contains(typ_2, typ_3)
+        contains(typ_2, t)
     of _:
       false
 
-  function uniqueTypes, *typ -> bool:
+  func uniqueTypes(list: *typ) -> bool =
     ## Computes whether all types in the list are unique.
-    case _
+    case list
     of [typ_1, +typ_2]:
       if not contains(typ_2, typ_1):
         uniqueTypes(typ_2)
@@ -931,9 +916,9 @@ const lang* = language:
     of _:
       true
 
-  function unique, *string -> bool:
+  func unique(list: *string) -> bool =
     ## Computes whether all strings in the list are unique.
-    case _
+    case list
     of [string_1, +string_2]:
       if string_1 notin string_2:
         unique(string_2)

--- a/languages/source.nim
+++ b/languages/source.nim
@@ -517,8 +517,8 @@ const lang* = language:
       Asgn(substitute(e_1, with), substitute(e_2, with))
     of TupleCons(*e_1):
       TupleCons(...substitute(e_1, with))
-    of Seq(texpr_1, *e_1):
-      Seq(texpr_1, ...substitute(e_1, with))
+    of Seq(texpr, *e_1):
+      Seq(texpr, ...substitute(e_1, with))
     of FieldAccess(e_1, IntVal(z_1)):
       FieldAccess(substitute(e_1, with), IntVal(z_1))
     of At(e_1, e_2):

--- a/spec/langdefs.nim
+++ b/spec/langdefs.nim
@@ -1451,7 +1451,7 @@ proc semType(c; body: NimNode, self: Type; base = Type(nil)) =
     do:
       c.lookup[name] = sym
 
-proc semBody(c; n: NimNode, typ, input: Type): Node
+proc semBody(c; n: NimNode, typ: Type, top: bool): Node
 
 proc restore(c; start: int) =
   # collect the names of the vars to remove:
@@ -1465,19 +1465,13 @@ proc restore(c; start: int) =
 
 proc semScopedBody(c; n: NimNode, typ: Type): Node =
   var start = c.vars.len
-  result = semBody(c, n, typ, nil)
+  result = semBody(c, n, typ, false)
   c.restore(start)
 
-proc semCase(c; n: NimNode, typ: Type, input: Type): Node =
+proc semCase(c; n: NimNode, typ: Type): Node =
   ## Analyzes and type-checks a ``case`` expression.
-  var input = input
-  if input.isNil:
-    result = tree(nkMatch, semExpr(c, n[0]))
-    input = result[0].typ
-  else:
-    if n[0].kind != nnkIdent or n[0].strVal != "_":
-      error("selector of top-level 'case' must be '_'", n[0])
-    result = tree(nkMatch, Node(kind: nkHole))
+  result = tree(nkMatch, semExpr(c, n[0]))
+  let input = result[0].typ
 
   for i in 1..<n.len:
     let b = n[i]
@@ -1516,31 +1510,35 @@ proc semCase(c; n: NimNode, typ: Type, input: Type): Node =
     else:
       error("expected 'else' or 'of' branch", b)
 
-    o.add semBody(c, b[^1], typ, nil)
+    o.add semBody(c, b[^1], typ, false)
     result.add o
     # branches introduce a new scope:
     c.restore(start)
 
-proc semBody(c; n: NimNode, typ, input: Type): Node =
+proc semBody(c; n: NimNode, typ: Type, top: bool): Node =
   ## Analyzes a tree appearing somwhere nested in a function body. `typ` is
-  ## the expected expression's expected type, `input` the type of the implicit
-  ## argument to a case expression (nil means no implicit argument).
+  ## the expected expression's expected type, and `top` signals whether it's a
+  ## top-level expression the type of the implicit.
   case n.kind
   of nnkStmtList:
     var stmts: seq[Node]
-    for i in 0..<n.len-1:
+    # skip leading comments:
+    var start = 0
+    while top and start < n.len and n[start].kind == nnkCommentStmt:
+      inc start
+    # process the leading 'let' statements:
+    for i in start..<n.len-1:
       if n[i].kind == nnkLetSection:
         stmts.add semLet(c, n[i])
       else:
         error("expected 'let' statement", n[i])
-    # no longer a top-level statement, so pass nil as the input type
-    result = semBody(c, n[^1], typ, nil)
+    result = semBody(c, n[^1], typ, top)
     if stmts.len > 0:
       # lower the let statements into nested match expressions
       for i in countdown(stmts.high, 0):
         result = tree(nkMatch, stmts[i][1], tree(nkOf, stmts[i][0], result))
   of nnkCaseStmt:
-    result = semCase(c, n, typ, input)
+    result = semCase(c, n, typ)
   of nnkIfStmt, nnkIfExpr:
     if n.len > 1 and n[1].kind == nnkElifBranch:
       error("only if/else is supported", n[1])
@@ -1560,27 +1558,62 @@ proc semBody(c; n: NimNode, typ, input: Type): Node =
     # must be a normal term
     result = receive(c, n, typ)
 
-proc semFunction(c; def: NimNode): Function[Type] =
+proc semFunctionHeader(c; params: NimNode): Type =
+  ## Constructs the function type using the parameter list.
+  params.expectKind nnkFormalParams
+  if params.len == 1:
+    error("functions must have at least one parameter", params)
+
+  var args: seq[Type]
+  # check and gather the parameters first:
+  for i in 1..<params.len:
+    let def = params[i]
+    def.expectKind nnkIdentDefs
+    if def[^1].kind != nnkEmpty:
+      error("default values are disallowed", def[^1])
+    # no parameter type is interpreted as meaning "accepts everything"
+    let typ =
+      if def[^2].kind == nnkEmpty:
+        Type(kind: tkAll)
+      else:
+        parseTypeUse(c, def[^2])
+
+    # the names are validated later, when registering the bindings
+    for _ in 0..<def.len-2:
+      args.add typ
+
+  # then assemble and return the function type:
+  if args.len == 1:
+    fntype(args[0], parseTypeUse(c, params[0]))
+  else:
+    fntype(tup(args), parseTypeUse(c, params[0]))
+
+proc semFunction(c; def: NimNode, sig: Type): Function[Type] =
   ## Analyzes and type-checks function definition `def`, producing the fully-
   ## typed definition.
-  result = Function[Type](name: $def[1])
-  var i = 0
-  # skip/parse the leading comment statements
-  while i < def[3].len and def[3][i].kind == nnkCommentStmt:
-    # TODO: handle
-    inc i
+  result = Function[Type](name: name(macros.name(def)))
+  let
+    body   = def.body
+    params = def.params
 
-  if i == def[3].len:
+  if body.kind == nnkEmpty:
     # empty function; this is currently allowed
     result.body = Node(kind: nkHole)
     return
 
-  let sig = parseTypeUse(c, def[2])
-  if sig.kind != tkFunc:
-    error("must be a function type", def[2])
+  # register the bindings for all parameters:
+  var branch = Node(kind: nkOf)
+  var paramIdx = 0
+  for i in 1..<params.len:
+    for j in 0..<params[i].len-2: # go over all identifiers
+      branch.add:
+        toPattern c.semBindingName(params[i][j], getParam(sig, paramIdx))
+      inc paramIdx
 
-  result.body = semBody(c, def[3][i], sig[1], sig[0])
+  branch.add semBody(c, body, sig[1], top=true)
+  result.body = tree(nkMatch, Node(kind: nkHole), branch)
   c.finalize(result.body)
+  c.flushVars()
 
 proc semRelationHeader(c; n: NimNode): Relation[Type] =
   ## Parses and checks the relation's signature from `n`.
@@ -1709,7 +1742,8 @@ macro language*(body: untyped): LangDef =
   # first pass: make sure the broad shape of `body` is correct and collect the
   # names of all symbols while looking for and reporting collisions
   for it in body.items:
-    if it.kind in nnkCallKinds:
+    case it.kind
+    of nnkCallKinds:
       it[0].expectKind nnkIdent
       case it[0].strVal
       of "inductive":
@@ -1725,11 +1759,6 @@ macro language*(body: untyped): LangDef =
         it.expectLen 4
         addSym(c, name(it[1]), it):
           Sym(kind: skType, typ: Type(kind: tkData))
-      of "function":
-        it.expectLen 4
-        addSym(c, name(it[1]), it):
-          Sym(kind: skFunc, id: c.functions.len)
-        c.functions.add Function[Type](name: name(it[1]))
       of "context":
         it.expectLen 3
         # use void as the type, so that an r-pattern can be used everywhere
@@ -1750,16 +1779,22 @@ macro language*(body: untyped): LangDef =
           Sym(kind: skDef, e: semExpr(c, it[2]))
       else:
         error(fmt"unknown declaration: '{it[0].strVal}'", it)
-    elif it.kind == nnkCommentStmt:
+    of nnkFuncDef:
+      addSym(c, name(macros.name(it)), it):
+        Sym(kind: skFunc, id: c.functions.len)
+      # only add a placeholder for now; it's replaced with a proper entry later
+      c.functions.add Function[Type]()
+    of nnkCommentStmt:
       # TODO: process
       discard
     else:
-      error("expected declaration or doc comment", it)
+      error("expected declaration, function, or doc comment", it)
 
   # second pass: process all type definitions, plus the signatures
   # of functions and relations
   for it in body.items:
-    if it.kind in nnkCallKinds:
+    case it.kind
+    of nnkCallKinds:
       case it[0].strVal
       of "inductive":
         let rel = semRelationHeader(c, it)
@@ -1785,12 +1820,15 @@ macro language*(body: untyped): LangDef =
             if f.name == name:
               error(fmt"field with name '{name}' already exists", ece[0])
           typ.fields.add (name, parseTypeUse(c, ece[1]))
-      of "function":
-        c.lookup[name(it[1])].typ = parseTypeUse(c, it[2])
+    of nnkFuncDef:
+      c.lookup[name(macros.name(it))].typ = semFunctionHeader(c, it.params)
+    else:
+      discard "nothing to do"
 
   # third pass: process the remaining declarations
   for it in body.items:
-    if it.kind in nnkCallKinds:
+    case it.kind
+    of nnkCallKinds:
       case it[0].strVal
       of "inductive":
         let id = c.lookup[name(it[1][0])].id
@@ -1804,8 +1842,9 @@ macro language*(body: untyped): LangDef =
           c.finalize(pat) # resolve type variables
           c.flushVars()
           c.matchers[id].patterns.add pat
-      of "function":
-        c.functions[c.lookup[name(it[1])].id] = semFunction(c, it)
+    of nnkFuncDef:
+      c.lookup.withValue name(macros.name(it)), val:
+        c.functions[val.id] = semFunction(c, it, val.typ)
     else:
       discard "nothing to do"
 


### PR DESCRIPTION
## Summary

* use native `func` syntax for function definitions, which allows for
  named parameters
* allow all valid meta-language identifiers to be used as `let` names
* support tuple unpacking in `let` statements
* adjust the source language definition to the new syntax

## Details

The changes are aimed at making it possible to express the same functions
in less code.

* replace the `function`-statement syntax with the native `func` syntax
* remove the `case _` construct, which is no longer needed now that
  there's named parameters
* implement scoping properly. Only the identifiers introduced within an
  `if`, `else`, and `of` branch are discarded at their end
* move all non-pattern binding introduction logic into the `addBinding`
  procedure
* disallow `_` as a forvar name (an identifier is currently required
  internally)

---

## Notes For Reviewers
* these are some improvements I gathered while working on the floating-point specification, which needs a lot of helper function