### PR TITLE
use arbitrary-precision integers in the meta language 

### DIFF
--- a/spec/bignums.nim
+++ b/spec/bignums.nim
@@ -1,0 +1,461 @@
+## Provides an arbitrary-precision integers type and the associated arithmetic,
+## logical, and comparison operators.
+
+import std/bitops
+
+type Bignum* = object
+  ## An arbitrary-precision integer.
+  limbs: seq[uint64]
+    ## * values are stored in the shortest possible two's complement
+    ##   representation
+    ## * a leading 0 limb is used to distinguish overflowing positive values
+    ##   from negative values
+    ## * the value '0' is represented by an empty list, so that
+    ##   `default(Bignum)` is a valid big number
+
+const
+  Zero* = Bignum()
+  Ten   = Bignum(limbs: @[10'u64])
+
+# convenience templates:
+template len(n: Bignum): int =
+  n.limbs.len
+template `[]`(n: Bignum, i: untyped): untyped =
+  n.limbs[i]
+template `[]=`(n: Bignum, i, val: untyped) =
+  n.limbs[i] = val
+
+proc last(n: Bignum): uint64 =
+  if n.len == 0: 0'u64
+  else:          n[^1]
+
+proc cons(limbs: varargs[uint64]): Bignum {.used.} =
+  ## Private helper function for use by unit tests.
+  Bignum(limbs: @limbs)
+
+proc adc(a, b: uint64, carry: bool): (uint64, bool) =
+  ## Add with carry bit. Returns the result and new carry bit.
+  let r1 = a + b
+  let r2 = r1 + uint64(ord(carry))
+  (r2, r2 < r1 or r1 < a)
+
+proc add(a, b: uint64): (uint64, bool) =
+  ## Add `a` and `b` and return the carry bit.
+  let r = a + b
+  (r, r < a)
+
+proc bignum*(x: SomeInteger): Bignum =
+  ## Converts `x` to a big number.
+  if x == 0:
+    Zero
+  else:
+    when x is int64:
+      Bignum(limbs: @[cast[uint64](x)])
+    elif x is SomeSignedInt:
+      Bignum(limbs: @[cast[uint64](int64(x))])
+    else:
+      if x shr 63 == 1:
+        Bignum(limbs: @[x, 0])
+      else:
+        Bignum(limbs: @[x])
+
+proc isNeg*(x: Bignum): bool =
+  ## Whether `x` is a negative number.
+  x.len > 0 and (x[^1] shr 63) == 1
+
+proc normalize(n: var Bignum, an, bn: bool, carry: bool) =
+  ## Normalizes the result of an addition (`n`). `an` and `bn` indicate
+  ## whether the operands were negative.
+  if carry and an == bn:
+    # only pos + pos and neg + neg can meaningfully overflow; the carry bit
+    # indicates a change in sign, otherwise
+    if an:
+      # if the MSB doesn't change, nothing needs to be extended
+      if (n.last shr 63) == 0:
+        n.limbs.add high(uint64)
+    else:
+      n.limbs.add 1'u64
+  elif n.isNeg:
+    if an == bn and not an:
+      # positive + positive can only be positive
+      n.limbs.add 0'u64
+    else:
+      # normalize; trim unnecessary ones
+      var i = n.len - 1
+      while i >= 1 and n[i] == high(uint64) and (n[i - 1] shr 63) == 1:
+        dec i
+      n.limbs.setLen(i + 1)
+  else:
+    # normalize; trim unnecessary zeros
+    var i = n.len - 1
+    while i >= 0 and n[i] == 0 and (i == 0 or (n[i - 1] shr 63) == 0):
+      dec i
+    n.limbs.setLen(i + 1)
+
+proc trimLastNeg(x: var Bignum) =
+  ## Removes the last limb if negative and superfluous.
+  if x.len > 1 and x.last == high(uint64) and (x[^2] shr 63) == 1:
+    x.limbs.shrink(x.len - 1)
+
+proc fastLog2*(a: Bignum): int =
+  ## Computes the integer binary logarithm.
+  if a.last == 0:
+    if a.len == 0: 0 else: (a.len - 1) * 64 - 1
+  else:
+    fastLog2(a.limbs[^1]) + (a.limbs.len - 1) * 64
+
+proc `+`*(a: sink Bignum, b: Natural): Bignum =
+  if a.len == 0:
+    # handle empty numbers
+    if b == 0: return a
+    else:      return bignum(b)
+
+  result = a
+  let wasNegative = result.isNeg
+  var overflow = cast[uint64](b)
+  var i = 0
+  while i < result.len and overflow != 0:
+    var carry: bool
+    (result[i], carry) = add(result[i], overflow)
+    overflow = ord(carry).uint64
+    inc i
+
+  normalize(result, wasNegative, false, overflow != 0)
+
+proc `+`*(a, b: Bignum): Bignum =
+  ## Arbitrary-precision integer addition.
+  if a.len < b.len:
+    return b + a
+  elif b.len == 0:
+    return a
+
+  # `a` is always the number with more limbs
+  result.limbs.newSeq(a.len)
+  var carry = false
+  var i = 0
+  # add the common limbs:
+  while i < b.len:
+    (result[i], carry) = adc(a[i], b[i], carry)
+    inc i
+  if b.isNeg:
+    # treat all missing bits as one
+    while i < a.limbs.len:
+      (result[i], carry) = adc(a[i], high(uint64), carry)
+      inc i
+  else:
+    # treat all missing bits as zero
+    while i < a.limbs.len:
+      (result[i], carry) = adc(a[i], 0, carry)
+      inc i
+
+  normalize(result, a.isNeg, b.isNeg, carry)
+
+proc `-`*(x: sink Bignum): Bignum =
+  ## Yields the two's complement of `x`.
+  let last = x.last
+  result = x
+  var carry = true
+  for val in result.limbs.mitems:
+    (val, carry) = add(not(val), uint64 ord(carry))
+
+  if (result.last shr 63) == 1 and (last shr 63) == 1:
+    # edge case: the two's complement of x is equal to x, but the value is
+    # positive now
+    result.limbs.add 0'u64
+  else:
+    # inverting can produce a superfluous last limb
+    trimLastNeg(result)
+
+proc `-`*(a, b: Bignum): Bignum =
+  ## Arbitrary-precision integer subtraction.
+  a + (-b)
+
+proc `shl`*(x: sink Bignum, by: int): Bignum =
+  ## Arithmetic left shift. The sign bit is extended.
+  if x.len == 0 or by == 0:
+    result = x
+  elif (by and 63) == 0:
+    # shift whole limbs
+    result = x
+    let by = by shr 6 # div 64
+    let L = result.len
+    result.limbs.setLen(L + by)
+    for i in countdown(L-1, 0):
+      result[i + by] = result[i]
+    # shift in zeros from the right:
+    for i in 0..<by:
+      result[i] = 0
+    # nothing to normalize, the leading zero already exists when needed
+  else:
+    let
+      wasNegative = x.isNeg
+      bias  = by shr 6
+      shift = by and 63
+    result.limbs.newSeq((fastLog2(x) + 64 + by) shr 6)
+    var overflow = 0'u64
+    for i, it in x.limbs.pairs:
+      result[i + bias] = overflow + (it shl shift)
+      overflow = it shr (64 - shift)
+
+    if overflow != 0:
+      result.limbs[x.limbs.len + bias] += overflow
+
+    if (result.last shr 63) == 1:
+      if not wasNegative:
+        # mark as unsigned
+        result.limbs.add 0
+    elif wasNegative:
+      # sign extend the high limb
+      result[^1] = cast[uint64](cast[int64](result[^1] shl (64-shift)) shr (64-shift))
+      result.trimLastNeg()
+
+proc `shr`*(x: sink Bignum, by: int): Bignum =
+  ## Arithmetic right shift.
+  if x.len == 0 or by == 0:
+    result = x
+  elif (by and 63) == 0:
+    # shift whole limbs
+    result = x
+    let
+      neg  = result.isNeg
+      bias = by shr 6 # div 64
+      L = result.len
+    for i in 0..<(result.len - bias):
+      result[i] = result[i + bias]
+    result.limbs.setLen(L - bias)
+
+    if result.len == 0 and neg:
+      # make sure `negative shr x` doesn't result in 0
+      result.limbs.add high(uint64)
+  else:
+    let
+      neg   = x.isNeg
+      shift = by and 63
+      bias  = by shr 6
+    result.limbs.newSeq((fastLog2(x) + 64 - by) shr 6)
+    var overflow = 0'u64
+    for i in countdown(x.limbs.high, bias):
+      if i - bias < result.len:
+        result[i - bias] = overflow + (x[i] shr shift)
+      overflow = x[i] shl (64 - shift)
+
+    if (result.last shr 63) == 1:
+      if not neg:
+        # mark as unsigned
+        result.limbs.add 0
+    elif neg:
+      # sign extend the high limb
+      result[^1] = cast[uint64](cast[int64](result[^1] shl shift) shr shift)
+      result.trimLastNeg()
+
+proc cmp*(a, b: Bignum): int =
+  if a.isNeg and not b.isNeg:
+    -1
+  elif not(a.isNeg) and b.isNeg:
+    1
+  elif a.len != b.len:
+    if a.isNeg:
+      b.len - a.len
+    else:
+      a.len - b.len
+  else:
+    # same length
+    for i in countdown(a.len - 1, 0):
+      if a[i] < b[i]:
+        return -1
+      elif a[i] > b[i]:
+        return 1
+    0
+
+proc `<`*(a, b: Bignum): bool =
+  ## Less-than comparison.
+  cmp(a, b) < 0
+
+proc `<=`*(a, b: Bignum): bool =
+  ## Less-than-or-equal comparison.
+  cmp(a, b) <= 0
+
+proc addShift(a: var Bignum, b: Bignum, by: int) =
+  ## Adds `b` shifted by `by` to `a`. Both numbers must be positive.
+  assert not b.isNeg
+  let start = by shr 6
+  let shift = by and 63
+
+  if a.len < b.len + start:
+    a.limbs.setLen(b.len + start)
+
+  var overflow = 0'u64
+  var i = 0
+  # add the common limbs:
+  while i < b.len:
+    var carry: bool
+    (a[i + start], carry) = add(a[start + i], b[i] shl shift)
+    var next = uint64 ord(carry)
+    (a[i + start], carry) = add(a[start + i], overflow)
+    next += uint64 ord(carry)
+    if shift != 0:
+      next += b[i] shr (64 - shift)
+      # ^^ cannot overflow, because the MSB is never set
+
+    overflow = next
+    inc i
+
+  # add the overflow to the remaining limbs:
+  while overflow != 0 and i < a.len:
+    var carry: bool
+    (a[i], carry) = add(a[i], overflow)
+    overflow = ord(carry).uint64
+    inc i
+
+  if overflow != 0:
+    a.limbs.add overflow
+  # adding a zero-limb for disambiguation is left to the callsite
+
+proc `*`*(a: Bignum, b: Natural): Bignum =
+  if a.len == 0 or b == 0:
+    return Zero
+  elif a.isNeg:
+    return -(-a * b)
+
+  # simple shift-and-add implementation
+  let last = fastLog2(b)
+  for i in 0..last:
+    if (b and (1 shl i)) != 0:
+      result.addShift(a, i)
+
+  if (result.last shr 63) == 1:
+    result.limbs.add 0'u64
+
+proc `*`*(a, b: Bignum): Bignum =
+  ## Arbitrary-precision integer multiplication.
+  if a.len == 0 or b.len == 0:
+    return Zero
+  elif b.isNeg:
+    return -(a * (-b))
+  elif a.isNeg:
+    return -(-a * b)
+
+  # simple shift-and-add implementation
+  let last = fastLog2(b)
+  for i in 0..last:
+    # limb: divide by 64
+    # bit:  modulo 64
+    if (b[i shr 6] and (1'u64 shl (i and 63))) != 0:
+      result.addShift(a, i)
+
+  if (result.last shr 63) == 1:
+    result.limbs.add 0'u64
+
+proc udivMod*(dividend, divisor: Bignum): (Bignum, Bignum) =
+  ## Arbitrary-precision division where the inputs have to be positive values.
+  ## Returns the quotient and remainder.
+  if divisor > dividend:
+    return (Zero, dividend)
+
+  # shift-subtract algorithm (refer to
+  # https://blog.segger.com/algorithms-for-division-part-2-classics)
+  var
+    quotient = Zero
+    remainder = dividend
+
+  let digits = fastLog2(dividend) - fastLog2(divisor)
+  var divisor = divisor shl digits
+
+  for _ in 0..digits:
+    quotient = quotient shl 1
+    if remainder >= divisor:
+      remainder = remainder - divisor
+      quotient = quotient + 1
+
+    divisor = divisor shr 1
+
+  result[0] = quotient
+  result[1] = remainder
+
+proc divMod*(dividend, divisor: Bignum): (Bignum, Bignum) =
+  ## Arbitrary-precision truncating integer division (sign of the remainder
+  ## matches that of the dividend).
+  let
+    ndivisor  = isNeg(divisor)
+    ndividend = isNeg(dividend)
+    a = if ndividend: -dividend else: dividend
+    b = if ndivisor:  -divisor  else: divisor
+  result = udivMod(a, b)
+  if ndivisor xor ndividend:
+    # the quotient must be negative
+    result[0] = -result[0]
+  if ndividend:
+    result[1] = -result[1]
+
+proc `div`*(a, b: Bignum): Bignum =
+  ## Arbitrary-precision truncating integer division.
+  divMod(a, b)[0]
+
+proc add*(result: var string; value: Bignum) =
+  ## Renders `value` to a string and appends it to `result`.
+  if value.len == 0:
+    result.add "0"
+    return
+
+  var value = value
+  let neg = isNeg(value)
+  if neg:
+    value = -value
+    result.add "-"
+
+  let start = result.len
+  while value != Zero:
+    let (q, r) = udivMod(value, Ten)
+    result.add "0123456789"[r.last]
+    value = q
+
+  # the characters are in the wrong order! reverse them by swapping
+  var
+    i = start
+    j = high(result)
+  while i < j:
+    swap(result[i], result[j])
+    i += 1
+    j -= 1
+
+proc `$`*(x: Bignum): string =
+  result.add(x)
+
+proc parseBignum*(x: string): Bignum =
+  ## Parses a big number from `x`.
+  var i = 0
+  if x[0] == '-':
+    inc i
+
+  while i < x.len and x[i] in {'0'..'9'}:
+    result = result * 10
+    result = result + (ord(x[i]) - ord('0'))
+    inc i
+
+  if x[0] == '-':
+    result = -result
+
+proc `'n`*(s: string): Bignum {.compiletime.} =
+  parseBignum(s)
+
+proc toInt*(n: Bignum): int64 =
+  ## Converts `n` to a 64-bit signed integer. `n` must be in range.
+  assert n.len <= 1
+  cast[int64](n.last)
+
+# some additional operators (also also present for normal integers) that build
+# upon the basic operators:
+
+proc succ*(x: sink Bignum): Bignum {.inline.} = x + 1
+proc pred*(x: sink Bignum): Bignum {.inline.} = x + -1'n
+
+proc `inc`*(a: var Bignum; b = 1) =
+  ## Increments `a` by `b`.
+  if b >= 0:
+    a = a + b
+  else:
+    a = a + bignum(b)
+
+template `..<`*(a, b: Bignum): Slice[Bignum] =
+  ## Constructs a half-open slice from `a` and `b`.
+  a .. pred(b)

--- a/spec/builtin.nim
+++ b/spec/builtin.nim
@@ -2,7 +2,7 @@
 ## be used by the interpreter.
 
 import std/tables
-import int128
+import bignums
 import types except Node
 
 type Node = types.Node[TypeId]
@@ -23,11 +23,11 @@ proc `==`*(a, b: Node): bool =
   else:
     false
 
-proc num(n: Node): Int128 =
+proc num(n: Node): Bignum =
   # TODO: all numbers should be treated as rational numbers by default
-  parseInt128(n.sym)
+  parseBignum(n.sym)
 
-proc makeNum(i: Int128): Node =
+proc makeNum(i: Bignum): Node =
   Node(kind: nkNumber, sym: $i)
 
 proc merge(a: var Node, b: Node) =
@@ -102,7 +102,7 @@ const arr = [
       Node(kind: nkNumber, sym: "1")
     else:
       var val = base
-      for _ in 1..<exponent.toInt:
+      for _ in 1'n..<exponent:
         val = val * base
       makeNum(val)
   ),

--- a/spec/manual.md
+++ b/spec/manual.md
@@ -7,9 +7,8 @@ with a focus on defining/describing the semantics of programming languages.
 ## Types
 
 There are three built-in primitive types:
-* `z` - the type of integer numbers (with a maximum range of a 128-bit signed
-  integer)
-* `r` - rational values (with an unspecified range)
+* `z` - integer numbers
+* `r` - rational numbers
 * `bool` - `true` and `false`
 
 There are some additional primitive types, such as `void` and `all`, but

--- a/tests/unittest/tbignums.nim
+++ b/tests/unittest/tbignums.nim
@@ -1,0 +1,283 @@
+discard """
+  description: "Tests for the 128-bit integer implementation"
+"""
+
+import spec/bignums {.all.}
+
+const Full = high(uint64) # all 64 bits are set
+
+# don't use 'n for early tests, as it relies on parsing, which itself relies
+# on working addition and multiplication
+proc bn(x: SomeInteger): Bignum =
+  bignum(x)
+
+block add_with_carry:
+  # test the internal add-with-carry implementation
+  doAssert adc(1, 1, false) == (2'u64, false)
+  doAssert adc(Full, 1, false) == (0'u64, true)
+  doAssert adc(Full, 0, true) == (0'u64, true)
+  doAssert adc(Full, 1, true) == (1'u64, true)
+  doAssert adc(Full, Full, false) == (Full shl 1, true)
+  doAssert adc(Full, Full, true)  == (Full, true)
+
+block negation:
+  doAssert -bn(0) == bn(0)
+  doAssert -bn(1) == bn(-1)
+  doAssert -bn(-1) == bn(1)
+  # negation creating an number overflowing the int64 range:
+  doAssert -bn(-9223372036854775808) == bn(9223372036854775808'u64)
+  # negation requiring limb normalization:
+  doAssert -bn(9223372036854775808'u64) == bn(-9223372036854775808)
+
+block basic_addition:
+  doAssert bn(0) + bn(0) == bn(0)
+  doAssert bn(10) + bn(10) == bn(20)
+  doAssert bn(-1) + bn(2) == bn(1) # negative + positive overflows to positive
+  doAssert bn(-1) + bn(1) == bn(0) # negative + positive overflows to zero
+  doAssert bn(1) + bn(-1) == bn(0) # positive + negative overflows to zero
+  doAssert bn(1) + bn(-2) == bn(-1) # positive + negative overflows to negative
+  doAssert bn(-1) + bn(-1) == bn(-2)
+  # edge case: result overflows 64-bit signed integer range without
+  # overflowing the 64-bit unsigned range
+  doAssert bn(9223372036854775807) + bn(1) == bn(9223372036854775808'u64)
+  # negative + negative overflows the limb:
+  doAssert bn(-9223372036854775808) + bn(-1) == -bn(9223372036854775809'u64)
+  # multi-limb addition that zeroes out:
+  doAssert -bn(9223372036854775809'u64) + bn(9223372036854775809'u64) == bn(0)
+  # larger + smaller with no carry:
+  doAssert cons(0, 1) + cons(1) == cons(1, 1)
+  doAssert cons(1) + cons(0, 1) == cons(1, 1)
+  # larger + smaller with carry:
+  doAssert cons(0b11'u64 shl 62, 0x1) + bn(1'u64 shl 62) == cons(0, 0b10)
+  doAssert bn(1'u64 shl 62) + cons(0b11'u64 shl 62, 1) == cons(0, 0b10)
+  # larger negative + smaller positive:
+  doAssert -bn(9223372036854775809'u64) + bn(1) == bn(-9223372036854775808)
+  doAssert bn(1) + -bn(9223372036854775809'u64) == bn(-9223372036854775808)
+  # larger positive + smaller negative:
+  doAssert bn(9223372036854775808'u64) + bn(-1) == bn(9223372036854775807)
+  doAssert bn(-1) + bn(9223372036854775808'u64) == bn(9223372036854775807)
+  # integration test for internal `adc` (add with carry):
+  const Large = cons(Full, Full, 0)
+  doAssert Large + Large == cons(Full shl 1, Full, 1)
+
+block basic_left_shift:
+  doAssert bn(0) shl 1 == bn(0)
+  doAssert bn(2) shl 0 == bn(2)
+  doAssert bn(2) shl 1 == bn(4)
+  # shift by power-of-64:
+  doAssert bn(1) shl 64 == cons(0, 1)
+  doAssert bn(1) shl 128 == cons(0, 0, 1)
+  # shift negative number:
+  doAssert bn(-1) shl 1 == bn(-2)
+  # shift negative number across limbs:
+  doAssert bn(-1) shl 65 == cons(0, cast[uint64](-2))
+  # shift by less than one limb, adding one new limb:
+  doAssert bn(0b1010) shl 62 == cons(9223372036854775808'u64, 0b10)
+  # shift by less than two limbs, adding two new limbs:
+  doAssert bn(0b1010) shl 126 == cons(0x0, 9223372036854775808'u64, 0b10)
+  # shift one into the MSL's MSB:
+  doAssert bn(1) shl 63 == bn(9223372036854775808'u64)
+  doAssert bn(1) shl 127 == cons(0, 9223372036854775808'u64, 0)
+
+block basic_right_shift:
+  doAssert bn(1) shr 0 == bn(1) # shift by zero
+  doAssert bn(0) shr 1 == bn(0) # shift zero
+  doAssert bn(-1) shr 1 == bn(-1)
+  doAssert bn(-6) shr 1 == bn(-3)
+  # shift a negative number by a full limb:
+  doAssert bn(-1) shr 64 == bn(-1)
+  # shift by less than two limbs, removing two limbs:
+  doAssert cons(0x0, (1'u64 shl 63), 0b10) shr 67 == bn(0b0101 shl 60)
+  # shift 1 into the MSL's MSB (negative input):
+  doAssert (bn(-1) shl 64)  shr  1 == bn(-9223372036854775808)
+  doAssert (bn(-1) shl 128) shr 65 == bn(-9223372036854775808)
+  # shift 1 into the MSL's MSB (positive input):
+  doAssert cons(0, 1)    shr  1 == bn(9223372036854775808'u64)
+  doAssert cons(0, 0, 1) shr 65 == bn(9223372036854775808'u64)
+
+block parsing:
+  doAssert parseBignum("0") == bn(0)
+  doAssert parseBignum("-0") == bn(0)
+  doAssert parseBignum("1") == bn(1)
+  doAssert parseBignum("-1") == bn(-1)
+  doAssert parseBignum("123456") == bn(123456)
+  doAssert parseBignum("-123456") == bn(-123456)
+
+var d: array[39, Bignum] ## array of powers of 10
+d[0] =  1'n
+d[1] =  10'n
+d[2] =  100'n
+d[3] =  1000'n
+d[4] =  10000'n
+d[5] =  100000'n
+d[6] =  1000000'n
+d[7] =  10000000'n
+d[8] =  100000000'n
+d[9] =  1000000000'n
+d[10] = 10000000000'n
+d[11] = 100000000000'n
+d[12] = 1000000000000'n
+d[13] = 10000000000000'n
+d[14] = 100000000000000'n
+d[15] = 1000000000000000'n
+d[16] = 10000000000000000'n
+d[17] = 100000000000000000'n
+d[18] = 1000000000000000000'n
+d[19] = 10000000000000000000'n
+d[20] = 100000000000000000000'n
+d[21] = 1000000000000000000000'n
+d[22] = 10000000000000000000000'n
+d[23] = 100000000000000000000000'n
+d[24] = 1000000000000000000000000'n
+d[25] = 10000000000000000000000000'n
+d[26] = 100000000000000000000000000'n
+d[27] = 1000000000000000000000000000'n
+d[28] = 10000000000000000000000000000'n
+d[29] = 100000000000000000000000000000'n
+d[30] = 1000000000000000000000000000000'n
+d[31] = 10000000000000000000000000000000'n
+d[32] = 100000000000000000000000000000000'n
+d[33] = 1000000000000000000000000000000000'n
+d[34] = 10000000000000000000000000000000000'n
+d[35] = 100000000000000000000000000000000000'n
+d[36] = 1000000000000000000000000000000000000'n
+d[37] = 10000000000000000000000000000000000000'n
+d[38] = 100000000000000000000000000000000000000'n
+
+block add_sub_test:
+  # test addition:
+  var sum: Bignum
+  for it in d.items:
+    sum = sum + it
+
+  doAssert sum == 111111111111111111111111111111111111111'n
+
+  # test subtraction:
+  for it in d.items:
+    sum = sum - it
+
+  doAssert sum == Zero
+
+# test comparison, multiplication, and division with positive nubers:
+for i, a in d.pairs:
+  for j, b in d.pairs:
+    doAssert(cmp(a, b) == cmp(i, j))
+    if i + j < d.len:
+      doAssert a * b == d[i + j]
+    if i - j >= 0:
+      doAssert a div b == d[i - j]
+
+# test comparison, multiplication, and division with negative nubers:
+for it in d.mitems:
+  it = -it
+
+for i, a in d.pairs:
+  for j, b in d.pairs:
+    doAssert(cmp(a, b) == -cmp(i, j))
+    if i + j < d.len:
+      doAssert a * b == -d[i + j]
+    if i - j >= 0:
+      doAssert a div b == -d[i - j]
+
+block sign_test:
+  # make sure the sign of quotients, remainders, and products is correct
+  let
+    a = 100'i64
+    b = 13
+
+  doAssert bignum(a) * bignum(0) == bignum(0)
+  doAssert bignum(-a) * bignum(0) == bignum(0)
+
+  template compare(a, b): bool =
+    divMod(bignum(a), bignum(b)) == (bignum(a div b), bignum(a mod b))
+
+  doAssert compare( a,  b)
+  doAssert compare(-a,  b)
+  doAssert compare(-a, -b)
+  doAssert compare( a, -b)
+
+  doAssert compare( b,  b)
+  doAssert compare(-b,  b)
+  doAssert compare(-b, -b)
+  doAssert compare( b, -b)
+
+  doAssert compare( b,  a)
+  doAssert compare(-b,  a)
+  doAssert compare(-b, -a)
+  doAssert compare( b, -a)
+
+# more tests for logical left and right shift:
+let e = 70997106675279150998592376708984375'n
+let rshifted = [
+  # toHex(e shr 0), toHex(e shr 1), toHex(e shr 2), toHex(e shr 3), ...
+  "000dac6d782d266a37300c32591eee37", "0006d636bc1693351b9806192c8f771b", "00036b1b5e0b499a8dcc030c9647bb8d", "0001b58daf05a4cd46e601864b23ddc6",
+  "0000dac6d782d266a37300c32591eee3", "00006d636bc1693351b9806192c8f771", "000036b1b5e0b499a8dcc030c9647bb8", "00001b58daf05a4cd46e601864b23ddc",
+  "00000dac6d782d266a37300c32591eee", "000006d636bc1693351b9806192c8f77", "0000036b1b5e0b499a8dcc030c9647bb", "000001b58daf05a4cd46e601864b23dd",
+  "000000dac6d782d266a37300c32591ee", "0000006d636bc1693351b9806192c8f7", "00000036b1b5e0b499a8dcc030c9647b", "0000001b58daf05a4cd46e601864b23d",
+  "0000000dac6d782d266a37300c32591e", "00000006d636bc1693351b9806192c8f", "000000036b1b5e0b499a8dcc030c9647", "00000001b58daf05a4cd46e601864b23",
+  "00000000dac6d782d266a37300c32591", "000000006d636bc1693351b9806192c8", "0000000036b1b5e0b499a8dcc030c964", "000000001b58daf05a4cd46e601864b2",
+  "000000000dac6d782d266a37300c3259", "0000000006d636bc1693351b9806192c", "00000000036b1b5e0b499a8dcc030c96", "0000000001b58daf05a4cd46e601864b",
+  "0000000000dac6d782d266a37300c325", "00000000006d636bc1693351b9806192", "000000000036b1b5e0b499a8dcc030c9", "00000000001b58daf05a4cd46e601864",
+  "00000000000dac6d782d266a37300c32", "000000000006d636bc1693351b980619", "0000000000036b1b5e0b499a8dcc030c", "000000000001b58daf05a4cd46e60186",
+  "000000000000dac6d782d266a37300c3", "0000000000006d636bc1693351b98061", "00000000000036b1b5e0b499a8dcc030", "0000000000001b58daf05a4cd46e6018",
+  "0000000000000dac6d782d266a37300c", "00000000000006d636bc1693351b9806", "000000000000036b1b5e0b499a8dcc03", "00000000000001b58daf05a4cd46e601",
+  "00000000000000dac6d782d266a37300", "000000000000006d636bc1693351b980", "0000000000000036b1b5e0b499a8dcc0", "000000000000001b58daf05a4cd46e60",
+  "000000000000000dac6d782d266a3730", "0000000000000006d636bc1693351b98", "00000000000000036b1b5e0b499a8dcc", "0000000000000001b58daf05a4cd46e6",
+  "0000000000000000dac6d782d266a373", "00000000000000006d636bc1693351b9", "000000000000000036b1b5e0b499a8dc", "00000000000000001b58daf05a4cd46e",
+  "00000000000000000dac6d782d266a37", "000000000000000006d636bc1693351b", "0000000000000000036b1b5e0b499a8d", "000000000000000001b58daf05a4cd46",
+  "000000000000000000dac6d782d266a3", "0000000000000000006d636bc1693351", "00000000000000000036b1b5e0b499a8", "0000000000000000001b58daf05a4cd4",
+  "0000000000000000000dac6d782d266a", "00000000000000000006d636bc169335", "000000000000000000036b1b5e0b499a", "00000000000000000001b58daf05a4cd",
+  "00000000000000000000dac6d782d266", "000000000000000000006d636bc16933", "0000000000000000000036b1b5e0b499", "000000000000000000001b58daf05a4c",
+  "000000000000000000000dac6d782d26", "0000000000000000000006d636bc1693", "00000000000000000000036b1b5e0b49", "0000000000000000000001b58daf05a4",
+  "0000000000000000000000dac6d782d2", "00000000000000000000006d636bc169", "000000000000000000000036b1b5e0b4", "00000000000000000000001b58daf05a",
+  "00000000000000000000000dac6d782d", "000000000000000000000006d636bc16", "0000000000000000000000036b1b5e0b", "000000000000000000000001b58daf05",
+  "000000000000000000000000dac6d782", "0000000000000000000000006d636bc1", "00000000000000000000000036b1b5e0", "0000000000000000000000001b58daf0",
+  "0000000000000000000000000dac6d78", "00000000000000000000000006d636bc", "000000000000000000000000036b1b5e", "00000000000000000000000001b58daf",
+  "00000000000000000000000000dac6d7", "000000000000000000000000006d636b", "0000000000000000000000000036b1b5", "000000000000000000000000001b58da",
+  "000000000000000000000000000dac6d", "0000000000000000000000000006d636", "00000000000000000000000000036b1b", "0000000000000000000000000001b58d",
+  "0000000000000000000000000000dac6", "00000000000000000000000000006d63", "000000000000000000000000000036b1", "00000000000000000000000000001b58",
+  "00000000000000000000000000000dac", "000000000000000000000000000006d6", "0000000000000000000000000000036b", "000000000000000000000000000001b5",
+  "000000000000000000000000000000da", "0000000000000000000000000000006d", "00000000000000000000000000000036", "0000000000000000000000000000001b",
+  "0000000000000000000000000000000d", "00000000000000000000000000000006", "00000000000000000000000000000003", "00000000000000000000000000000001",
+  "00000000000000000000000000000000", "00000000000000000000000000000000", "00000000000000000000000000000000", "00000000000000000000000000000000",
+  "00000000000000000000000000000000", "00000000000000000000000000000000", "00000000000000000000000000000000", "00000000000000000000000000000000",
+  "00000000000000000000000000000000", "00000000000000000000000000000000", "00000000000000000000000000000000", "00000000000000000000000000000000",
+]
+let lshifted = [
+  # toHex(e shl 0), toHex(e shl 1), toHex(e shl 2), toHex(e shl 3), ...
+  "dac6d782d266a37300c32591eee37", "1b58daf05a4cd46e601864b23ddc6e", "36b1b5e0b499a8dcc030c9647bb8dc", "6d636bc1693351b9806192c8f771b8"
+]
+
+proc toHex(i: Bignum): string =
+  var val = i
+  while val != Zero:
+    let (q, r) = udivMod(val, 16'n)
+    result.insert $"0123456789abcdef"[r.toInt]
+    val = q
+
+proc pad(x: sink string): string =
+  result = x
+  for _ in result.len..<32:
+    result.insert "0"
+
+for i in 0 ..< 128:
+  doAssert rshifted[i] == pad(toHex(e shr i))
+
+  var lsh = lshifted[i mod 4]
+  # append a zero for every 4 bit:
+  for _ in 0..<(i div 4):
+    lsh.add "0"
+  doAssert lsh == toHex(e shl i)
+
+block parse_stringify_roundtrip:
+  template test(str: string): bool = $parseBignum(str) == str
+
+  doAssert test("12345678987654321012345678987")
+  doAssert test("0")
+  # leading zeroes:
+  doAssert $parseBignum("0001") == "1"
+  doAssert $parseBignum("-0001") == "-1"
+  doAssert $parseBignum("-0") == "0"
+  # trailing zeroes:
+  doAssert test("10")
+  doAssert test("-10")

--- a/tests/unittest/tbignums.nim
+++ b/tests/unittest/tbignums.nim
@@ -158,7 +158,7 @@ block add_sub_test:
 
   doAssert sum == Zero
 
-# test comparison, multiplication, and division with positive nubers:
+# test comparison, multiplication, and division with positive numbers:
 for i, a in d.pairs:
   for j, b in d.pairs:
     doAssert(cmp(a, b) == cmp(i, j))
@@ -167,7 +167,7 @@ for i, a in d.pairs:
     if i - j >= 0:
       doAssert a div b == d[i - j]
 
-# test comparison, multiplication, and division with negative nubers:
+# test comparison, multiplication, and division with negative numbers:
 for it in d.mitems:
   it = -it
 


### PR DESCRIPTION
## Summary

* add a native `Bignum` implementation (`bignums.nim`)
* use `Bignum` for all arithmetic/comparison operations in the
  interpreter

## Details

A NimSkull-native `Bignum` implementation is used because:
* porting it to the source language in the future will be easier / can
  be automated
* the repository stays self-contained

Two explicit goals the implementation were that it's fully usable at
compile-time (in the VM) and that zero-initialized `Bignum`s are valid.
The implementation tries to strike a balance between complexity and
efficiency, usually preferring a simpler over a more efficient
implementation.

Using two's complement representation gets around having an extra sign
flag, which would increase the size of `Bignum`s by 8 byte (on a 64-bit
target).

Tests based on the `int128` tests are added for `Bignum`, with new
tests added for the various overflow/carry/extension scenarios.

---

## Notes For Reviewers
* a prerequisite for #119
* the `int128` module - while now unused - is kept because it'll likely be needed again in the future  