### PR TITLE
lang: allow non-void expressions as bodies

### DIFF
--- a/languages/source.nim
+++ b/languages/source.nim
@@ -471,7 +471,8 @@ const lang* = language:
       let typ_3 = ProcTy(typ_1, ...typ_2)
       let C_2 = C_1 + C(symbols: {string_1: typ_3})
       let C_3 = C_2 + C(ret: typ_1, symbols: map(zip(string_2, typ_2)))
-      premise types(C_3, e_1, VoidTy())
+      premise types(C_3, e_1, typ_4)
+      condition typ_4 <:= typ_1
       conclusion C_1, ProcDecl(Ident(string_1), texpr_1, Params(*ParamDecl(Ident(string_2), texpr_2)), e_1), C_2
 
     axiom "S-empty-module", C_1, Module(), C_1

--- a/tests/expr/spectest.nim
+++ b/tests/expr/spectest.nim
@@ -52,6 +52,7 @@ const
     "t05_proc_with_float_return_type.test",
     "t05_proc_with_int_return_type.test",
     "t05_proc_with_non_void_body.test",
+    "t05_proc_with_non_void_body_error.test",
     "t05_proc_with_non_void_body_subtype.test",
     "t05_proc_with_union_return_type.test",
     "t05_return_operand_cannot_be_void.test",

--- a/tests/expr/spectest.nim
+++ b/tests/expr/spectest.nim
@@ -51,6 +51,8 @@ const
     "t05_proc_with_bool_return_type.test",
     "t05_proc_with_float_return_type.test",
     "t05_proc_with_int_return_type.test",
+    "t05_proc_with_non_void_body.test",
+    "t05_proc_with_non_void_body_subtype.test",
     "t05_proc_with_union_return_type.test",
     "t05_return_operand_cannot_be_void.test",
     "t05_return_type_mismatch.test",

--- a/tests/expr/t05_proc_with_non_void_body.test
+++ b/tests/expr/t05_proc_with_non_void_body.test
@@ -1,0 +1,9 @@
+discard """
+  description: "
+    The type of a procedure's body must be equal to or a sub-type of its return
+    type
+  "
+  output: "1 : (IntTy)"
+"""
+(ProcDecl (Ident "a") (IntTy) (Params)
+  (IntVal 1))

--- a/tests/expr/t05_proc_with_non_void_body_error.test
+++ b/tests/expr/t05_proc_with_non_void_body_error.test
@@ -1,0 +1,9 @@
+discard """
+  description: "
+    The type of a procedure's body must be equal to or a sub-type of its return
+    type
+  "
+  reject: true
+"""
+(ProcDecl (Ident "a") (IntTy) (Params)
+  (FloatVal 1.0))

--- a/tests/expr/t05_proc_with_non_void_body_subtype.test
+++ b/tests/expr/t05_proc_with_non_void_body_subtype.test
@@ -1,0 +1,9 @@
+discard """
+  description: "
+    The type of a procedure's body must be equal to or a sub-type of its return
+    type
+  "
+  output: "1 : (UnionTy (UnitTy) (IntTy))"
+"""
+(ProcDecl (Ident "a") (UnionTy (UnitTy) (IntTy)) (Params)
+  (IntVal 1))


### PR DESCRIPTION
## Summary

Allow any non-void expression as procedure's body, as long as its type
fits the return type. This reduces `Return` noise and allows for more
functional-style procedure declarations.

## Details

* update the language definition
* implement the feature in `source2il`, by passing the body expression
  to `fitExpr` and wrapping non-void expression in a `Return` expression

---

## Notes For Reviewers
* a small out-of-band improvement to the language