### PR TITLE
spec: add missing `At` context rules

### DIFF
--- a/languages/source.nim
+++ b/languages/source.nim
@@ -641,6 +641,7 @@ const lang* = language:
     FieldAccess(E, IntVal(n))
     At(E, e)
     At(le, E)
+    At(val, E)
     Asgn(E, e)
     Asgn(le, E)
     With(E, n, e)
@@ -659,6 +660,7 @@ const lang* = language:
     # projections
     Exprs(hole, +e)
     At(le, hole)
+    At(val, hole)
     Asgn(le, hole)
     With(hole, n, e)
     With(val, n, hole)

--- a/tests/expr/t13_usage_in_at.test
+++ b/tests/expr/t13_usage_in_at.test
@@ -1,0 +1,9 @@
+discard """
+  description: "Make sure a local can be used as an index operand"
+  output: "1 : (IntTy)"
+"""
+(Exprs
+  (Decl (Ident "a") (IntVal 0))
+  (At
+    (Seq (IntTy) 1)
+    (Ident "a")))

--- a/tests/expr/t17_seq_at_eval_order_3.test
+++ b/tests/expr/t17_seq_at_eval_order_3.test
@@ -1,0 +1,9 @@
+discard """
+  description: "
+    The index operand is also evaluated when the array operand is not an lvalue
+  "
+  output: "1 : (IntTy)"
+"""
+(At
+  (Seq (IntTy) 1 2)
+  (Exprs (IntVal 0)))


### PR DESCRIPTION
## Summary

Also allow evaluation/reduction of the index operand of an `At`
expression when the array operand is not an lvalue expression.

## Details

* add an `As` pattern to both `E` and `F` that admits all `val` in the
  array operand position
* add two tests, one covering the `(As val le)` case and one the
  `(As val e)` case

---

## Notes For Reviewers
* I missed adding these rules with #127
* blocks #122