### PR TITLE
lang: add dynamic tuple indexing

### DIFF
--- a/languages/source.nim
+++ b/languages/source.nim
@@ -296,7 +296,7 @@ const lang* = language:
     # of types
     case list
     of [typ_1, *typ_2]:
-      if typ_1 in typ_2:
+      if contains(typ_2, typ_1):
         # it's a duplicate; skip
         unionOfAux(typ_2, accum)
       else:

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -151,7 +151,7 @@ using
 
 func align(val: SizeUnit, to: SizeUnit): SizeUnit =
   ## Rounds `val` to the multiple of `to`, the latter must be a power of two.
-  let mask = val - 1
+  let mask = to - 1
   (val + mask) and not mask
 
 template `+`(t: SemType, a: set[ExprFlag]): ExprType =

--- a/tests/expr/spectest.nim
+++ b/tests/expr/spectest.nim
@@ -33,6 +33,8 @@ const
   issues = [ # tests that are currently expected to fail
     "t02_add_float_values.test",
     "t02_sub_float_values.test",
+    "t03_tuple_at_eval_order_1.test",
+    "t03_tuple_at_eval_order_2.test",
     "t04_empty_module.test",
     "t04_proc_declaration.test",
     "t04_type_declaration.test",

--- a/tests/expr/t03_tuple_at_1.test
+++ b/tests/expr/t03_tuple_at_1.test
@@ -1,0 +1,5 @@
+discard """
+  description: "No union is created for homogeneous tuples"
+  output: "1 : (IntTy)"
+"""
+(At (TupleCons 1 2) 0)

--- a/tests/expr/t03_tuple_at_10.test
+++ b/tests/expr/t03_tuple_at_10.test
@@ -1,0 +1,6 @@
+discard """
+  output: "1 : (UnionTy (IntTy) (UnionTy (IntTy) (FloatTy)))"
+"""
+(At
+  (TupleCons 1 (As 2 (UnionTy (IntTy) (FloatTy))))
+  0)

--- a/tests/expr/t03_tuple_at_11.test
+++ b/tests/expr/t03_tuple_at_11.test
@@ -1,0 +1,6 @@
+discard """
+  output: "2 : (UnionTy (IntTy) (UnionTy (IntTy) (FloatTy)))"
+"""
+(At
+  (TupleCons 1 (As 2 (UnionTy (IntTy) (FloatTy))))
+  1)

--- a/tests/expr/t03_tuple_at_2.test
+++ b/tests/expr/t03_tuple_at_2.test
@@ -1,0 +1,5 @@
+discard """
+  description: "No union is created for homogeneous tuples"
+  output: "2 : (IntTy)"
+"""
+(At (TupleCons 1 2) 1)

--- a/tests/expr/t03_tuple_at_3.test
+++ b/tests/expr/t03_tuple_at_3.test
@@ -1,0 +1,4 @@
+discard """
+  output: "(Unreachable) : (IntTy)"
+"""
+(At (TupleCons 1 2) -1)

--- a/tests/expr/t03_tuple_at_4.test
+++ b/tests/expr/t03_tuple_at_4.test
@@ -1,0 +1,4 @@
+discard """
+  output: "(Unreachable) : (IntTy)"
+"""
+(At (TupleCons 1 2) 2)

--- a/tests/expr/t03_tuple_at_5.test
+++ b/tests/expr/t03_tuple_at_5.test
@@ -1,0 +1,5 @@
+discard """
+  description: "A union is created for heterogeneous tuples"
+  output: "(TupleCons) : (UnionTy (UnitTy) (IntTy) (FloatTy))"
+"""
+(At (TupleCons (TupleCons) 1 2.5) 0)

--- a/tests/expr/t03_tuple_at_6.test
+++ b/tests/expr/t03_tuple_at_6.test
@@ -1,0 +1,4 @@
+discard """
+  output: "1 : (UnionTy (UnitTy) (IntTy) (FloatTy))"
+"""
+(At (TupleCons (TupleCons) 1 2.5) 1)

--- a/tests/expr/t03_tuple_at_7.test
+++ b/tests/expr/t03_tuple_at_7.test
@@ -1,0 +1,4 @@
+discard """
+  output: "2.5 : (UnionTy (UnitTy) (IntTy) (FloatTy))"
+"""
+(At (TupleCons (TupleCons) 1 2.5) 2)

--- a/tests/expr/t03_tuple_at_8.test
+++ b/tests/expr/t03_tuple_at_8.test
@@ -1,0 +1,4 @@
+discard """
+  output: "(Unreachable) : (UnionTy (UnitTy) (IntTy) (FloatTy))"
+"""
+(At (TupleCons (TupleCons) 1 2.5) -1)

--- a/tests/expr/t03_tuple_at_9.test
+++ b/tests/expr/t03_tuple_at_9.test
@@ -1,0 +1,4 @@
+discard """
+  output: "(Unreachable) : (UnionTy (UnitTy) (IntTy) (FloatTy))"
+"""
+(At (TupleCons (TupleCons) 1 2.5) 3)

--- a/tests/expr/t03_tuple_at_eval_order_1.test
+++ b/tests/expr/t03_tuple_at_eval_order_1.test
@@ -1,0 +1,14 @@
+discard """
+  description: "
+    The index check for non-lvalue operands takes place immediately once
+    the index value is available.
+  "
+  output: "(Unreachable) : (IntTy)"
+"""
+(ProcDecl test (IntTy) (Params)
+  (At
+    (At
+      (TupleCons
+        (TupleCons 1 2))
+      2)
+    (If true (Return 3) 0)))

--- a/tests/expr/t03_tuple_at_eval_order_2.test
+++ b/tests/expr/t03_tuple_at_eval_order_2.test
@@ -1,0 +1,14 @@
+discard """
+  description: "
+    The index check for lvalue operands takes place only once all index
+    expressions in the enclosing lvalue expression are evaluated (layered
+    evaluation).
+  "
+  output: "3 : (IntTy)"
+"""
+(ProcDecl test (IntTy) (Params)
+  (Exprs
+    (Decl tup (TupleCons (TupleCons 1 2)))
+    (At
+      (At tup 2)
+      (If true (Return 3) 0))))

--- a/tests/expr/t03_tuple_at_eval_order_3.test
+++ b/tests/expr/t03_tuple_at_eval_order_3.test
@@ -1,0 +1,14 @@
+discard """
+  description: "The index expressions are evaluated strictly from left to right"
+  output: "1 : (IntTy)"
+"""
+(Exprs
+  (Decl i 0)
+  (At
+    (At
+      (TupleCons
+        (TupleCons 1 2))
+      i)
+    (Exprs
+      (Asgn i 100)
+      0)))

--- a/tests/expr/t03_tuple_at_eval_order_4.test
+++ b/tests/expr/t03_tuple_at_eval_order_4.test
@@ -1,0 +1,13 @@
+discard """
+  description: "The index expressions are evaluated strictly from left to right"
+  output: "1 : (IntTy)"
+"""
+(Exprs
+  (Decl tup
+    (TupleCons (TupleCons 1 2)))
+  (Decl i 0)
+  (At
+    (At tup i)
+    (Exprs
+      (Asgn i 100)
+      0)))

--- a/tests/expr/t03_tuple_at_eval_order_5.test
+++ b/tests/expr/t03_tuple_at_eval_order_5.test
@@ -1,0 +1,18 @@
+discard """
+  description: "
+    The non-lvalue parts of the tuple operand are also evaluated strictly from
+    left to right.
+  "
+  output: "1 : (IntTy)"
+"""
+(Exprs
+  (Decl tup
+    (TupleCons (TupleCons 1 2)))
+  (Decl i 10)
+  (At
+    (At
+      (Exprs
+        (Asgn i 0)
+        tup)
+      i)
+    0)))

--- a/tests/expr/t10_asgn_lhs_must_be_lvalue_11_error.test
+++ b/tests/expr/t10_asgn_lhs_must_be_lvalue_11_error.test
@@ -1,0 +1,10 @@
+discard """
+  description: "
+    An `At` projection from a homogeneous tuple l-value is not an l-value
+    expression.
+  "
+  reject: true
+"""
+(Exprs
+  (Decl x (TupleCons 1 2 3))
+  (Asgn (At x 0) 4))

--- a/tests/expr/t10_asgn_lhs_must_be_lvalue_12_error.test
+++ b/tests/expr/t10_asgn_lhs_must_be_lvalue_12_error.test
@@ -1,0 +1,10 @@
+discard """
+  description: "
+    An `At` projection from a heterogeneous tuple l-value is not an l-value
+    expression.
+  "
+  reject: true
+"""
+(Exprs
+  (Decl x (TupleCons 1 2.5 3))
+  (Asgn (At x 0) 4))


### PR DESCRIPTION
## Summary

Extend `At` to also allow tuple values as the first operand. If the
tuple is homogeneous, the expression has the type of the tuple element,
otherwise it's a union of all possible element types.

## Details

* add a typing rule for `At` with tuples
* add reduction rules for `At` and `With` covering tuples
* implement `At` support for tuple values in `source2il`
* fix a bug with `source2il.align` that resulted in the wrong value
  being returned (the mask was computed incorrectly)

`At` with a tuple operand never yields a mutable lvalue, even if the
input is one, as it'll make the future initial implementation of
pattern matching easier, but this decision is subject to change.

---

## Notes For Reviewers
* depends on #122 to work