### PR TITLE
builtin: fix a compilation error

### DIFF
--- a/spec/builtin.nim
+++ b/spec/builtin.nim
@@ -127,9 +127,9 @@ const arr = [
   ("updated", proc(n: Node): Node =
     let idx = toInt(n[1].num)
     assert n[0].kind == nkGroup
-    assert idx in 0..n[0].children.high
+    assert idx in 0'n..bignum(n[0].children.high)
     result = n[0]
-    result.children[idx] = n[2]
+    result.children[idx.toInt] = n[2]
   )]
 
 const functions* = block:


### PR DESCRIPTION
Fix the `updated` implementation not compiling due to still assuming
that numeric values are represented as `Int128`.