### PR TITLE
lang: add record types

### DIFF
--- a/languages/source.nim
+++ b/languages/source.nim
@@ -19,15 +19,21 @@ const lang* = language:
   #       numbers, not *integer* numbers
   typ ident: Ident(string)
   alias x, ident
+  typ eindex:
+    # element index
+    IntVal(z)
+    Ident(string)
+
   typ expr:
     Ident(string)
     IntVal(z)
     FloatVal(r)
     TupleCons(*expr)
+    RecordCons(+Field(ident, expr))
     Seq(texpr, *expr)
     Seq(StringVal(string))
     Call(+expr)
-    FieldAccess(expr, IntVal(z))
+    FieldAccess(expr, eindex)
     At(expr, expr)
     As(expr, texpr)
     And(expr, expr)
@@ -53,10 +59,12 @@ const lang* = language:
     `proc`(typ, *[x, typ], e)
 
     With(e, n, e) # return a tuple/array value with the n-th element replaced
+    With(e, string, e)
     Frame(typ, e) # a special expression for assisting with evaluation
 
   alias e, expr
 
+  typ fieldDecl: Field(ident, texpr)
   typ texpr:
     Ident(string)
     VoidTy()
@@ -69,6 +77,7 @@ const lang* = language:
     UnionTy(+texpr)
     ProcTy(+texpr)
     SeqTy(texpr)
+    RecordTy(+fieldDecl)
 
     # type expressions not available at the source level
     mut(texpr)
@@ -93,12 +102,13 @@ const lang* = language:
     char(z)
     `array`(*val)
     TupleCons(*val) # an empty tuple is also a valid value (i.e., unit)
+    RecordCons(+Field(x, val))
     `proc`(typ, *[x, typ], e)
 
   subtype le, e:
     # Lvalue expression with all non-lvalue operands already evaluated.
     loc(z)
-    FieldAccess(le, IntVal(n))
+    FieldAccess(le, eindex)
     At(le, IntVal(n))
 
   func update(a: expr, xfrm: e -> e) -> expr =
@@ -119,10 +129,12 @@ const lang* = language:
       Asgn(xfrm(e_1), xfrm(e_2))
     of TupleCons(*e_1):
       TupleCons(...xfrm(e_1))
+    of RecordCons(+Field(x_1, e_1)):
+      RecordCons(...Field(x_1, xfrm(e_1)))
     of Seq(texpr_1, *e_1):
       Seq(texpr_1, ...xfrm(e_1))
-    of FieldAccess(e_1, IntVal(z_1)):
-      FieldAccess(xfrm(e_1), IntVal(z_1))
+    of FieldAccess(e_1, eindex_1):
+      FieldAccess(xfrm(e_1), eindex_1)
     of At(e_1, e_2):
       At(xfrm(e_1), xfrm(e_2))
     of As(e_1, texpr_1):
@@ -192,11 +204,24 @@ const lang* = language:
       conclusion typ_1, UnionTy(+typ_2)
 
   func `==`(a, b: typ) -> bool =
-    ## Except for union types, all type equality uses *structural equality*.
+    ## Type equality.
     case (a, b)
     of UnionTy(+typ_1), UnionTy(+typ_2):
+      # equal set of types -> equivalent types
       if (for typ_3 in typ_1: contains(typ_2, typ_3)):
         if (for typ_3 in typ_2: contains(typ_1, typ_3)):
+          true
+        else:
+          false
+      else:
+        false
+    of RecordTy(+Field(Ident(string_1), typ_1)),
+       RecordTy(+Field(Ident(string_2), typ_2)):
+      # equal fields -> equivalent type
+      let m_1 = zip(string_1, typ_1)
+      let m_2 = zip(string_2, typ_2)
+      if (for it in m_1: mapContains(m_2, it)):
+        if (for it in m_2: mapContains(m_1, it)):
           true
         else:
           false
@@ -253,6 +278,13 @@ const lang* = language:
       premise ...ttypes(C_1, texpr_1, typ_1)
       condition ...(typ_1 != VoidTy())
       conclusion C_1, TupleTy(+texpr_1), TupleTy(...typ_1)
+
+    rule "S-record-type":
+      premise ...ttypes(C_1, texpr_1, typ_1)
+      condition ...(typ_1 != VoidTy())
+      condition unique(string_1)
+      conclusion C_1, RecordTy(+Field(Ident(string_1), texpr_1)),
+                      RecordTy(...Field(Ident(string_1), typ_1))
 
     rule "S-union-type":
       premise ...ttypes(C_1, texpr_1, typ_1)
@@ -312,6 +344,13 @@ const lang* = language:
       condition ...(typ_1 != VoidTy())
       conclusion C_1, TupleCons(+e_1), TupleTy(...typ_1)
 
+    rule "S-record":
+      premise ...mtypes(C_1, e_1, typ_1)
+      condition ...(typ_1 != VoidTy())
+      condition unique(string_1)
+      conclusion C_1, RecordCons(+Field(Ident(string_1), e_1)),
+                      RecordTy(...Field(Ident(string_1), typ_1))
+
     rule "S-seq-cons":
       premise ttypes(C_1, texpr_1, typ_1)
       premise ...types(C_1, e_2, typ_2)
@@ -340,6 +379,18 @@ const lang* = language:
       where TupleTy(+typ_3), typ_1
       where typ_2, typ_3[n_1]
       conclusion C_1, FieldAccess(e_1, IntVal(n_1)), mut(typ_2)
+
+    rule "S-rec-field":
+      premise types(C_1, e_1, typ_1)
+      where RecordTy(+Field(Ident(string_2), typ_2)), typ_1
+      where typ_3, map(zip(string_2, typ_2))(string_1)
+      conclusion C_1, FieldAccess(e_1, Ident(string_1)), typ_3
+
+    rule "S-mut-rec-field":
+      premise types(C_1, e_1, mut(typ_1))
+      where RecordTy(+Field(Ident(string_2), typ_2)), typ_1
+      where typ_3, map(zip(string_2, typ_2))(string_1)
+      conclusion C_1, FieldAccess(e_1, Ident(string_1)), mut(typ_3)
 
     rule "S-at":
       premise types(C_1, e_1, typ_1)
@@ -579,10 +630,12 @@ const lang* = language:
       Asgn(substitute(e_1, with), substitute(e_2, with))
     of TupleCons(*e_1):
       TupleCons(...substitute(e_1, with))
+    of RecordCons(+Field(x_1, e_1)):
+      RecordCons(...Field(x_1, substitute(e_1, with)))
     of Seq(texpr_1, *e_1):
       Seq(texpr_1, ...substitute(e_1, with))
-    of FieldAccess(e_1, IntVal(z_1)):
-      FieldAccess(substitute(e_1, with), IntVal(z_1))
+    of FieldAccess(e_1, eindex_1):
+      FieldAccess(substitute(e_1, with), eindex_1)
     of At(e_1, e_2):
       At(substitute(e_1, with), substitute(e_2, with))
     of As(e_1, texpr_1):
@@ -695,13 +748,13 @@ const lang* = language:
   context L:
     # evaluation context for locs in lvalue expressions
     hole
-    FieldAccess(L, IntVal(n))
+    FieldAccess(L, eindex)
     At(L, IntVal(n))
 
   context E:
     hole
     Exprs(E, +e)
-    FieldAccess(E, IntVal(n))
+    FieldAccess(E, eindex)
     At(E, e)
     At(le, E)
     At(val, E)
@@ -710,7 +763,10 @@ const lang* = language:
     Asgn(le, E)
     With(E, n, e)
     With(val, n, E)
+    With(E, string, e)
+    With(val, string, E)
     TupleCons(*val, E, *e)
+    RecordCons(*Field(x, val), Field(x, E), *Field(x, e))
     Seq(typ, *val, E, *e)
     Call(*val, E, *e)
     Call(x, *val, E, *e)
@@ -729,7 +785,10 @@ const lang* = language:
     Asgn(le, hole)
     With(hole, n, e)
     With(val, n, hole)
+    With(hole, string, e)
+    With(val, string, hole)
     TupleCons(*val, hole, *e)
+    RecordCons(*Field(x, val), Field(x, hole), *Field(x, e))
     Seq(typ, *val, hole, *e)
     Call(*val, hole, *e)
     Call(x, *val, hole, *e)
@@ -764,8 +823,16 @@ const lang* = language:
       where val_2, val_3[n_1]
       conclusion FieldAccess(val_1, IntVal(n_1)), val_2
 
+    rule "E-rec-access":
+      let val_2 = map(zip(string_1, val_1))(string_2)
+      conclusion FieldAccess(RecordCons(+Field(Ident(string_1), val_1)), Ident(string_2)),
+                 val_2
+
     axiom "E-field-asgn", Asgn(FieldAccess(le_1, IntVal(n_1)), val_1), Asgn(le_1, With(le_1, n_1, val_1))
     axiom "E-elem-asgn", Asgn(At(le_1, IntVal(n_1)), val_1), Asgn(le_1, With(le_1, n_1, val_1))
+    axiom "E-rec-field-asgn",
+          Asgn(FieldAccess(le_1, Ident(string_1)), val_1),
+          Asgn(le_1, With(le_1, string_1, val_1))
 
     axiom "E-seq-cons", Seq(typ, *val_1), `array`(...val_1)
 
@@ -788,6 +855,10 @@ const lang* = language:
     rule "E-with-out-of-bounds":
       condition n_1 < 0 or len(val_1) <= n_1
       conclusion With(array(*val_1), n_1, val_2), Unreachable()
+    rule "E-with-record":
+      let val_3 = updated(val_1, indexOf(string_1, string_2, 0), val_2)
+      conclusion With(RecordCons(+Field(Ident(string_1), val_1)), string_2, val_2),
+                 RecordCons(...Field(Ident(string_1), val_3))
 
     axiom "E-not-false", Call(Ident("not"), False), True
     axiom "E-not-true",  Call(Ident("not"), True),  False
@@ -970,6 +1041,11 @@ const lang* = language:
     of _:
       false
 
+  func mapContains(list: *(string, typ), p: (string, typ)) -> bool =
+    let (s, t) = p
+    let m = map(list)
+    s in m and m(s) == t
+
   func uniqueTypes(list: *typ) -> bool =
     ## Computes whether all types in the list are unique.
     case list
@@ -991,3 +1067,11 @@ const lang* = language:
         false
     of _:
       true
+
+  func indexOf(list: *string, it: string, i: n) -> n =
+    case list
+    of [string_1, *string_2]:
+      if same(string_1, it):
+        i
+      else:
+        indexOf(string_2, it, i + 1)

--- a/languages/specification.md
+++ b/languages/specification.md
@@ -15,10 +15,12 @@ expr     ::= <ident>
           |  <intVal>
           |  <floatVal>
           |  (TupleCons <expr>*)
+          |  (RecordCons (Field <ident> <expr>)+)
           |  (Seq <texpr> <expr>*)
           |  (Seq <strVal>)
           |  (Call <expr>+)
           |  (FieldAccess <expr> <intVal>)
+          |  (FieldAccess <expr> <ident>)
           |  (At <expr> <expr>)
           |  (As <expr> <texpr>)
           |  (And <expr> <expr>)
@@ -37,6 +39,7 @@ texpr    ::= <ident>
           |  (IntTy)
           |  (FloatTy)
           |  (TupleTy <texpr>*)
+          |  (RecordTy (Field <ident> <texpr>)+)
           |  (UnionTy <texpr>+)
           |  (ProcTy <texpr>+)
           |  (SeqTy <texpr>)

--- a/passes/syntax_source.nim
+++ b/passes/syntax_source.nim
@@ -11,13 +11,14 @@ type
   NodeKind* {.pure.} = enum
     IntVal, FloatVal, StringVal
     Ident,
-    VoidTy, UnitTy, BoolTy, CharTy, IntTy, FloatTy, TupleTy, UnionTy, ProcTy,
-    SeqTy
+    VoidTy, UnitTy, BoolTy, CharTy, IntTy, FloatTy, TupleTy, RecordTy, UnionTy,
+    ProcTy, SeqTy
     And, Or
     If
     While
     Call
     TupleCons
+    RecordCons
     Seq
     FieldAccess, At
     As
@@ -25,6 +26,7 @@ type
     Asgn
     Return
     Unreachable
+    Field
     Params
     ProcDecl, ParamDecl
     Decl
@@ -35,8 +37,8 @@ type
 
 const
   ExprNodes* = {IntVal, FloatVal, Ident, And, Or, If, While, Call, TupleCons,
-                Seq, FieldAccess, At, As, Asgn, Return, Unreachable, Exprs,
-                Decl}
+                RecordCons, Seq, FieldAccess, At, As, Asgn, Return,
+                Unreachable, Exprs, Decl}
   DeclNodes* = {ProcDecl, TypeDecl}
   AllNodes* = {low(NodeKind) .. high(NodeKind)}
 

--- a/phy/type_rendering.nim
+++ b/phy/type_rendering.nim
@@ -30,6 +30,16 @@ proc typeToString*(typ: SemType): string =
       res.add ","
     res.add ")"
     res
+  of tkRecord:
+    var res = "{"
+    for i, it in typ.fields.pairs:
+      if i > 0:
+        res.add ", "
+      res.add it.name
+      res.add " : "
+      res.add typeToString(it.typ)
+    res.add "}"
+    res
   of tkUnion:
     var res = "union("
     for i, it in typ.elems.pairs:
@@ -73,6 +83,13 @@ proc typeToSexp*(typ: SemType): SexpNode =
     var res = newSList(newSSymbol("TupleTy"))
     for it in typ.elems.items:
       res.add typeToSexp(it)
+    res
+  of tkRecord:
+    var res = newSList(newSSymbol("RecordTy"))
+    for it in typ.fields.items:
+      res.add newSList(newSSymbol("Field"),
+                       newSSymbol(it.name),
+                       typeToSexp(it.typ))
     res
   of tkUnion:
     var res = newSList(newSSymbol("UnionTy"))

--- a/phy/vmexec.nim
+++ b/phy/vmexec.nim
@@ -83,6 +83,16 @@ proc valueToSexp(env: var VmEnv, a: VirtualAddr, typ: SemType): SexpNode =
     for i, it in typ.elems.pairs:
       result.add valueToSexp(env, VirtualAddr(a.uint64 + offset.uint64), it)
       offset += size(it)
+  of tkRecord:
+    result = newCons("RecordCons")
+    var offset = 0
+    for i, it in typ.fields.pairs:
+      let mask = alignment(it.typ) - 1
+      offset = (offset + mask) and not mask # align the offset
+      var field = newCons("Field", newSSymbol(it.name))
+      field.add valueToSexp(env, VirtualAddr(a.uint64 + offset.uint64), it.typ)
+      result.add field
+      offset += size(it.typ)
   of tkUnion:
     let tag = readInt(p, 8)
     if tag in 0..typ.elems.high:

--- a/spec/langdefs.nim
+++ b/spec/langdefs.nim
@@ -701,7 +701,7 @@ proc typeConstr(c; n: var Node, info: NimNode, isPattern: static[bool]) =
       # the choice
       n.typ = c.newTypeVar(info, Type(kind: tkOr, children: cand))
   else:
-    unreachable()
+    error(fmt"not a constructor: {n[0].sym}", info)
 
   if n.typ.isNil:
     error("no valid construction with the given shape exists", info)

--- a/tests/expr/spectest.nim
+++ b/tests/expr/spectest.nim
@@ -98,6 +98,11 @@ const
     "t19_writeErr.test",
     "t20_readFile.test",
     "t20_readFile_missing.test",
+    "t21_record_type_cons_1.test",
+    "t21_record_type_cons_2.test",
+    "t21_record_type_cons_duplicate_field_error.test",
+    "t21_record_type_cons_no_void_error.test",
+    "t22_record_type_equality_1.test"
   ]
 
 var typesRel, cstepRel, desugarFnc = -1

--- a/tests/expr/spectest.nim
+++ b/tests/expr/spectest.nim
@@ -172,6 +172,8 @@ proc add(res: var string, n: Node) =
         res.add ".0"
     elif n[0].sym == "proc":
       res.add "(proc ...)"
+    elif n[0].sym == "Ident":
+      res.add n[^1].sym
     else:
       res.add "("
       for i, it in n.children.pairs:

--- a/tests/expr/t21_record_cons_1.test
+++ b/tests/expr/t21_record_cons_1.test
@@ -1,0 +1,4 @@
+discard """
+  output: "(RecordCons (Field x 10)) : (RecordTy (Field x (IntTy)))"
+"""
+(RecordCons (Field x 10))

--- a/tests/expr/t21_record_cons_2.test
+++ b/tests/expr/t21_record_cons_2.test
@@ -1,0 +1,4 @@
+discard """
+  output: "(RecordCons (Field x (TupleCons 1 2))) : (RecordTy (Field x (TupleTy (IntTy) (IntTy))))"
+"""
+(RecordCons (Field x (TupleCons 1 2)))

--- a/tests/expr/t21_record_cons_3.test
+++ b/tests/expr/t21_record_cons_3.test
@@ -1,0 +1,4 @@
+discard """
+  output: "(RecordCons (Field x (array 1 2 3))) : (RecordTy (Field x (SeqTy (IntTy))))"
+"""
+(RecordCons (Field x (Seq (IntTy) 1 2 3)))

--- a/tests/expr/t21_record_cons_4.test
+++ b/tests/expr/t21_record_cons_4.test
@@ -1,0 +1,5 @@
+discard """
+  description: "Records may be part of other records"
+  output: "(RecordCons (Field x (RecordCons (Field x 1)))) : (RecordTy (Field x (RecordTy (Field x (IntTy)))))"
+"""
+(RecordCons (Field x (RecordCons (Field x 1))))

--- a/tests/expr/t21_record_cons_5.test
+++ b/tests/expr/t21_record_cons_5.test
@@ -1,0 +1,4 @@
+discard """
+  output: "(RecordCons (Field x 1) (Field y 2)) : (RecordTy (Field x (IntTy)) (Field y (IntTy)))"
+"""
+(RecordCons (Field x 1) (Field y 2))

--- a/tests/expr/t21_record_cons_6.test
+++ b/tests/expr/t21_record_cons_6.test
@@ -1,0 +1,7 @@
+discard """
+  description: "Identifiers used for field name don't conflict with decl names"
+  output: "(RecordCons (Field x 1)) : (RecordTy (Field x (IntTy)))"
+"""
+(Exprs
+  (Decl x 1)
+  (RecordCons (Field x x)))

--- a/tests/expr/t21_record_cons_duplicate_field_name_error.test
+++ b/tests/expr/t21_record_cons_duplicate_field_name_error.test
@@ -1,0 +1,5 @@
+discard """
+  description: "Record fields cannot be of void type"
+  reject: true
+"""
+(RecordCons (Field x 1) (Field x 2))

--- a/tests/expr/t21_record_cons_no_void_error.test
+++ b/tests/expr/t21_record_cons_no_void_error.test
@@ -1,0 +1,5 @@
+discard """
+  description: "Record fields cannot have type void"
+  reject: true
+"""
+(RecordCons (Field x (Unreachable)))

--- a/tests/expr/t21_record_type_cons_1.test
+++ b/tests/expr/t21_record_type_cons_1.test
@@ -1,0 +1,4 @@
+discard """
+  arguments: "c"
+"""
+(TypeDecl rec (RecordTy (Field x (IntTy))))

--- a/tests/expr/t21_record_type_cons_2.test
+++ b/tests/expr/t21_record_type_cons_2.test
@@ -1,0 +1,4 @@
+discard """
+  arguments: "c"
+"""
+(TypeDecl rec (RecordTy (Field x (IntTy)) (Field y (FloatTy))))

--- a/tests/expr/t21_record_type_cons_duplicate_field_error.test
+++ b/tests/expr/t21_record_type_cons_duplicate_field_error.test
@@ -1,0 +1,4 @@
+discard """
+  reject: true
+"""
+(TypeDecl rec (RecordTy (Field x (IntTy)) (Field x (IntTy))))

--- a/tests/expr/t21_record_type_cons_no_void_error.test
+++ b/tests/expr/t21_record_type_cons_no_void_error.test
@@ -1,0 +1,4 @@
+discard """
+  reject: true
+"""
+(TypeDecl rec (RecordTy (Field x (VoidTy))))

--- a/tests/expr/t22_record_access_1.test
+++ b/tests/expr/t22_record_access_1.test
@@ -1,0 +1,6 @@
+discard """
+  output: "1 : (IntTy)"
+"""
+(FieldAccess
+  (RecordCons (Field x 1))
+  x)

--- a/tests/expr/t22_record_access_2.test
+++ b/tests/expr/t22_record_access_2.test
@@ -1,0 +1,6 @@
+discard """
+  output: "1 : (IntTy)"
+"""
+(Exprs
+  (Decl rec (RecordCons (Field x 1)))
+  (FieldAccess rec x))

--- a/tests/expr/t22_record_access_3.test
+++ b/tests/expr/t22_record_access_3.test
@@ -1,0 +1,9 @@
+discard """
+  output: "2 : (IntTy)"
+"""
+(Exprs
+  (Decl rec
+    (RecordCons
+      (Field x
+        (RecordCons (Field y 2)))))
+  (FieldAccess (FieldAccess rec x) y))

--- a/tests/expr/t22_record_access_4.test
+++ b/tests/expr/t22_record_access_4.test
@@ -1,0 +1,8 @@
+discard """
+  description: "A record field's value can be modified with assignments"
+  output: "(RecordCons (Field x 2)) : (RecordTy (Field x (IntTy)))"
+"""
+(Exprs
+  (Decl rec (RecordCons (Field x 1)))
+  (Asgn (FieldAccess rec x) 2)
+  rec)

--- a/tests/expr/t22_record_access_5.test
+++ b/tests/expr/t22_record_access_5.test
@@ -1,0 +1,11 @@
+discard """
+  description: "A nested record field's value can be modified with assignments"
+  output: "(RecordCons (Field x (RecordCons (Field y 3)))) : (RecordTy (Field x (RecordTy (Field y (IntTy)))))"
+"""
+(Exprs
+  (Decl rec
+    (RecordCons
+      (Field x
+        (RecordCons (Field y 2)))))
+  (Asgn (FieldAccess (FieldAccess rec x) y) 3)
+  rec)

--- a/tests/expr/t22_record_access_index_must_be_ident_error.test
+++ b/tests/expr/t22_record_access_index_must_be_ident_error.test
@@ -1,0 +1,7 @@
+discard """
+  description: "The index used to access the record must be an identifier"
+  reject: true
+"""
+(FieldAccess
+  (RecordCons (Field x 1))
+  0)

--- a/tests/expr/t22_record_access_missing_field_error.test
+++ b/tests/expr/t22_record_access_missing_field_error.test
@@ -1,0 +1,6 @@
+discard """
+  reject: true
+"""
+(FieldAccess
+  (RecordCons (Field x 1))
+  y)

--- a/tests/expr/t22_record_type_equality_1.test
+++ b/tests/expr/t22_record_type_equality_1.test
@@ -1,0 +1,10 @@
+discard """
+  description: "
+    Record types with the same fields but in a different order are equal.
+  "
+  output: "(RecordCons (Field x 2) (Field y 1)) : (RecordTy (Field x (IntTy)) (Field y (IntTy)))"
+"""
+(Exprs
+  (Decl rec (RecordCons (Field x 1) (Field y 2)))
+  (Asgn rec (RecordCons (Field y 1) (Field x 2)))
+  rec)

--- a/tests/expr/t22_record_type_equality_2_error.test
+++ b/tests/expr/t22_record_type_equality_2_error.test
@@ -1,0 +1,8 @@
+discard """
+  description: "One record has fields the other one doesn't -> different type"
+  reject: true
+"""
+(Exprs
+  (Decl rec (RecordCons (Field x 1)))
+  (Asgn rec (RecordCons (Field x 1) (Field y 2)))
+  rec)

--- a/tests/expr/t22_record_type_equality_3_error.test
+++ b/tests/expr/t22_record_type_equality_3_error.test
@@ -1,0 +1,8 @@
+discard """
+  description: "One record has fields the other one doesn't -> different type"
+  reject: true
+"""
+(Exprs
+  (Decl rec (RecordCons (Field x 1) (Field y 2)))
+  (Asgn rec (RecordCons (Field x 1)))
+  rec)

--- a/tests/expr/t22_record_type_equality_4_error.test
+++ b/tests/expr/t22_record_type_equality_4_error.test
@@ -1,0 +1,8 @@
+discard """
+  description: "No overlapping fields -> different type"
+  reject: true
+"""
+(Exprs
+  (Decl rec (RecordCons (Field x 1)))
+  (Asgn rec (RecordCons (Field y 1)))
+  rec)


### PR DESCRIPTION
## Summary

Add record types, record constructors, and record type constructors to
the source language. Record types are similar to tuples, with the
difference that the fields are looked up by name, not by position.

## Details

### Language Definition

* add the syntax for records. The type constructor uses `RecordTy`, the
  value constructor `RecordCons`, and the elimination re-uses
  `FieldAccess`, but with an identifier
* add the static and dynamic semantics for records. They're largely the
  same as those for tuples, but using name lookup instead of positional
  lookup

### Meta Language

* make nested constructors (i.e., constructors appearing within
  constructors in data type definitions) proper ones that can be used
  standalone
* report a proper error when using undeclared identifiers in patterns

### Source2IL

* implement records as defined by the source language specification

### Tests

* add tests for all aspects of records (construction, access, etc.)
* render `Ident("x")` as just `x` in the output of `spectest`, so that
  the record tests' output specification can be shorter

Multiple new tests are marked as known issues in `spectest`:
* the `TypeDecl`-using ones need proper top-level code semantics to work
* `t22_record_type_equality_1.test` works, but the output comparison
  only compares the rendered results (which differ), not the actual
  values (which are equal)
