### PR TITLE
skully: fix codegen for setup of temporaries

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         target:
           - name: Linux
-            runner: ubuntu-20.04
+            runner: ubuntu-22.04
           - name: MacOS (M1)
             runner: macos-14
           - name: MacOS

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,7 +59,7 @@ jobs:
       # use a pinned version in order to make CI runs reproducible
       - uses: nim-works/setup-nimskull@0.1.2
         with:
-          nimskull-version: "0.1.0-dev.21434"
+          nimskull-version: "0.1.0-dev.21449"
 
       - name: Build koch
         run: nim c -d:nimStrictMode --outdir:bin koch.nim
@@ -91,7 +91,7 @@ jobs:
       # use a pinned version in order to make CI runs reproducible
       - uses: nim-works/setup-nimskull@0.1.2
         with:
-          nimskull-version: "0.1.0-dev.21434"
+          nimskull-version: "0.1.0-dev.21449"
 
       - name: Build koch
         run: nim c -d:nimStrictMode --outdir:bin koch.nim
@@ -123,7 +123,7 @@ jobs:
       # use a pinned version in order to make CI runs reproducible
       - uses: nim-works/setup-nimskull@0.1.2
         with:
-          nimskull-version: "0.1.0-dev.21434"
+          nimskull-version: "0.1.0-dev.21449"
 
       - name: Build koch
         run: nim c -d:nimStrictMode --outdir:bin koch.nim

--- a/skully/backend.nim
+++ b/skully/backend.nim
@@ -2806,8 +2806,12 @@ proc generateCode*(graph: ModuleGraph): PackedTree[NodeKind] =
 
   # --- run the MIR processing and translate the MIR code
   let config =
-    BackendConfig(noImported: true, # prefer not using FFI procedures
-                  tconfig: TranslationConfig(magicsToKeep: MagicsToKeep))
+    BackendConfig(
+      noImported: true, # prefer not using FFI procedures
+      tconfig: TranslationConfig(
+        magicsToKeep: MagicsToKeep,
+        options: {goTailCallElim}
+      ))
 
   var
     discovery: DiscoveryData

--- a/skully/passes.nim
+++ b/skully/passes.nim
@@ -19,7 +19,47 @@ proc liftStrings(tree: MirTree, env: var MirEnv, changes: var Changeset) =
       changes.replaceMulti(tree, NodePosition(i), bu):
         bu.use toValue(c, tree[i].typ)
 
+proc moveUnscoped(tree: MirTree, changes: var Changeset) =
+  ## Moves defs within `mnkIf` sections without an accompanying scope to
+  ## before the if, so that the def is guaranteed to dominate all usages.
+  var
+    stack: seq[(int, NodePosition, LabelId)]
+    depth = 0
+    it = NodePosition(0)
+  while it < tree.len.NodePosition:
+    case tree[it].kind
+    of mnkIf:
+      if tree[tree.sibling(it)].kind != mnkScope:
+        # found an 'if' with an unscoped body
+        if stack.len == 0 or stack[^1][0] != depth:
+          # make sure to move to the start of the *outermost* unscoped 'if':
+          #   if ...:  # <- move to before here, not before the if below
+          #     if ...:
+          #       def x = ...
+          stack.add (depth, it, tree[it, 1].label)
+    of mnkDef, mnkDefCursor:
+      if stack.len > 0 and stack[^1][0] == depth:
+        # the def is part of an if and there's no scope start in-between
+        # them -> move
+        changes.insert(tree, stack[^1][1], it, bu):
+          bu.subTree tree[it].kind:
+            bu.add tree[it, 0]
+            bu.add MirNode(kind: mnkNone)
+        changes.changeTree(tree, it, MirNode(kind: mnkInit))
+    of mnkScope:
+      inc depth
+    of mnkEndScope:
+      dec depth
+    of mnkEndStruct:
+      if stack.len > 0 and stack[^1][2] == tree[it, 0].label:
+        stack.shrink(stack.len - 1)
+    else:
+      discard
+
+    it = tree.sibling(it)
+
 proc apply*(body: var MirBody, env: var MirEnv) =
   var c = initChangeset(body)
   liftStrings(body.code, env, c)
+  moveUnscoped(body.code, c)
   apply(body, c)


### PR DESCRIPTION
## Summary

* fix code generator bug with skully, leading to crashes of the
  compiled code
* update to the `0.1.0-dev.21449` NimSkull compiler

## Details

### Skully

The `if` expressions emitted for `and` and `or` in the MIR currently
open no scope, meaning that the lifetime of temporaries created within
extend into the `if`'s scope.

Skully's code generator emits the location only for `def` statements,
and thus locations for which the `def` is in an unscoped `if` are in an
undefined state when the `if` is not entered, potentially leading to
memory corruption or access violations when using the location's
content (e.g., during destruction).

A MIR pass is added that moves moves the problematic `def`s (but not
the assignment) to right before the unscoped `if`, making all usages of
a location are dominated by the location's `def`.

### Misc

* bump the required NimSkull compiler version; the most recent release
  fixes a NimSkull bug that the above `skully` fix triggers
* bump the Ubuntu runner image to `22.04`; the recent NimSkull builds
  don't run on older images anymore (due to a too old glibc version)

---

## Notes For Reviewers
* fixes the bug blocking #131