### PR TITLE
lang: add float multiplication and division

### DIFF
--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -884,8 +884,14 @@ proc binaryArithToIL(c; t; n: NodeIndex, name: string, expr, stmts): SemType =
         c.error("arguments must be of 'int' or 'float' type")
         result = errorType()
     of "*":
-      wantType {tkInt}, "arguments must be of 'int' type"
-      expr = check(c, MulChck, valA, valB, stmts)
+      case result.kind
+      of tkInt:
+        expr = check(c, MulChck, valA, valB, stmts)
+      of tkFloat:
+        expr = newBinaryOp(Mul, c.typeToIL(result), valA, valB)
+      else:
+        c.error("arguments must be of 'int' or 'float' type")
+        result = errorType()
     of "div":
       wantType {tkInt}, "arguments must be of 'int' type"
       # emit a division-by-zero guard:

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -116,6 +116,7 @@ const
     "+": ekBuiltinProc,
     "-": ekBuiltinProc,
     "*": ekBuiltinProc,
+    "/": ekBuiltinProc,
     "div": ekBuiltinProc,
     "mod": ekBuiltinProc,
     "==": ekBuiltinProc,
@@ -892,6 +893,9 @@ proc binaryArithToIL(c; t; n: NodeIndex, name: string, expr, stmts): SemType =
       else:
         c.error("arguments must be of 'int' or 'float' type")
         result = errorType()
+    of "/":
+      wantType {tkFloat}, "arguments must of type 'float'"
+      expr = newBinaryOp(Div, c.typeToIL(result), valA, valB)
     of "div":
       wantType {tkInt}, "arguments must be of 'int' type"
       # emit a division-by-zero guard:
@@ -1027,7 +1031,7 @@ proc callToIL(c; t; n: NodeIndex, expr; stmts): SemType =
 
     if ent.kind == ekBuiltinProc:
       case name
-      of "+", "-", "*", "div", "mod":
+      of "+", "-", "*", "/", "div", "mod":
         result = binaryArithToIL(c, t, n, name, expr, stmts)
       of "==", "<", "<=":
         result = relToIL(c, t, n, name, expr, stmts)

--- a/tests/expr/t02_add_float_values_round_overflow_1.test
+++ b/tests/expr/t02_add_float_values_round_overflow_1.test
@@ -5,4 +5,4 @@ discard """
   "
   output: "inf : (FloatTy)"
 """
-(Call (Ident "+") (FloatVal 1.797693134862316e+308) (FloatVal 1.99584030953472e+292))
+(Call (Ident "+") (FloatVal 1.7976931348623157e+308) (FloatVal 1.99584030953472e+292))

--- a/tests/expr/t02_add_float_values_round_overflow_2.test
+++ b/tests/expr/t02_add_float_values_round_overflow_2.test
@@ -5,4 +5,4 @@ discard """
   "
   output: "-inf : (FloatTy)"
 """
-(Call (Ident "+") (FloatVal -1.797693134862316e+308) (FloatVal -1.99584030953472e+292))
+(Call (Ident "+") (FloatVal -1.7976931348623157e+308) (FloatVal -1.99584030953472e+292))

--- a/tests/expr/t02_div_float_values_1.test
+++ b/tests/expr/t02_div_float_values_1.test
@@ -1,0 +1,4 @@
+discard """
+  output: "0.5 : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal 1.0) (FloatVal 2.0))

--- a/tests/expr/t02_div_float_values_2.test
+++ b/tests/expr/t02_div_float_values_2.test
@@ -1,0 +1,4 @@
+discard """
+  output: "0.3333333333333333 : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal 1.0) (FloatVal 3.0))

--- a/tests/expr/t02_div_float_values_3.test
+++ b/tests/expr/t02_div_float_values_3.test
@@ -1,0 +1,7 @@
+discard """
+  description: "
+    Division with subnormal dividend that requires tie-to-even rounding
+  "
+  output: "1e-323 : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal 1.5e-323) (FloatVal 2.0))

--- a/tests/expr/t02_div_float_values_4.test
+++ b/tests/expr/t02_div_float_values_4.test
@@ -1,0 +1,7 @@
+discard """
+  description: "
+    Division with subnormal dividend that requires tie-to-even rounding
+  "
+  output: "1e-323 : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal 2.5e-323) (FloatVal 2.0))

--- a/tests/expr/t02_div_float_values_5.test
+++ b/tests/expr/t02_div_float_values_5.test
@@ -1,0 +1,7 @@
+discard """
+  description: "
+    Division with subnormal dividend that requires rounding down
+  "
+  output: "1e-323 : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal 4.4e-323) (FloatVal 4.0))

--- a/tests/expr/t02_div_float_values_6.test
+++ b/tests/expr/t02_div_float_values_6.test
@@ -1,0 +1,7 @@
+discard """
+  description: "
+    Division with subnormal dividend that requires rounding up
+  "
+  output: "1.5e-323 : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal 5.4e-323) (FloatVal 4.0))

--- a/tests/expr/t02_div_float_values_nan_nan.test
+++ b/tests/expr/t02_div_float_values_nan_nan.test
@@ -1,0 +1,4 @@
+discard """
+  output: "nan : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal nan) (FloatVal nan))

--- a/tests/expr/t02_div_float_values_ninf_nfinite.test
+++ b/tests/expr/t02_div_float_values_ninf_nfinite.test
@@ -1,0 +1,4 @@
+discard """
+  output: "inf : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal -inf) (FloatVal -1.0))

--- a/tests/expr/t02_div_float_values_ninf_ninf.test
+++ b/tests/expr/t02_div_float_values_ninf_ninf.test
@@ -1,0 +1,4 @@
+discard """
+  output: "nan : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal -inf) (FloatVal -inf))

--- a/tests/expr/t02_div_float_values_ninf_nzero.test
+++ b/tests/expr/t02_div_float_values_ninf_nzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "inf : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal -inf) (FloatVal -0.0))

--- a/tests/expr/t02_div_float_values_ninf_pfinite.test
+++ b/tests/expr/t02_div_float_values_ninf_pfinite.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-inf : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal -inf) (FloatVal 1.0))

--- a/tests/expr/t02_div_float_values_ninf_pinf.test
+++ b/tests/expr/t02_div_float_values_ninf_pinf.test
@@ -1,0 +1,4 @@
+discard """
+  output: "nan : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal -inf) (FloatVal inf))

--- a/tests/expr/t02_div_float_values_ninf_pzero.test
+++ b/tests/expr/t02_div_float_values_ninf_pzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-inf : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal -inf) (FloatVal 0.0))

--- a/tests/expr/t02_div_float_values_nzero_nfinite.test
+++ b/tests/expr/t02_div_float_values_nzero_nfinite.test
@@ -1,0 +1,4 @@
+discard """
+  output: "0.0 : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal -0.0) (FloatVal -1.0))

--- a/tests/expr/t02_div_float_values_nzero_ninf.test
+++ b/tests/expr/t02_div_float_values_nzero_ninf.test
@@ -1,0 +1,4 @@
+discard """
+  output: "0.0 : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal -0.0) (FloatVal -inf))

--- a/tests/expr/t02_div_float_values_nzero_nzero.test
+++ b/tests/expr/t02_div_float_values_nzero_nzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "nan : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal -0.0) (FloatVal -0.0))

--- a/tests/expr/t02_div_float_values_nzero_pfinite.test
+++ b/tests/expr/t02_div_float_values_nzero_pfinite.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-0.0 : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal -0.0) (FloatVal 1.0))

--- a/tests/expr/t02_div_float_values_nzero_pinf.test
+++ b/tests/expr/t02_div_float_values_nzero_pinf.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-0.0 : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal -0.0) (FloatVal inf))

--- a/tests/expr/t02_div_float_values_nzero_pzero.test
+++ b/tests/expr/t02_div_float_values_nzero_pzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "nan : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal -0.0) (FloatVal 0.0))

--- a/tests/expr/t02_div_float_values_pinf_nfinite.test
+++ b/tests/expr/t02_div_float_values_pinf_nfinite.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-inf : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal inf) (FloatVal -1.0))

--- a/tests/expr/t02_div_float_values_pinf_ninf.test
+++ b/tests/expr/t02_div_float_values_pinf_ninf.test
@@ -1,0 +1,4 @@
+discard """
+  output: "nan : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal inf) (FloatVal -inf))

--- a/tests/expr/t02_div_float_values_pinf_nzero.test
+++ b/tests/expr/t02_div_float_values_pinf_nzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-inf : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal inf) (FloatVal -0.0))

--- a/tests/expr/t02_div_float_values_pinf_pfinite.test
+++ b/tests/expr/t02_div_float_values_pinf_pfinite.test
@@ -1,0 +1,4 @@
+discard """
+  output: "inf : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal inf) (FloatVal 1.0))

--- a/tests/expr/t02_div_float_values_pinf_pinf.test
+++ b/tests/expr/t02_div_float_values_pinf_pinf.test
@@ -1,0 +1,4 @@
+discard """
+  output: "nan : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal inf) (FloatVal inf))

--- a/tests/expr/t02_div_float_values_pinf_pzero.test
+++ b/tests/expr/t02_div_float_values_pinf_pzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "inf : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal inf) (FloatVal 0.0))

--- a/tests/expr/t02_div_float_values_pzero_nfinite.test
+++ b/tests/expr/t02_div_float_values_pzero_nfinite.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-0.0 : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal 0.0) (FloatVal -1.0))

--- a/tests/expr/t02_div_float_values_pzero_ninf.test
+++ b/tests/expr/t02_div_float_values_pzero_ninf.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-0.0 : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal 0.0) (FloatVal -inf))

--- a/tests/expr/t02_div_float_values_pzero_nzero.test
+++ b/tests/expr/t02_div_float_values_pzero_nzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "nan : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal 0.0) (FloatVal -0.0))

--- a/tests/expr/t02_div_float_values_pzero_pfinite.test
+++ b/tests/expr/t02_div_float_values_pzero_pfinite.test
@@ -1,0 +1,4 @@
+discard """
+  output: "0.0 : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal 0.0) (FloatVal 1.0))

--- a/tests/expr/t02_div_float_values_pzero_pinf.test
+++ b/tests/expr/t02_div_float_values_pzero_pinf.test
@@ -1,0 +1,4 @@
+discard """
+  output: "0.0 : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal 0.0) (FloatVal inf))

--- a/tests/expr/t02_div_float_values_pzero_pzero.test
+++ b/tests/expr/t02_div_float_values_pzero_pzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "nan : (FloatTy)"
+"""
+(Call (Ident "/") (FloatVal 0.0) (FloatVal 0.0))

--- a/tests/expr/t02_mul_float_values.test
+++ b/tests/expr/t02_mul_float_values.test
@@ -1,0 +1,4 @@
+discard """
+  output: "8.75 : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal 3.5) (FloatVal 2.5))

--- a/tests/expr/t02_mul_float_values_nan_nan.test
+++ b/tests/expr/t02_mul_float_values_nan_nan.test
@@ -1,0 +1,4 @@
+discard """
+  output: "nan : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal nan) (FloatVal nan))

--- a/tests/expr/t02_mul_float_values_nfinite_nzero.test
+++ b/tests/expr/t02_mul_float_values_nfinite_nzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "0.0 : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal -1.0) (FloatVal -0.0))

--- a/tests/expr/t02_mul_float_values_nfinite_pzero.test
+++ b/tests/expr/t02_mul_float_values_nfinite_pzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-0.0 : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal -1.0) (FloatVal 0.0))

--- a/tests/expr/t02_mul_float_values_ninf_nfinite.test
+++ b/tests/expr/t02_mul_float_values_ninf_nfinite.test
@@ -1,0 +1,4 @@
+discard """
+  output: "inf : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal -inf) (FloatVal -1.0))

--- a/tests/expr/t02_mul_float_values_ninf_ninf.test
+++ b/tests/expr/t02_mul_float_values_ninf_ninf.test
@@ -1,0 +1,4 @@
+discard """
+  output: "inf : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal -inf) (FloatVal -inf))

--- a/tests/expr/t02_mul_float_values_ninf_nzero.test
+++ b/tests/expr/t02_mul_float_values_ninf_nzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "nan : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal -inf) (FloatVal -0.0))

--- a/tests/expr/t02_mul_float_values_ninf_pfinite.test
+++ b/tests/expr/t02_mul_float_values_ninf_pfinite.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-inf : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal -inf) (FloatVal 1.0))

--- a/tests/expr/t02_mul_float_values_ninf_pinf.test
+++ b/tests/expr/t02_mul_float_values_ninf_pinf.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-inf : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal -inf) (FloatVal inf))

--- a/tests/expr/t02_mul_float_values_ninf_pzero.test
+++ b/tests/expr/t02_mul_float_values_ninf_pzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "nan : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal -inf) (FloatVal 0.0))

--- a/tests/expr/t02_mul_float_values_nzero_nzero.test
+++ b/tests/expr/t02_mul_float_values_nzero_nzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "0.0 : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal -0.0) (FloatVal -0.0))

--- a/tests/expr/t02_mul_float_values_overflow_1.test
+++ b/tests/expr/t02_mul_float_values_overflow_1.test
@@ -1,0 +1,4 @@
+discard """
+  output: "inf : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal 1.7976931348623157e+308) (FloatVal 2.0))

--- a/tests/expr/t02_mul_float_values_overflow_2.test
+++ b/tests/expr/t02_mul_float_values_overflow_2.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-inf : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal 1.7976931348623157e+308) (FloatVal -2.0))

--- a/tests/expr/t02_mul_float_values_pfinite_nzero.test
+++ b/tests/expr/t02_mul_float_values_pfinite_nzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-0.0 : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal 1.0) (FloatVal -0.0))

--- a/tests/expr/t02_mul_float_values_pfinite_pzero.test
+++ b/tests/expr/t02_mul_float_values_pfinite_pzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "0.0 : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal 1.0) (FloatVal 0.0))

--- a/tests/expr/t02_mul_float_values_pinf_nan.test
+++ b/tests/expr/t02_mul_float_values_pinf_nan.test
@@ -1,0 +1,4 @@
+discard """
+  output: "nan : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal inf) (FloatVal nan))

--- a/tests/expr/t02_mul_float_values_pinf_nfinite.test
+++ b/tests/expr/t02_mul_float_values_pinf_nfinite.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-inf : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal inf) (FloatVal -1.0))

--- a/tests/expr/t02_mul_float_values_pinf_ninf.test
+++ b/tests/expr/t02_mul_float_values_pinf_ninf.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-inf : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal inf) (FloatVal -inf))

--- a/tests/expr/t02_mul_float_values_pinf_nzero.test
+++ b/tests/expr/t02_mul_float_values_pinf_nzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "nan : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal inf) (FloatVal -0.0))

--- a/tests/expr/t02_mul_float_values_pinf_pfinite.test
+++ b/tests/expr/t02_mul_float_values_pinf_pfinite.test
@@ -1,0 +1,4 @@
+discard """
+  output: "inf : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal inf) (FloatVal 1.0))

--- a/tests/expr/t02_mul_float_values_pinf_pinf.test
+++ b/tests/expr/t02_mul_float_values_pinf_pinf.test
@@ -1,0 +1,4 @@
+discard """
+  output: "inf : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal inf) (FloatVal inf))

--- a/tests/expr/t02_mul_float_values_pinf_pzero.test
+++ b/tests/expr/t02_mul_float_values_pinf_pzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "nan : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal inf) (FloatVal 0.0))

--- a/tests/expr/t02_mul_float_values_pzero_nzero.test
+++ b/tests/expr/t02_mul_float_values_pzero_nzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-0.0 : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal 0.0) (FloatVal -0.0))

--- a/tests/expr/t02_mul_float_values_pzero_pzero.test
+++ b/tests/expr/t02_mul_float_values_pzero_pzero.test
@@ -1,0 +1,4 @@
+discard """
+  output: "0.0 : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal 0.0) (FloatVal 0.0))

--- a/tests/expr/t02_mul_float_values_underflow_1.test
+++ b/tests/expr/t02_mul_float_values_underflow_1.test
@@ -1,0 +1,4 @@
+discard """
+  output: "0.0 : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal 5e-324) (FloatVal 0.5))

--- a/tests/expr/t02_mul_float_values_underflow_2.test
+++ b/tests/expr/t02_mul_float_values_underflow_2.test
@@ -1,0 +1,4 @@
+discard """
+  output: "-0.0 : (FloatTy)"
+"""
+(Call (Ident "*") (FloatVal 5e-324) (FloatVal -0.5))


### PR DESCRIPTION
## Summary

Add the `*` and `/` operators for float values. Their operational
semantics are defined according to the IEEE 754 standard.

## Details

Both the definition in `source` and implementation in `source2il` are
straightforward. Tests are added to make sure multiplication and
division works, especially when involving non-finite values.

Integer and floating-point division are different enough to warrant
using separate identifiers (`/` vs. `div`). This also makes it possible
to add a `/` overload accepting integer values, in the future.

Division is defined in terms of a rational number division + to-float
conversion, as this is easier to understand than a division algorithm
using only integer numbers.

### Misc

Fix a small issue with the float addition overflow tests; they were
using constants that are outside the finite 64-bit floating point range,
meaning that the tests were effectively testing `inf` + finite. The
constants are changed to the largest possible finite values. 
