### PR TITLE
lang: add array type

### DIFF
--- a/languages/specification.md
+++ b/languages/specification.md
@@ -14,6 +14,7 @@ strVal   ::= (StringVal <string>)
 expr     ::= <ident>
           |  <intVal>
           |  <floatVal>
+          |  (ArrayCons <expr>+)
           |  (TupleCons <expr>*)
           |  (RecordCons (Field <ident> <expr>)+)
           |  (Seq <texpr> <expr>*)
@@ -39,6 +40,7 @@ texpr    ::= <ident>
           |  (BoolTy)
           |  (IntTy)
           |  (FloatTy)
+          |  (ArrayTy <intVal> <texpr>)
           |  (TupleTy <texpr>*)
           |  (RecordTy (Field <ident> <texpr>)+)
           |  (UnionTy <texpr>+)

--- a/passes/ir.nim
+++ b/passes/ir.nim
@@ -47,8 +47,11 @@ template add*(n: var IrNode, elems: seq[IrNode]) =
   let tmp = elems
   n.children.add tmp
 
-proc newIntVal*(v: BiggestInt): IrNode =
-  IrNode(kind: IntVal, intVal: v.int)
+proc newIntVal*(v: SomeInteger): IrNode =
+  when v is SomeUnsignedInt:
+    IrNode(kind: IntVal, intVal: cast[int](v))
+  else:
+    IrNode(kind: IntVal, intVal: v.int)
 
 proc newFloatVal*(val: float): IrNode =
   IrNode(kind: FloatVal, floatVal: val)
@@ -70,6 +73,9 @@ proc newChoice*(val, then: sink IrNode): IrNode =
 
 proc newCase*(typ: uint32, sel: sink IrNode): IrNode =
   IrNode(kind: Case, children: @[newTypeUse(typ), sel])
+
+proc newLoop*(body: sink IrNode): IrNode =
+  IrNode(kind: Loop, children: @[body])
 
 proc newAsgn*(dest, src: sink IrNode): IrNode =
   # allow none for the sake of error correction

--- a/passes/syntax_source.nim
+++ b/passes/syntax_source.nim
@@ -11,12 +11,13 @@ type
   NodeKind* {.pure.} = enum
     IntVal, FloatVal, StringVal
     Ident,
-    VoidTy, UnitTy, BoolTy, CharTy, IntTy, FloatTy, TupleTy, RecordTy, UnionTy,
-    ProcTy, SeqTy
+    VoidTy, UnitTy, BoolTy, CharTy, IntTy, FloatTy, ArrayTy, TupleTy, RecordTy,
+    UnionTy, ProcTy, SeqTy
     And, Or
     If
     While
     Call
+    ArrayCons
     TupleCons
     RecordCons
     Seq
@@ -38,8 +39,8 @@ type
   Node = TreeNode[NodeKind]
 
 const
-  ExprNodes* = {IntVal, FloatVal, Ident, And, Or, If, While, Call, TupleCons,
-                RecordCons, Seq, FieldAccess, At, As, Asgn, Return,
+  ExprNodes* = {IntVal, FloatVal, Ident, And, Or, If, While, Call, ArrayCons,
+                TupleCons, RecordCons, Seq, FieldAccess, At, As, Asgn, Return,
                 Unreachable, Match, Exprs, Decl}
   DeclNodes* = {ProcDecl, TypeDecl}
   AllNodes* = {low(NodeKind) .. high(NodeKind)}

--- a/phy/type_rendering.nim
+++ b/phy/type_rendering.nim
@@ -19,6 +19,13 @@ proc typeToString*(typ: SemType): string =
   of tkChar:  "char"
   of tkInt:   "int"
   of tkFloat: "float"
+  of tkArray:
+    var res = "array("
+    res.addInt typ.length
+    res.add ", "
+    res.add typeToString(typ.elem[0])
+    res.add ")"
+    res
   of tkTuple:
     var res = "("
     for i, it in typ.elems.pairs:
@@ -79,6 +86,8 @@ proc typeToSexp*(typ: SemType): SexpNode =
   of tkChar:  newSList(newSSymbol("CharTy"))
   of tkInt:   newSList(newSSymbol("IntTy"))
   of tkFloat: newSList(newSSymbol("FloatTy"))
+  of tkArray: newSList(newSSymbol("ArrayTy"), newSInt(typ.length),
+                       typeToSexp(typ.elem[0]))
   of tkTuple:
     var res = newSList(newSSymbol("TupleTy"))
     for it in typ.elems.items:

--- a/phy/vmexec.nim
+++ b/phy/vmexec.nim
@@ -77,6 +77,12 @@ proc valueToSexp(env: var VmEnv, a: VirtualAddr, typ: SemType): SexpNode =
     result = primToSexp(Value(readInt(p, 8)), typ)
   of tkFloat:
     result = primToSexp(cast[Value](readFloat64(p)), typ)
+  of tkArray:
+    result = newCons("ArrayCons")
+    let stride = size(typ.elem[0])
+    for i in 0..<typ.length:
+      result.add valueToSexp(env, VirtualAddr(a.uint64 + uint64(stride * i)),
+                             typ.elem[0])
   of tkTuple:
     result = newCons("TupleCons")
     var offset = 0

--- a/tests/expr/spectest.nim
+++ b/tests/expr/spectest.nim
@@ -31,6 +31,12 @@ const
        files: {:}))
     ## the initial dynamic context to pass to `cstep`
   issues = [ # tests that are currently expected to fail
+    "t03_array_at_eval_order_1.test",
+    "t03_array_at_eval_order_2.test",
+    "t03_array_type_cons.test",
+    "t03_array_type_cons_count_1_error.test",
+    "t03_array_type_cons_count_2_error.test",
+    "t03_array_type_cons_no_void_error.test",
     "t03_tuple_at_eval_order_1.test",
     "t03_tuple_at_eval_order_2.test",
     "t04_empty_module.test",

--- a/tests/expr/t03_array_access_1.test
+++ b/tests/expr/t03_array_access_1.test
@@ -1,0 +1,4 @@
+discard """
+  output: "1 : (IntTy)"
+"""
+(At (ArrayCons 1 2) (IntVal 0))

--- a/tests/expr/t03_array_access_2.test
+++ b/tests/expr/t03_array_access_2.test
@@ -1,0 +1,4 @@
+discard """
+  output: "2 : (IntTy)"
+"""
+(At (ArrayCons 1 2) (IntVal 1))

--- a/tests/expr/t03_array_access_3.test
+++ b/tests/expr/t03_array_access_3.test
@@ -1,0 +1,6 @@
+discard """
+  output: "1 : (IntTy)"
+"""
+(Exprs
+  (Decl x (ArrayCons 1 2))
+  (At x (IntVal 0)))

--- a/tests/expr/t03_array_access_4.test
+++ b/tests/expr/t03_array_access_4.test
@@ -1,0 +1,7 @@
+discard """
+  output: "(ArrayCons 3 2) : (ArrayTy 2 (IntTy))"
+"""
+(Exprs
+  (Decl x (ArrayCons 1 2))
+  (Asgn (At x (IntVal 0)) 3)
+  x)

--- a/tests/expr/t03_array_access_5.test
+++ b/tests/expr/t03_array_access_5.test
@@ -1,0 +1,7 @@
+discard """
+  output: "(ArrayCons 1 3) : (ArrayTy 2 (IntTy))"
+"""
+(Exprs
+  (Decl x (ArrayCons 1 2))
+  (Asgn (At x (IntVal 1)) 3)
+  x)

--- a/tests/expr/t03_array_access_out_of_bounds_1.test
+++ b/tests/expr/t03_array_access_out_of_bounds_1.test
@@ -1,0 +1,4 @@
+discard """
+  output: "(Unreachable) : (IntTy)"
+"""
+(At (ArrayCons 1 2) (IntVal -1))

--- a/tests/expr/t03_array_access_out_of_bounds_2.test
+++ b/tests/expr/t03_array_access_out_of_bounds_2.test
@@ -1,0 +1,4 @@
+discard """
+  output: "(Unreachable) : (IntTy)"
+"""
+(At (ArrayCons 1 2) (IntVal 3))

--- a/tests/expr/t03_array_at_eval_order_1.test
+++ b/tests/expr/t03_array_at_eval_order_1.test
@@ -1,0 +1,14 @@
+discard """
+  description: "
+    The index check for non-lvalue operands takes place immediately once
+    the index value is available.
+  "
+  output: "(Unreachable) : (IntTy)"
+"""
+(ProcDecl test (IntTy) (Params)
+  (At
+    (At
+      (ArrayCons
+        (ArrayCons 1 2))
+      2)
+    (If true (Return 3) 0)))

--- a/tests/expr/t03_array_at_eval_order_2.test
+++ b/tests/expr/t03_array_at_eval_order_2.test
@@ -1,0 +1,14 @@
+discard """
+  description: "
+    The index check for lvalue operands takes place only once all index
+    expressions in the enclosing lvalue expression are evaluated (layered
+    evaluation).
+  "
+  output: "3 : (IntTy)"
+"""
+(ProcDecl test (IntTy) (Params)
+  (Exprs
+    (Decl arr (ArrayCons (ArrayCons 1 2)))
+    (At
+      (At arr 2)
+      (If true (Return 3) 0))))

--- a/tests/expr/t03_array_at_eval_order_3.test
+++ b/tests/expr/t03_array_at_eval_order_3.test
@@ -1,0 +1,14 @@
+discard """
+  description: "The index expressions are evaluated strictly from left to right"
+  output: "1 : (IntTy)"
+"""
+(Exprs
+  (Decl i 0)
+  (At
+    (At
+      (ArrayCons
+        (ArrayCons 1 2))
+      i)
+    (Exprs
+      (Asgn i 100)
+      0)))

--- a/tests/expr/t03_array_at_eval_order_4.test
+++ b/tests/expr/t03_array_at_eval_order_4.test
@@ -1,0 +1,13 @@
+discard """
+  description: "The index expressions are evaluated strictly from left to right"
+  output: "1 : (IntTy)"
+"""
+(Exprs
+  (Decl arr
+    (ArrayCons (ArrayCons 1 2)))
+  (Decl i 0)
+  (At
+    (At arr i)
+    (Exprs
+      (Asgn i 100)
+      0)))

--- a/tests/expr/t03_array_at_eval_order_5.test
+++ b/tests/expr/t03_array_at_eval_order_5.test
@@ -1,0 +1,18 @@
+discard """
+  description: "
+    The non-lvalue parts of the array operand are also evaluated strictly from
+    left to right.
+  "
+  output: "1 : (IntTy)"
+"""
+(Exprs
+  (Decl arr
+    (ArrayCons (ArrayCons 1 2)))
+  (Decl i 10)
+  (At
+    (At
+      (Exprs
+        (Asgn i 0)
+        arr)
+      i)
+    0)))

--- a/tests/expr/t03_array_cons_1.test
+++ b/tests/expr/t03_array_cons_1.test
@@ -1,0 +1,4 @@
+discard """
+  output: "(ArrayCons 1) : (ArrayTy 1 (IntTy))"
+"""
+(ArrayCons 1)

--- a/tests/expr/t03_array_cons_2.test
+++ b/tests/expr/t03_array_cons_2.test
@@ -1,0 +1,4 @@
+discard """
+  output: "(ArrayCons 1 2) : (ArrayTy 2 (IntTy))"
+"""
+(ArrayCons 1 2)

--- a/tests/expr/t03_array_cons_3.test
+++ b/tests/expr/t03_array_cons_3.test
@@ -1,0 +1,8 @@
+discard """
+  description: "
+    The element type of a construct array is the common type of all supplied
+    elements.
+  "
+  output: "(ArrayCons 1 (TupleCons)) : (ArrayTy 2 (UnionTy (UnitTy) (IntTy)))"
+"""
+(ArrayCons 1 (As (TupleCons) (UnionTy (UnitTy) (IntTy))))

--- a/tests/expr/t03_array_cons_4.test
+++ b/tests/expr/t03_array_cons_4.test
@@ -1,0 +1,8 @@
+discard """
+  description: "
+    The element type of a construct array is the common type of all supplied
+    elements.
+  "
+  output: "(ArrayCons (TupleCons) 1) : (ArrayTy 2 (UnionTy (UnitTy) (IntTy)))"
+"""
+(ArrayCons (As (TupleCons) (UnionTy (UnitTy) (IntTy))) 1)

--- a/tests/expr/t03_array_cons_no_common_type_error.test
+++ b/tests/expr/t03_array_cons_no_common_type_error.test
@@ -1,0 +1,4 @@
+discard """
+  reject: true
+"""
+(ArrayCons 1 (TupleCons))

--- a/tests/expr/t03_array_cons_no_void_1_error.test
+++ b/tests/expr/t03_array_cons_no_void_1_error.test
@@ -1,0 +1,4 @@
+discard """
+  reject: true
+"""
+(ArrayCons (Unreachable))

--- a/tests/expr/t03_array_cons_no_void_2_error.test
+++ b/tests/expr/t03_array_cons_no_void_2_error.test
@@ -1,0 +1,4 @@
+discard """
+  reject: true
+"""
+(ArrayCons 1 (Unreachable))

--- a/tests/expr/t03_array_type_cons.test
+++ b/tests/expr/t03_array_type_cons.test
@@ -1,0 +1,4 @@
+discard """
+  arguments: "c"
+"""
+(TypeDecl x (ArrayTy 1 (IntTy)))

--- a/tests/expr/t03_array_type_cons_count_1_error.test
+++ b/tests/expr/t03_array_type_cons_count_1_error.test
@@ -1,0 +1,4 @@
+discard """
+  reject: true
+"""
+(TypeDecl x (ArrayTy -1 (VoidTy)))

--- a/tests/expr/t03_array_type_cons_count_2_error.test
+++ b/tests/expr/t03_array_type_cons_count_2_error.test
@@ -1,0 +1,4 @@
+discard """
+  reject: true
+"""
+(TypeDecl x (ArrayTy 4294967296 (VoidTy)))

--- a/tests/expr/t03_array_type_cons_no_void_error.test
+++ b/tests/expr/t03_array_type_cons_no_void_error.test
@@ -1,0 +1,4 @@
+discard """
+  reject: true
+"""
+(TypeDecl x (ArrayTy 1 (VoidTy)))

--- a/tests/expr/t17_seq_copy_5.test
+++ b/tests/expr/t17_seq_copy_5.test
@@ -1,0 +1,8 @@
+discard """
+  output: "(ArrayCons (array 1 2 3)) : (ArrayTy 1 (SeqTy (IntTy)))"
+"""
+(Exprs
+  (Decl x (Seq (IntTy) 1 2 3))
+  (Decl y (ArrayCons x))
+  (Asgn (At x 0) 4)
+  y)


### PR DESCRIPTION
## Summary

Add an array type to the source language, which represents a
homogeneous fixed-size vector type. Array values are constructed with
`ArrayCons`.

## Details

Arrays have significant overlap with homogeneous tuples, to the point
that they are essentially isomorphic (but they aren't considered as
such by the language, at the moment), most likely requiring a rework in
the near future.

For the moment, `ArrayTy` provides a more convenient way (when compared
to `TupleTy`) to express homogeneous vectors with many elements.
Compared to `TupleCons`, `ArrayCons` requires the elements' types to be
homogeneous, or that they at least have a common ancestor type.
