### PR TITLE
interpreter: start with using tail calls

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,7 +59,7 @@ jobs:
       # use a pinned version in order to make CI runs reproducible
       - uses: nim-works/setup-nimskull@0.1.2
         with:
-          nimskull-version: "0.1.0-dev.21449"
+          nimskull-version: "0.1.0-dev.21456"
 
       - name: Build koch
         run: nim c -d:nimStrictMode --outdir:bin koch.nim
@@ -91,7 +91,7 @@ jobs:
       # use a pinned version in order to make CI runs reproducible
       - uses: nim-works/setup-nimskull@0.1.2
         with:
-          nimskull-version: "0.1.0-dev.21449"
+          nimskull-version: "0.1.0-dev.21456"
 
       - name: Build koch
         run: nim c -d:nimStrictMode --outdir:bin koch.nim
@@ -123,7 +123,7 @@ jobs:
       # use a pinned version in order to make CI runs reproducible
       - uses: nim-works/setup-nimskull@0.1.2
         with:
-          nimskull-version: "0.1.0-dev.21449"
+          nimskull-version: "0.1.0-dev.21456"
 
       - name: Build koch
         run: nim c -d:nimStrictMode --outdir:bin koch.nim

--- a/spec/cps.nim
+++ b/spec/cps.nim
@@ -27,6 +27,8 @@ proc `=copy`(dst: var CellRef, src: CellRef) =
       dst.p = src.p.copy(src.p)
 
 proc take[T](c: sink CellRef): T {.inline.} =
+  ## Returns the value from the given cell, `c`, which has to have dynamic
+  ## type `T`.
   move (Cell[T])(c.p).val
 
 proc copyImpl[T](x: CellBase): CellBase =

--- a/spec/cps.nim
+++ b/spec/cps.nim
@@ -1,0 +1,150 @@
+## Implements some macros and types to make writing code in continuation-
+## passing style easier.
+
+import std/macros
+
+{.experimental: "callOperator".}
+
+type
+  CellBase = ref object of RootObj
+    ## Header for a heap cell.
+    copy: (proc(x: CellBase): CellBase {.nimcall, raises: [].})
+  Cell[T] = ref object of CellBase
+    val: T
+
+  CellRef = object
+    ## Type-erased managed unique pointer to a heap cell. Needed for storing
+    ## the environment for continuations.
+    p: CellBase
+
+# --- cell implementation
+
+proc `=copy`(dst: var CellRef, src: CellRef) =
+  if dst.p != src.p: # do nothing for self assignments
+    if src.p.isNil:
+      dst.p = nil
+    else:
+      dst.p = src.p.copy(src.p)
+
+proc take[T](c: sink CellRef): T {.inline.} =
+  move (Cell[T])(c.p).val
+
+proc copyImpl[T](x: CellBase): CellBase =
+  Cell[T](val: Cell[T](x).val, copy: x.copy)
+
+proc newCell[T](val: sink T): CellRef {.inline.} =
+  CellRef(p: Cell[T](val: val, copy: copyImpl[T]))
+
+# ---- macro helpers
+
+template strip[T](x: typedesc[sink T]): typedesc = T
+
+proc paramType(): NimNode =
+  newCall(ident"sink", bindSym"CellRef")
+
+macro cont*(captures, lambda: untyped): untyped =
+  ## Meant to be used as a pragma. Turns a lambda expression into a
+  ## continuation construction, with all items in the `captures` list captured
+  ## by value (or address).
+  lambda.expectKind nnkLambda
+  lambda.pragma.add ident"nimcall"
+
+  let
+    unpack = nnkVarTuple.newTree() ## the capture tuple unpacking
+    typ    = nnkTupleConstr.newTree() ## the type of the capture tuple
+    constr = nnkTupleConstr.newTree() ## the capture tuple construction
+
+  # create the adapter/thunk procedure. It's responsible for unpacking the
+  # environment
+  let wrapper = newProc(newEmptyNode())
+  wrapper.pragma = nnkPragma.newTree(ident"nimcall")
+  wrapper.body = newStmtList()
+  wrapper.params = lambda.params.copyNimTree()
+  wrapper.params.add newIdentDefs(ident"env", paramType())
+
+  let call = newCall(lambda) # the call to the original lambda
+  for i in 1..<lambda.params.len:
+    for j in 0..<lambda.params[i].len-2:
+      call.add lambda.params[i][j]
+
+  proc fixedTypeof(n: NimNode): NimNode =
+    # work around the compiler not dropping the sink modifier with `typeof`
+    newCall(bindSym"strip", quote do: typeof(`n`))
+
+  captures.expectKind {nnkPar, nnkTupleConstr}
+  # handle the captures:
+  for it in captures.items:
+    case it.kind
+    of nnkPtrTy:
+      # the value is captured by address. It's passed to the inner procedure as
+      # an immutable parameter
+      it.expectLen 1
+      let name = it[0]
+      unpack.add name
+      call.add (quote do: `name`[])
+      constr.add nnkAddr.newTree(name)
+      typ.add nnkPtrTy.newTree(fixedTypeof(name))
+      lambda.params.add newIdentDefs(name, quote do: typeof(`name`[]))
+    of nnkIdent:
+      # capture by value -- the value is passed to the inner procedure as a
+      # sink parameter
+      unpack.add it
+      call.add it
+      constr.add it
+      typ.add fixedTypeof(it)
+      lambda.params.add newIdentDefs(it, quote do: sink typeof(`it`))
+    else:
+      error("expected identifier or `ptr x`", it)
+
+  # finish the tuple unpacking statement and emit it into the wrapper
+  # procedure:
+  unpack.add newEmptyNode()
+  unpack.add newCall(nnkBracketExpr.newTree(bindSym"take", typ), ident"env")
+
+  wrapper.body.add nnkVarSection.newTree(unpack)
+  wrapper.body.add call
+
+  # the original lambda expression becomes a continuation construction
+  result = nnkTupleConstr.newTree(wrapper, newCall(bindSym"newCell", constr))
+
+macro cont*(lambda: untyped): untyped =
+  ## Meant to be used as a pragma. Turns a lambda expression into a
+  ## continuation construction.
+  lambda.expectKind nnkLambda
+  lambda.params.add newIdentDefs(ident"env", paramType())
+  lambda.pragma.add ident"nimcall"
+  result = nnkTupleConstr.newTree(
+    lambda,
+    nnkObjConstr.newTree(bindSym"CellRef"))
+
+macro contcc*(typ: untyped): typedesc =
+  ## A proc type annotation, marking the proc type as being a continuation.
+  ## Storage wise, a continuation is a tuple.
+  typ.expectKind nnkProcTy
+
+  let ntyp = copyNimTree(typ)
+  ntyp.pragma.add ident"nimcall"
+  ntyp[0].add newIdentDefs(ident"env", paramType())
+
+  result = nnkTupleConstr.newTree(ntyp, bindSym"CellRef")
+
+  # for reasons that are beyond silly (the compiler analyzes the proc type
+  # expression twice, with each macro pragma application being destructive
+  # to the original AST, but only within type sections), we need to add the
+  # pragma back to the original AST...
+  typ.pragma.add ident"contcc"
+
+macro `()`*[T](c: (T, CellRef), args: varargs[untyped]): untyped =
+  ## Invokes continuation `c` with the given `args`, consuming it in the
+  ## process.
+  let
+    callee = genSym(nskLet, "callee")
+    arg    = genSym(nskLet, "arg")
+    call   = newCall(callee)
+  for it in args.items:
+    call.add it
+  call.add arg
+
+  result = quote do:
+    let (`callee`, `arg`) = `c`
+    `call`

--- a/spec/cps.nim
+++ b/spec/cps.nim
@@ -47,7 +47,7 @@ macro cont*(captures, lambda: untyped): untyped =
   ## continuation construction, with all items in the `captures` list captured
   ## by value (or address).
   lambda.expectKind nnkLambda
-  lambda.pragma.add ident"nimcall"
+  lambda.pragma.add ident"tailcall"
 
   let
     unpack = nnkVarTuple.newTree() ## the capture tuple unpacking
@@ -57,7 +57,7 @@ macro cont*(captures, lambda: untyped): untyped =
   # create the adapter/thunk procedure. It's responsible for unpacking the
   # environment
   let wrapper = newProc(newEmptyNode())
-  wrapper.pragma = nnkPragma.newTree(ident"nimcall")
+  wrapper.pragma = nnkPragma.newTree(ident"tailcall")
   wrapper.body = newStmtList()
   wrapper.params = lambda.params.copyNimTree()
   wrapper.params.add newIdentDefs(ident"env", paramType())
@@ -112,7 +112,7 @@ macro cont*(lambda: untyped): untyped =
   ## continuation construction.
   lambda.expectKind nnkLambda
   lambda.params.add newIdentDefs(ident"env", paramType())
-  lambda.pragma.add ident"nimcall"
+  lambda.pragma.add ident"tailcall"
   result = nnkTupleConstr.newTree(
     lambda,
     nnkObjConstr.newTree(bindSym"CellRef"))
@@ -123,7 +123,7 @@ macro contcc*(typ: untyped): typedesc =
   typ.expectKind nnkProcTy
 
   let ntyp = copyNimTree(typ)
-  ntyp.pragma.add ident"nimcall"
+  ntyp.pragma.add ident"tailcall"
   ntyp[0].add newIdentDefs(ident"env", paramType())
 
   result = nnkTupleConstr.newTree(ntyp, bindSym"CellRef")


### PR DESCRIPTION
## Summary

Start with using tail calls for the continuations in the `interpret`
procedure. This prevents stack overflows when interpreting functions
with very complex bodies.

## Details

So far, continuations were just arbitrary closures, but now they're
`.tailcall` procedures. Anonymous `.tailcall` procedure cannot capture
outer variables, so captures have to be handled manually. A small set of
simple macro helpers (the `cps` module) is introduced to eliminate the
boilerplate code this would entail.

The main change is made out of two parts:
1. the lambda sugar is replaced with `proc(...): ...` that use the
   `.cont` calling convention (which is a macro pragma)
2. where sensible and necessary, procedure parameters use `sink`, and
   owning locals and parameter are destroyed manually, using the `drop`
   helper. The inner procedures in `interpret` are also turned into
   `.tailcall` procedures, so that the the tail-call chain is not
   interrupted

The `cps` macros are kept as simple as possible, performing no analysis
of the procedure bodies. Continuations have value semantics and
capture everything by value by default.

Since closure environments are now only created when really needed, with
automatic moves used wherever possible, this change also noticeably
improves run-time performance of the interpreter.

The required NimSkull compiler version is bumped to the most recent one,
as it include a bugfix necessary for the changes to compile.

---

## Notes For Reviewers

* this is the first step in using tail calls throughout the
  `interpreter` module; next up is updating the pattern matching
* since only the core interpreter loop uses tail-calls at the moment,
  stack overflows are still possible with long patterns or deep function
  recursion
* for review, I recommend first taking a look at the `cps` module
