### PR TITLE
use the built-in `unreachable`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,7 +59,7 @@ jobs:
       # use a pinned version in order to make CI runs reproducible
       - uses: nim-works/setup-nimskull@0.1.2
         with:
-          nimskull-version: "0.1.0-dev.21456"
+          nimskull-version: "0.1.0-dev.21464"
 
       - name: Build koch
         run: nim c -d:nimStrictMode --outdir:bin koch.nim
@@ -91,7 +91,7 @@ jobs:
       # use a pinned version in order to make CI runs reproducible
       - uses: nim-works/setup-nimskull@0.1.2
         with:
-          nimskull-version: "0.1.0-dev.21456"
+          nimskull-version: "0.1.0-dev.21464"
 
       - name: Build koch
         run: nim c -d:nimStrictMode --outdir:bin koch.nim
@@ -123,7 +123,7 @@ jobs:
       # use a pinned version in order to make CI runs reproducible
       - uses: nim-works/setup-nimskull@0.1.2
         with:
-          nimskull-version: "0.1.0-dev.21456"
+          nimskull-version: "0.1.0-dev.21464"
 
       - name: Build koch
         run: nim c -d:nimStrictMode --outdir:bin koch.nim

--- a/passes/ir.nim
+++ b/passes/ir.nim
@@ -8,8 +8,7 @@
 ## translation.
 
 import
-  passes/[builders, syntax, trees],
-  vm/utils
+  passes/[builders, syntax, trees]
 
 type
   IrNode* = object

--- a/passes/pass25.nim
+++ b/passes/pass25.nim
@@ -3,8 +3,7 @@
 
 import
   std/[tables],
-  passes/[builders, changesets, trees, syntax],
-  vm/utils
+  passes/[builders, changesets, trees, syntax]
 
 type
   Node = TreeNode[NodeKind]

--- a/passes/pass30.nim
+++ b/passes/pass30.nim
@@ -4,8 +4,7 @@
 
 import
   std/options,
-  passes/[builders, changesets, trees, syntax],
-  vm/utils
+  passes/[builders, changesets, trees, syntax]
 
 type
   Node = TreeNode[NodeKind]

--- a/passes/pass_aggregatesToBlob.nim
+++ b/passes/pass_aggregatesToBlob.nim
@@ -2,8 +2,7 @@
 ## address value arithmetic (|L3| -> |L3|).
 
 import
-  passes/[changesets, syntax, trees],
-  vm/utils
+  passes/[changesets, syntax, trees]
 
 type
   Node = TreeNode[NodeKind]

--- a/passes/pass_legalizeBlobOps.nim
+++ b/passes/pass_legalizeBlobOps.nim
@@ -2,8 +2,7 @@
 ## (|L3| -> |L3|).
 
 import
-  passes/[changesets, syntax, trees],
-  vm/utils
+  passes/[changesets, syntax, trees]
 
 using
   tree: PackedTree[NodeKind]

--- a/passes/pass_localsToBlob.nim
+++ b/passes/pass_localsToBlob.nim
@@ -3,8 +3,7 @@
 
 import
   std/[packedsets],
-  passes/[changesets, syntax, trees],
-  vm/utils
+  passes/[changesets, syntax, trees]
 
 type
   LocalId = distinct uint32

--- a/passes/pass_stackAlloc.nim
+++ b/passes/pass_stackAlloc.nim
@@ -3,8 +3,7 @@
 ## (|L2| -> |L1|).
 
 import
-  passes/[changesets, syntax, trees],
-  vm/utils
+  passes/[changesets, syntax, trees]
 
 type
   Node = TreeNode[NodeKind]

--- a/passes/syntax.nim
+++ b/passes/syntax.nim
@@ -5,8 +5,7 @@
 
 import
   experimental/sexp,
-  passes/trees,
-  vm/utils
+  passes/trees
 
 type
   NodeKind* = enum

--- a/passes/syntax_source.nim
+++ b/passes/syntax_source.nim
@@ -4,8 +4,7 @@
 
 import
   experimental/sexp,
-  passes/trees,
-  vm/utils
+  passes/trees
 
 type
   NodeKind* {.pure.} = enum

--- a/phy/reporting.nim
+++ b/phy/reporting.nim
@@ -2,9 +2,6 @@
 ## report hints, warnings, or errors needs access to a ``ReportContext``-
 ## derived type.
 
-import
-  vm/utils
-
 type
   ReportContext*[T] = object of RootObj
     ## The base type that all report context types must be derived from.

--- a/phy/type_rendering.nim
+++ b/phy/type_rendering.nim
@@ -6,8 +6,7 @@ import
   ],
   phy/[
     types
-  ],
-  vm/utils
+  ]
 
 proc typeToString*(typ: SemType): string =
   ## Returns the text representation of `typ` meant for diagnostic messages

--- a/phy/types.nim
+++ b/phy/types.nim
@@ -10,11 +10,6 @@
 #      If types are de-duplicated on creation, this would also reduce testing
 #      types for equality to an integer comparison
 
-import
-  vm/[
-    utils
-  ]
-
 type
   SizeUnit* = int
     ## Used for numbers that represent size and alignment values.

--- a/skully/backend.nim
+++ b/skully/backend.nim
@@ -9,6 +9,9 @@ import
     strtabs,
     tables
   ],
+  std/private/[
+    containers
+  ],
   compiler/front/[
     options,
     msgs
@@ -32,7 +35,6 @@ import
   ],
   compiler/utils/[
     bitsets,
-    containers,
     platform
   ],
   compiler/backend/[
@@ -57,7 +59,6 @@ import
 
 from compiler/mir/mirbodies import MirBody, `[]`
 
-import vm/utils as vm_utils
 import skully/passes as phy_passes
 
 type

--- a/vm/utils.nim
+++ b/vm/utils.nim
@@ -1,8 +1,6 @@
 ## Contains various not-yet sorted routines. These should eventually move into
 ## elswhere.
 
-import std/private/miscdollars
-
 # ------- HOslice
 
 type HOslice*[T: Ordinal] = object
@@ -21,24 +19,6 @@ iterator items*[T](s: HOslice[T]): T =
   ## Returns all values part of the slice.
   for it in s.a..<s.b:
     yield it
-
-# ------- unreachable
-
-type IInfo = typeof(instantiationInfo())
-
-func unreachableImpl(loc: IInfo, extra = "") {.noinline, noreturn.} =
-  var msg: string
-  msg.toLocation(loc.filename, loc.line, loc.column + 1)
-  msg.add" unreachable"
-  if extra.len != 0:
-    msg.add " "
-    msg.add extra
-  raiseAssert(msg)
-
-template unreachable*(xtraMsg = "") =
-  ## Use ``unreachable`` to mark a point in the program as unreachable. This
-  ## is preferred over ``assert false``.
-  unreachableImpl(instantiationInfo(-1), xtraMsg)
 
 # ------- checked arithmetic
 


### PR DESCRIPTION
## Summary

* replace the custom `unreachable` with the NimSkull-built-in one
* bump the minimum-required NimSkull version to `0.1.0-dev.21464`

## Details

* remove the custom `unreachable` implementation
* remove all now-unused imports of `vm/utils`
* use the `std/private/containers` module instead of `compiler/utils/containers`  