### PR TITLE
improve the meta-language's type system

### DIFF
--- a/languages/source.nim
+++ b/languages/source.nim
@@ -1270,13 +1270,13 @@ const lang* = language:
     axiom "E-while", While(e_1, e_2), If(e_1, Exprs(e_2, While(e_1, e_2)), TupleCons())
 
     rule "E-match-success":
-      premise types(C(ret: VoidTy), val_1, typ_1)
+      premise types(C(ret: VoidTy()), val_1, typ_1)
       condition typ_1 == texpr_1
       conclusion Match(val_1, Rule(As(Ident(string_1), texpr_1), e_1), *any),
                  substitute(e_1, {string_1 : val_1})
 
     rule "E-match-next":
-      premise types(C(ret: VoidTy), val_1, typ_1)
+      premise types(C(ret: VoidTy()), val_1, typ_1)
       condition typ_1 != texpr_1
       conclusion Match(val_1, Rule(As(x, texpr_1), e), +rule_1),
                  Match(val_1, ...rule_1)

--- a/phy/queryshell.nim
+++ b/phy/queryshell.nim
@@ -194,16 +194,20 @@ proc getDefault(lang: LangDef, typ: TypeId): types.Node[TypeId] =
       r.add tree(nkAssoc, Node(kind: nkSymbol, sym: it.name),
                  getDefault(lang, it.typ))
     r
-  of tkData:
-    var r: Node
-    # find a nullary constructor
-    for it in lang[typ].constr.items:
-      if it.kind == nkSymbol or it.len == 1:
-        r = it
-        break
-    r
   of tkSum:
-    getDefault(lang, lang[typ].children[0])
+    var r = Node(kind: nkFail)
+    # look for a type that has a default value
+    for it in lang[typ].children.items:
+      r = getDefault(lang, it)
+      if r.kind != nkFail:
+        return r
+    r
+  of tkPat:
+    if lang[typ].pat.kind == nkSymbol or lang[typ].pat.len == 1:
+      lang[typ].pat
+    else:
+      # too complex
+      Node(kind: nkFail)
 
 proc pretty(res: var ColText, t: Trace, indent: int) =
   ## Pretty-prints the trace `t` and adds the result to `res`.

--- a/spec/interpreter.nim
+++ b/spec/interpreter.nim
@@ -211,6 +211,41 @@ proc matchList(lang; pat: Node, term: Node): Match =
 
   step(lang, pat, term, 0, 0, Match(has: true))
 
+proc matches(lang; typ: TypeId, term: Node): Match =
+  template test(cond: bool): Match =
+    Match(has: cond)
+
+  case lang[typ].kind
+  of tkVoid, tkAll:
+    # TODO: address the type-system issue(s) that results in 'void'
+    #       and 'all' being the same thing at this stage (they shouldn't be)
+    Match(has: true)
+  of tkBool:
+    test term.kind in {nkTrue, nkFalse}
+  of tkInt:
+    test term.kind == nkNumber and term.num.isInt
+  of tkRat:
+    test term.kind == nkNumber
+  of tkList:
+    # TODO: not really correct...
+    test term.kind == nkString
+  of tkRecord:
+    # TODO: should not reach here. Static type checking should elide these
+    #       patterns
+    Match(has: true)
+  of tkFunc:
+    # TODO: same as above
+    test term.kind in {nkMap, nkSet}
+  of tkSum:
+    for it in lang[typ].children.items:
+      if matches(lang, it, term).has:
+        return Match(has: true)
+    Match(has: false)
+  of tkPat:
+    matches(lang, lang[typ].pat, term)
+  else:
+    unreachable()
+
 proc matches(lang; pat, term: Node): Match =
   ## The heart of the pattern matcher (for non-recursive patterns).
   template test(cond: bool): Match =
@@ -253,39 +288,7 @@ proc matches(lang; pat, term: Node): Match =
     else:
       Match(has: false)
   of nkType:
-    case lang[pat.typ].kind
-    of tkVoid, tkAll:
-      # TODO: address the type-system issue(s) that results in 'void'
-      #       and 'all' being the same thing at this stage (they shouldn't be)
-      Match(has: true)
-    of tkBool:
-      test term.kind in {nkTrue, nkFalse}
-    of tkInt:
-      test term.kind == nkNumber and term.num.isInt
-    of tkRat:
-      test term.kind == nkNumber
-    of tkList:
-      # TODO: not really correct...
-      test term.kind == nkString
-    of tkRecord:
-      # TODO: should not reach here. Static type checking should elide these
-      #       patterns
-      Match(has: true)
-    of tkFunc:
-      # TODO: same as above
-      test term.kind in {nkMap, nkSet}
-    of tkData:
-      for it in lang[pat.typ].constr.items:
-        if matches(lang, it, term).has:
-          return Match(has: true)
-      Match(has: false)
-    of tkSum:
-      for it in lang[pat.typ].children.items:
-        if matches(lang, Node(kind: nkType, typ: it), term).has:
-          return Match(has: true)
-      Match(has: false)
-    else:
-      unreachable()
+    matches(lang, pat.typ, term)
   of nkZeroOrMore:
     test term.kind == nkGroup or term.kind == nkString
   of nkOneOrMore:

--- a/spec/langdefs.nim
+++ b/spec/langdefs.nim
@@ -645,7 +645,7 @@ proc matchesPattern(c; pat, term: Node): bool =
 
 proc matchesType(c; typ: Type, n: Node): bool =
   ## Answers the question: "does expression `n` inhabit `typ`".
-  if typ.kind == tkSum and n.kind != nkType:
+  if typ.kind == tkSum and n.kind in {nkSymbol, nkConstr, nkTuple}:
     for it in typ.children.items:
       if matchesType(c, it, n):
         return true

--- a/spec/langdefs.nim
+++ b/spec/langdefs.nim
@@ -1276,10 +1276,12 @@ proc semPredicate(c; n: NimNode): Node =
     let
       pat = semPattern(c, n[1], AllPat)
       e = semExpr(c, n[2])
-    # XXX: this is overly strict. `where` is effectively a dynamic type check,
-    #      so we only need to make sure that the two types (i.e., sets) have
-    #      *some* overlap
-    check(c, e.typ, pat.typ, n[1])
+    # the pattern and source only need to have some overlap, if the actual
+    # run-time value isn't matched by the pattern, a run-time error will be
+    # reported
+    if fitsC(c, e.typ, pat.typ) == relNone and
+       fitsC(c, pat.typ, e.typ) == relNone:
+      error(fmt"{pat.typ} and {e.typ} have no overlap", n[0])
     tree(nkMatches, pat, e)
   elif n[0].eqIdent("condition"):
     n.expectLen 2

--- a/spec/manual.md
+++ b/spec/manual.md
@@ -21,19 +21,27 @@ identifiers to whom a value of the respective type was bound.
 
 Except for type constructors, all non-pattern expressions have a type.
 
-### Data Types
+### Custom Data Types
 
-Abstract data types are defined inductively via the `typ` declaration:
+Custom data types are introduced via the `typ` declaration:
 ```nim
 typ MyList:
   Nil
   Cons(z, MyList)
 ```
 
-`Nil` and `Cons` are *constructors* of `MyList`. `Cons(1, Cons(2, Nil))` is a
-*construction* and has type `MyList`. Multiple constructors may share the same
-name (i.e., they can be overloaded), but they must not have overlapping
-signatures. Constructor names can also be overloaded by other data types.
+`Nil` introduces, if not present already, a nominal unit type, which is
+inhabited by the single term `Nil`.
+
+`Cons` is a *constructor*; `Cons(z, MyList)` is a *pattern type*, inhabited by
+all terms matching the pattern (e.g., `Cons(1, Nil)`, `Cons(2, Nil)`,
+`Cons(3, Cons(1, Nil)))`, etc.). A *pattern type* appearing within a `typ`
+declaration automatically introduces, if not present already, the given
+constructor and pattern type.
+
+`MyList` is the sum between `Nil` and `Cons(z, MyList)`. There must be no
+overlap between the summands -- the set of terms inhabiting a summand must
+be disjoint from those inhabiting other summands.
 
 `subtype` is similar to the `typ` declaration, with the addition that it
 verifies that the defined type is a subtype of the specified base type. An

--- a/spec/types.nim
+++ b/spec/types.nim
@@ -63,7 +63,7 @@ type
     tkFunc
     tkTuple
     tkRecord ## record type
-    tkData   ## inductively defined data type
+    tkPat    ## pattern describing a set of values
     tkSum    ## sum type
 
   TypeId* = int
@@ -72,9 +72,8 @@ type
     case kind*: TypeKind
     of tkAll, tkVoid, tkBool, tkInt, tkRat:
       discard
-    of tkData:
-      constr*: seq[Node[TypeId]]
-        ## the patterns describing the shapes of valid constructions
+    of tkPat:
+      pat*: Node[TypeId]
     of tkFunc, tkTuple, tkList, tkSum:
       children*: seq[TypeId]
     of tkRecord:

--- a/tests/expr/spectest.nim
+++ b/tests/expr/spectest.nim
@@ -99,7 +99,7 @@ proc convertFloat(f: float): Node =
   of fcNegZero:
     tree(nkConstr, sym("Zero"), Node(kind: nkTrue))
   of fcNan:
-    tree(nkConstr, sym("Nan"))
+    sym("Nan")
   of fcInf:
     tree(nkConstr, sym("Inf"), Node(kind: nkFalse))
   of fcNegInf:
@@ -146,8 +146,6 @@ proc add(res: var string, n: Node) =
         res.add "-inf"
       else:
         res.add "inf"
-    elif n[0].sym == "Nan":
-      res.add "nan"
     elif n[0].sym == "Zero":
       if n[1].kind == nkTrue:
         res.add "-"
@@ -164,15 +162,20 @@ proc add(res: var string, n: Node) =
       res.add n[^1].sym
     else:
       res.add "("
-      for i, it in n.children.pairs:
-        if i > 0:
-          res.add ' '
-        res.add it
+      res.add n[0].sym
+      for i in 1..<n.len:
+        res.add ' '
+        res.add n[i]
       res.add ")"
   of nkNumber:
     res.addRat n.num
   of nkSymbol:
-    res.add n.sym
+    if n.sym == "Nan":
+      res.add "nan"
+    else:
+      res.add "("
+      res.add n.sym
+      res.add ")"
   of nkString:
     res.add escape(n.sym)
   else:


### PR DESCRIPTION
## Summary

* assign a dedicated type to constructor patterns in a `typ` declaration
* distinguish between `A` and `A()` (value vs. nullary construction)
* slightly clean up type checking and speed it up

## Details

The type checker and type system are changed as follows:
* patterns representing types are now treated as such, using the
  `tkPat` type kind
* distinguish between `A` and `A()`. Both are now disjoint terms
* the `tkData` type kind is removed. `typ` and `subtype` declaration
  now create (potentially recursive) sums of pattern types

The changes allow for more narrow typing of value constructions.
Previously, they had to be typed as the *data type* matching the
construction, which is unnecessarily broad and necessitated `or` types
in order to be able to resolve ambiguity (i.e., when a construction
is covered by more than one data type).

As a side-effect of the more narrow typing, the type checker has to run
pattern matching less often, which significantly speeds up type
checking.

What's still missing is type relationship computation for pattern types.

Finally:
* the construction/value translation logic in `spectest` now that `A`
  and `A()` are different
* `queryshell.getDefault` is updated to handle the new `tkPat` type kind
* the pattern matching logic for the `interpreter` is updated to handle
  the new `tkPat` type kind 
