### PR TITLE
partially restore interpreter performance

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,7 +59,7 @@ jobs:
       # use a pinned version in order to make CI runs reproducible
       - uses: nim-works/setup-nimskull@0.1.2
         with:
-          nimskull-version: "0.1.0-dev.21464"
+          nimskull-version: "0.1.0-dev.21466"
 
       - name: Build koch
         run: nim c -d:nimStrictMode --outdir:bin koch.nim
@@ -91,7 +91,7 @@ jobs:
       # use a pinned version in order to make CI runs reproducible
       - uses: nim-works/setup-nimskull@0.1.2
         with:
-          nimskull-version: "0.1.0-dev.21464"
+          nimskull-version: "0.1.0-dev.21466"
 
       - name: Build koch
         run: nim c -d:nimStrictMode --outdir:bin koch.nim
@@ -123,7 +123,7 @@ jobs:
       # use a pinned version in order to make CI runs reproducible
       - uses: nim-works/setup-nimskull@0.1.2
         with:
-          nimskull-version: "0.1.0-dev.21464"
+          nimskull-version: "0.1.0-dev.21466"
 
       - name: Build koch
         run: nim c -d:nimStrictMode --outdir:bin koch.nim

--- a/spec/cps.nim
+++ b/spec/cps.nim
@@ -26,10 +26,17 @@ proc `=copy`(dst: var CellRef, src: CellRef) =
     else:
       dst.p = src.p.copy(src.p)
 
+# the object checks in `take` have significant overhead, but since the
+# procedure is only used internally, we know that the dynamic type is always
+# correct and thus can safely disable the checks
+{.push checks: off.}
+
 proc take[T](c: sink CellRef): T {.inline.} =
   ## Returns the value from the given cell, `c`, which has to have dynamic
   ## type `T`.
   move (Cell[T])(c.p).val
+
+{.pop.}
 
 proc copyImpl[T](x: CellBase): CellBase =
   Cell[T](val: Cell[T](x).val, copy: x.copy)


### PR DESCRIPTION
## Summary

Use the most recent NimSkull version and selectively disable runtime
type checks. Interpreter performance is now closer to what it was prior
to the usage of tail calls for pattern matching, and memory usage no
longer grows indefinitely.

## Details

* using the most recent NimSkull version fixes both a severe memory leak
  and a lot unnecessary copies
* the object conversion type checks in `cps.take` made up ~25% of the
  execution time of `spectest`. Since the checks are unnecessary (the
  way `CellRef` is used makes dynamic type errors impossible), they're
  disabled