### PR TITLE
rename `source.nim` to `core.nim`

### DIFF
--- a/koch.nim
+++ b/koch.nim
@@ -173,7 +173,7 @@ proc buildDefs(args: string): bool =
 
   # there's nothing to do with the compiled language definition, making sure
   # the macro succeeds is enough
-  if not check(getCurrentDir() / "languages" / "source.nim"):
+  if not check(getCurrentDir() / "languages" / "core.nim"):
     echo "Failure"
     quit(1)
 

--- a/languages/core.nim
+++ b/languages/core.nim
@@ -1,14 +1,14 @@
-## Provides a reference implementation of the source language, written using
-## Phy's meta-language. The formal definition is derived from the reference
+## Provides a reference implementation of the *core language*, written using
+## Phy's meta language. The formal definition is derived from the reference
 ## implementation.
 ##
-## This is the one and only authoritative definition of the source language.
+## This is the one and only authoritative definition of the core language.
 ##
 ## As with most language-related things, the reference implementation /
 ## definition is a **work in progress**.
 ##
-## **Important:** as is, the language definition **does not** match
-## the originally intended semantics. This'll be fixed eventually.
+## At the moment, the *core* language is still mixed with the *source*
+## language, but this is going to change.
 
 import
   spec/[langdefs]

--- a/tests/expr/spectest.nim
+++ b/tests/expr/spectest.nim
@@ -1,10 +1,10 @@
 ## Temporary test orchestrator that runs all tests in the ``expr`` directory
-## using the reference implementation from ``languages/source.nim``. This
+## using the reference implementation from ``languages/core.nim``. This
 ## makes sure the reference implementation works as expected.
 
 import
   std/[os, strutils, strscans, streams, parsecfg, options, math],
-  languages/source,
+  languages/core,
   passes/[syntax_source, trees],
   phy/tree_parser,
   spec/[bignums, interpreter, langdefs, rationals]
@@ -72,7 +72,7 @@ template sym(s: string): Node = Node(kind: nkSymbol, sym: s)
 
 proc convertFloat(f: float): Node =
   ## Converts a floating-point value to the representation used by the
-  ## specification (refer to to the `float` type in ``source.nim``).
+  ## specification (refer to to the `float` type in ``core.nim``).
   # 1-bit sign, 11-bit biased exponent, 52-bit mantissa
   const Bias = 1022 + 53
   case classify(f)


### PR DESCRIPTION
In preparation for splitting the source language from the core language
definition, `source.nim` is renamed to `core.nim`, as it's mostly made
up of the core language definition.

---

## Notes For Reviewers

Separate from the main split-up so that git history for most of the core language definition is kept intact.