### PR TITLE
introduce a dedicated AST type

### DIFF
--- a/passes/asts.nim
+++ b/passes/asts.nim
@@ -1,0 +1,141 @@
+## Implements a generic packed storage type for arbitrary abstract syntax
+## trees -- no restrictions regarding the grammar are made.
+
+import
+  passes/[literals, trees],
+  experimental/sexp
+
+type
+  AstNode*[T] = object
+    ## A single node. How the `val` field is interpreted depends on the kind.
+    ## For leaf nodes, the field's meaning is decided externally, while for
+    ## non-leaf nodes, `val` stores the number of child nodes the node has.
+    kind*: T
+    val*: uint32
+
+  Ast*[T] = object
+    ## A self contained abstract-syntax-tree (=AST).
+    nodes*: PackedTree[AstNode[T]]
+    literals: Literals
+
+export trees.NodeIndex
+
+proc initAst*[T](nodes: sink PackedTree[AstNode[T]],
+                 literals: sink Literals): Ast[T] =
+  Ast[T](nodes: nodes, literals: literals)
+
+proc getInt*(tree: Ast, n: NodeIndex): int64 =
+  ## Returns the number stored by `n` as a signed integer.
+  tree.literals.loadInt(tree[n].val)
+
+proc getUInt*(tree: Ast, n: NodeIndex): uint64 =
+  ## Returns the number stored by `n` as an unsigned integer.
+  tree.literals.loadUInt(tree[n].val)
+
+proc getFloat*(tree: Ast, n: NodeIndex): float64 =
+  ## Returns the number stored by `n` as a float.
+  tree.literals.loadFloat(tree[n].val)
+
+proc getString*(tree: Ast, n: NodeIndex): lent string =
+  ## Returns the string value stored by `n`.
+  tree.literals.loadString(tree[n].val)
+
+func literals*(tree: Ast): lent Literals {.inline.} =
+  ## Returns the storage for the literal data.
+  tree.literals
+
+proc pack*(tree: var Ast, i: int64): uint32 {.inline.} =
+  ## Packs `i` into a ``uint32`` value that can be stored in a ``AstNode``.
+  pack(tree.literals, i)
+
+proc pack*(tree: var Ast, f: float64): uint32 {.inline.} =
+  ## Packs `f` into a ``uint32`` value that can be stored in a ``AstNode``.
+  pack(tree.literals, f)
+
+proc pack*(tree: var Ast, s: sink string): uint32 {.inline.} =
+  ## Packs `s` into a ``uint32`` value that can be stored in a ``AstNode``.
+  pack(tree.literals, s)
+
+template newNode*[T](k: T): AstNode[T] =
+  ## Creates an AST node with kind `k`.
+  AstNode[T](kind: k)
+
+template newNode*[T](k: T, v: uint32): AstNode[T] =
+  ## Creates an AST node with kind `k` and raw value `v`.
+  AstNode[T](kind: k, val: v)
+
+# TODO: move the S-expression serialization/deserialization elsewhere
+
+proc toSexp*[T](tree: PackedTree[T], at: NodeIndex): SexpNode =
+  mixin isAtom, toSexp
+  if isAtom(tree[at].kind):
+    result = toSexp(tree, at, tree[at])
+  else:
+    result = newSList()
+    result.add newSSymbol($tree[at].kind)
+    for it in tree.items(at):
+      result.add toSexp(tree, it)
+
+# ------ wrappers for tree operations --------
+# below are forwarding adapeters for all `PackedTree` operations, so that an
+# `Ast` can be used the same way a tree is
+
+template `[]`*[T](ast: Ast[T], n: NodeIndex): AstNode[T] =
+  `[]`(ast.nodes, n)
+
+template contains*(ast: Ast, n: NodeIndex): bool =
+  contains(ast.nodes, n)
+
+template next*(ast: Ast, n: NodeIndex): NodeIndex =
+  next(ast.nodes, n)
+
+template first*(ast: Ast, n: NodeIndex): NodeIndex =
+  first(ast.nodes, n)
+
+template child*(ast: Ast, n: NodeIndex, c: Natural): NodeIndex =
+  child(ast.nodes, n, c)
+
+template child*(ast: Ast, i: NodeIndex, c: BackwardsIndex): NodeIndex =
+  child(ast.nodes, i, c)
+
+template child*(ast: Ast, i: Natural): NodeIndex =
+  child(ast.nodes, i)
+
+template `[]`*[T](ast: Ast[T], i: NodeIndex, c: Natural): AstNode[T] =
+  `[]`(ast.nodes, i, c)
+
+template len*(ast: Ast, i: NodeIndex): int =
+  len(ast.nodes, i)
+
+template last*(ast: Ast, n: NodeIndex): NodeIndex =
+  last(ast.nodes, n)
+
+template fin*(ast: Ast, n: NodeIndex): NodeIndex =
+  fin(ast.nodes, n)
+
+iterator items*(ast: Ast, at: NodeIndex): NodeIndex =
+  for it in items(ast.nodes, at):
+    yield it
+
+iterator items*(ast: Ast, at: NodeIndex; start: int; last = ^1): NodeIndex =
+  for it in items(ast.nodes, at, start, last):
+    yield it
+
+iterator pairs*(ast: Ast, at: NodeIndex): (int, NodeIndex) =
+  for it in pairs(ast.nodes, at):
+    yield it
+
+iterator flat*(ast: Ast, at: NodeIndex): NodeIndex =
+  for it in flat(ast.nodes, at):
+    yield it
+
+iterator filter*[T](ast: Ast[T], at: NodeIndex,
+                    filter: static set[T]): NodeIndex =
+  for it in filter(ast.nodes, at, filter):
+    yield it
+
+template pair*(ast: Ast, n: NodeIndex): (NodeIndex, NodeIndex) =
+  pair(ast.nodes, n)
+
+template triplet*(ast: Ast, n: NodeIndex): (NodeIndex, NodeIndex, NodeIndex) =
+  triplet(ast.nodes, n)

--- a/passes/literals.nim
+++ b/passes/literals.nim
@@ -1,0 +1,59 @@
+## Implements a simple storage for integers.
+
+# XXX: maybe rename the module to ``constants``? But that name usually refers
+#      to something different...
+
+type
+  Numbers* = seq[uint64]
+
+  Literals* = object
+    numbers: Numbers
+    strings: seq[string]
+    # TODO: use a BiTable for both numbers and strings
+
+const
+  ExternalFlag = 0x8000_0000'u32
+    ## use the most significant bit to flag whether the value is larger than a
+    ## `max(int32)` and overflows into `Literals.numbers`.
+
+# TODO: return and accept a distinct uint32 rather than a raw one
+
+proc pack*(db: var Literals, i: int64): uint32 =
+  ## Packs `i` into a ``uint32`` value that can be stored in a ``AstNode``.
+  if i >= 0 and i < int64(ExternalFlag):
+    result = uint32(i) # fits into a uint32
+  else:
+    result = db.numbers.len.uint32 or ExternalFlag
+    db.numbers.add(cast[uint64](i))
+
+proc pack*(db: var Literals, f: float64): uint32 =
+  ## Packs `f` into a ``uint32`` value that can be stored in a ``AstNode``.
+  result = db.numbers.len.uint32
+  db.numbers.add(cast[uint64](f))
+
+proc pack*(db: var Literals, s: sink string): uint32 =
+  ## Packs `s` into a
+  result = db.strings.len.uint32
+  db.strings.add(s)
+
+func loadInt*(db: Literals, p: uint32): int64 {.inline.} =
+  ## Returns the number stored by `n` interpreted as a signed integer.
+  if (p and ExternalFlag) != 0:
+    cast[int64](db.numbers[p and not(ExternalFlag)])
+  else:
+    int64(p)
+
+proc loadUInt*(db: Literals, p: uint32): uint64 {.inline.} =
+  ## Returns the number stored by `n` interpreted as an unsigned integer.
+  if (p and ExternalFlag) != 0:
+    db.numbers[p or not(ExternalFlag)]
+  else:
+    p
+
+proc loadFloat*(db: Literals, p: uint32): float64 {.inline.} =
+  ## Returns the float64 stored by `n`.
+  cast[float64](db.numbers[p])
+
+proc loadString*(db: Literals, p: uint32): lent string {.inline.} =
+  ## Returns the string stored by `n`.
+  db.strings[p]


### PR DESCRIPTION
The goal is to separate the generic node storage and traversal operations from the specific concept of an abstract syntax tree (=AST).

An AST requires some extra bits of information (e.g., metadata), but adding this to `PackedTree` would make the type it no longer applicable for use cases that want just a sequence of nodes and the associated operations without anything else.

While there currently are no such use cases, I can foresee that changing in the future, so splitting the two things makes sense.

As is, the current code is a dead end. Conceptually, the node tree operations (e.g.: `child`, `next`, etc.) do not care about the concrete storage type -- they only require an input type that's a random-access supporting container type whose element is a type with a mutable `kind` and `val` property, nothing more. This makes them an ideal candidate for static interfaces (i.e., `concept`), but said NimSkull feature is not yet stable enough.

I've tried to approximate the ideal solution (static interfaces) by making `PackedTree` type only represent the node storage and have it be parameterized with the node type, with `Ast` then embedding a `PackedTree` instance and providing a wrapper template for every `PackedTree` routine such that `Ast` can be used in the same way a `PackedTree` can be, but this is annoying to maintain and it also significantly hurts code clarity, since various routines for `Builder`, `ChangeSet`, etc. have to use unnecessarily broad interfaces.

Using inheritance would work a little better in practice, but is not really correct (an `Ast` cannot be used everywhere a `PackedTree` can be, for example, serialization), and it would likely also surface some NimSkull bugs/issues with argument subtyping and `iterator`s.

Progress on this PR needs to wait until NimSkull supports working static interfaces. In the meantime, `PackedTree` will have to become the `Ast` type.