### PR TITLE
phy: instrument pass execution

### DIFF
--- a/phy/tracing.nim
+++ b/phy/tracing.nim
@@ -1,0 +1,51 @@
+## Implements some generic facilities for recording arbitrary events, intended
+## for performance-related instrumentation.
+
+import std/[monotimes, times]
+
+type
+  EventKind* {.pure.} = enum
+    Start ## something with a duration starts
+    End ## something with a duration stops
+    Action ## something with no duration happens
+
+  Event* = object
+    ## Represent something happening. Every event is associated with a timestamp.
+    kind*: EventKind
+      ## type of the event
+    timeStamp: MonoTime
+      ## when the event was recorded
+    data*: string
+      ## event payload
+
+  EventLog* = object
+    ## Represent an event log.
+    start {.requiresInit.}: MonoTime
+    events: seq[Event]
+
+proc initLog*(): EventLog =
+  ## Creates a fresh event log and sets its starting time to right now.
+  EventLog(start: getMonoTime())
+
+proc begin*(log: var EventLog, data: sink string) =
+  ## Records a `Start` event with the given data.
+  log.events.add Event(kind: EventKind.Start, timeStamp: getMonoTime(),
+                       data: data)
+
+proc stop*(log: var EventLog, data: sink string) =
+  ## Records an `End` event with the given data.
+  log.events.add Event(kind: EventKind.End, timeStamp: getMonoTime(),
+                       data: data)
+
+proc record*(log: var EventLog, data: sink string) =
+  ## Records an `Action` with the given data.
+  log.events.add Event(kind: EventKind.Action, timeStamp: getMonoTime(),
+                       data: data)
+
+proc relative*(log: EventLog, e: Event): Duration =
+  ## Returns the time-stamp of `e` relative to when the log was started.
+  e.timeStamp - log.start
+
+proc events*(log: EventLog): lent seq[Event] =
+  ## Returns the list of events.
+  log.events


### PR DESCRIPTION
## Summary

Add the `--measure` switch to `phy`, which allows dumping internal
timings gathered for various steps. This is intended as a development
and optimization aid.

## Details

* add the `tracing` module, which implements a simple time-stamped-
  event log collection facility (`EventLog`)
* use `EventLog` to collect the start and end times for each internal
  pass, as well as `source2il` and VM code generation
* the timings are gathered from the log, rendered as a CSV list, and
  dumped to the standard output

To continue supporting compiling `phy` with `skully`, instrumentation is
disabled (at compile time), as the `times` and `monotimes` standard
library modules cannot be imported when using `--os:any` (which `skully`
always does).

---

## Notes For Reviewers
* `tracing` is effectively a heavily trimmed-down, more generic version of the NimSkull's `tracer` module
