### PR TITLE
disasm: fix output for constants

### DIFF
--- a/tests/pass0/t03_demote_float64_to_float32.expected
+++ b/tests/pass0/t03_demote_float64_to_float32.expected
@@ -1,5 +1,5 @@
 .type t0 () -> float
-.const c0 0.5000000149
+.const c0 float 0.5000000149
 .start t0 p0
   LdConst c0
   ReinterpI32

--- a/vm/disasm.nim
+++ b/vm/disasm.nim
@@ -132,7 +132,7 @@ proc disassemble*(m: VmModule): string =
 
   # emit the constants:
   for i, val in m.constants.pairs:
-    result.add &".const c{i} {val}\n"
+    result.add &".const c{i} {val.typ} {val}\n"
 
   # emit the globals:
   for i, val in m.globals.pairs:


### PR DESCRIPTION
The output for VM constants was missing the type, meaning that it
wasn't a valid assembler directive.