### PR TITLE
vmmodules: add support for module memory

### DIFF
--- a/phy/phy.nim
+++ b/phy/phy.nim
@@ -438,7 +438,7 @@ proc main(args: openArray[string]) =
         error "invalid memory configuration"
 
       # setup the VM instance and load all modules (currently only one):
-      var env = initVm(mem.total, mem.total)
+      var env = initVm(mem.initial, mem.maximum)
       var ltab = LinkTable()
       if not load(env, ltab, module):
         error "loading the VM module failed"

--- a/phy/repl.nim
+++ b/phy/repl.nim
@@ -106,7 +106,7 @@ proc process(ctx: var ModuleCtx, reporter: Reporter,
     else:
       unreachable("memory config invalid; there's probably a bug in source2il")
 
-    var env = initVm(mem.total, mem.total)
+    var env = initVm(mem.initial, mem.maximum)
     var ltab = LinkTable()
     if not load(env, ltab, module):
       echo "Error: couldn't load module"

--- a/tests/vm/t08_relocation.test
+++ b/tests/vm/t08_relocation.test
@@ -1,0 +1,14 @@
+discard """
+  description: "Ensure that address relocation for globals works"
+  output: "(Done 5128)"
+"""
+.type P1 () -> int
+.memory 4096
+
+.global g0 int 8 # a local memory address
+.reloc g0
+
+.start P1 p
+  GetGlobal g0
+  Ret
+.end

--- a/tests/vm/t09_init.test
+++ b/tests/vm/t09_init.test
@@ -1,0 +1,22 @@
+discard """
+  description: "Ensure that region initializers work"
+  output: "(Done 48)"
+"""
+.type P1 () -> int
+.memory 4096
+.init 0 "\x10\x00\x00\x00"
+.init 4 "\x20\x00\x00\x00"
+
+.global g0 int 0
+.global g1 int 4
+.reloc g0
+.reloc g1
+
+.start P1 p
+  GetGlobal g0
+  LdInt32 0
+  GetGlobal g1
+  LdInt32 0
+  AddInt       # 16 + 32
+  Ret
+.end

--- a/vm/disasm.nim
+++ b/vm/disasm.nim
@@ -4,7 +4,8 @@
 import
   std/[
     intsets,
-    strformat
+    strformat,
+    strutils
   ],
   vm/[
     vmenv,
@@ -138,6 +139,17 @@ proc disassemble*(m: VmModule): string =
   for i, val in m.globals.pairs:
     result.add &".global g{i} {val.typ} {val}\n"
 
+  if m.memory > 0: # omit if zero
+    result.add &".memory {m.memory}\n"
+
+  # emit the regions:
+  for it in m.init.items:
+    result.add &".init {it.at} {escape(it.data)}\n"
+
+  # emit the relocations:
+  for it in m.relocations.items:
+    result.add &".reloc g{it}\n"
+
   # emit the procedures:
   for i, prc in m.procs.pairs:
     case prc.kind
@@ -152,7 +164,7 @@ proc disassemble*(m: VmModule): string =
     of pkStub:
       unreachable() # not possible
 
-  # # emit the exports:
+  # emit the exports:
   for e in m.exports.items:
     case e.kind
     of expGlobal:

--- a/vm/vmalloc.nim
+++ b/vm/vmalloc.nim
@@ -59,6 +59,10 @@ proc initAllocator*(initial, maxHost: uint): VmAllocator =
   result.host = cast[HostPointer](alloc0(initial))
   result.hostSize = initial
 
+func currSpace*(a: VmAllocator): uint =
+  ## Returns the currently allocated number of bytes.
+  a.hostSize
+
 proc translate*(a: VmAllocator, p: VirtualAddr): HostPointer {.inline.} =
   ## Translate `p` to a host address. This is an *unsafe* operation, no checks
   ## are performed.

--- a/vm/vmalloc.nim
+++ b/vm/vmalloc.nim
@@ -69,10 +69,11 @@ proc translate*(a: VmAllocator, p: VirtualAddr): HostPointer {.inline.} =
   cast[HostPointer](addr a.host[uint64(p) - AddressBias])
 
 proc grow*(a: var VmAllocator, size: uint): bool =
-  ## Grows the VM's available memory. In case of an error, nothing is modified
-  ## and false is returned.
-  if size > a.hostSize:
-    a.host = cast[HostPointer](realloc0(a.host, size, a.hostSize))
+  ## Grows the VM's memory to `size`. If `size` is less than the current size,
+  ## or greater than the maximum allowed size, nothing changes and `false`
+  ## is returned.
+  if size in a.hostSize..a.maxHost:
+    a.host = cast[HostPointer](realloc0(a.host, a.hostSize, size))
     a.hostSize = size
     true
   else:


### PR DESCRIPTION
## Summary

Add native support for memory management to VM modules, for allocating,
initializing, and referencing global memory.

## Details

To support programs made up of multiple, not-available-up-front modules,
where the current global memory management via the configuration
variables doesn't work well, VM modules now support:
* specifying a required memory size (`.memory`), which is allocated from
  the VM's global memory when the module is loaded
* memory initializers (`.init`), for initializing memory regions with
  constant data when the module is loaded
* relocations (`.reloc`), which allow storing offsets into the module's
  memory, and have be turned into a proper virtual address upon module
  load

The core VM does *not* change.

For temporary backwards compatibility, the existing configuration
variables still work as they did previously (allocating a static memory
region starting at address 0).

Finally, a bug with `vmalloc.grow` is fixed, where `grow` would always
crash for valid requests, due to misuse of `realloc0`.

## Notes For Reviewers
* support for the `total_memory`  and `stack_start` config variables will be removed once `skully` and `source2il` no longer need them
* I only didn't add a regression test for the `Grow` instruction (which was affected by the `grow` bug) because it's going to be removed anyway