### PR TITLE
add an IL with global locations

### DIFF
--- a/languages/lang0.md
+++ b/languages/lang0.md
@@ -106,8 +106,10 @@ stmt ::= (Asgn <local> <expr>)
 bblock ::= (Block  (Params <local>*) <stmt>* <exit>)
         |  (Except (Params <local>)  <stmt>* <exit>)
 
-int_or_float ::= <intVal> | <floatVal>
-globaldef ::= (GlobalDef <type> <int_or_float>)
+dataInit   ::= (Data align:<int> size:<int>)
+            |  (Data align:<int> content:(StringVal <string>))
+globalInit ::= <dataInit> | <intVal> | <floatVal>
+globaldef  ::= (GlobalDef <type> <globalInit>)
 ```
 
 ```grammar

--- a/languages/lang25.md
+++ b/languages/lang25.md
@@ -1,7 +1,7 @@
 ## L25 Language
 
 ```grammar
-.extends lang5
+.extends lang6
 ```
 
 Procedure bodies are not subdivided into basic-blocks, but instead consist of

--- a/languages/lang6.md
+++ b/languages/lang6.md
@@ -1,0 +1,35 @@
+## L6 Language
+
+```grammar
+.extends lang5
+```
+
+It's now possible to define global *variables*, which are locations that can be
+assigned to, read from, and have their address taken.
+
+Non-variables continue to works as they did previously.
+
+```grammar
+globalInit -= <dataInit>
+globaldef += (GlobalLoc <type> <dataInit>)
+
+dataInit -= (Data <int> <int>)
+          | (Data <int> (StringVal <string>))
+dataInit += (Data <type>)
+          | (Data <type> (StringVal <string>))
+```
+
+> TODO: instead of there being a `GlobalLoc`, `GlobalDef` should change its
+>       meaning to be that `GlobalLoc` from the L6 onwards. However, this is
+>       currently not possible, as some IL producers (mis-)use the globals for
+>       passing constants with external meaning to the VM
+
+They may be used as a `Copy` source and in paths, much like locals.
+```grammar
+global ::= (Global <int>)
+
+stmt += (Asgn <global> <expr>)
+
+expr += (Addr <global>)
+path_elem += <global>
+```

--- a/passes/pass25.nim
+++ b/passes/pass25.nim
@@ -1,5 +1,5 @@
 ## A pass that turns the transforms the bodies of procedures into the
-## basic-block-oriented structure (|L25| -> |L5|).
+## basic-block-oriented structure (|L25| -> |L6|).
 
 import
   std/[tables],

--- a/passes/pass_globalsToPointer.nim
+++ b/passes/pass_globalsToPointer.nim
@@ -1,0 +1,118 @@
+## Turns global locations into pointer globals. Read access is turned
+## into loads, write access into stores, and taking the address into copies
+## of the pointer global (|L6| -> |L5|).
+
+import
+  std/[tables],
+  passes/[changesets, syntax, trees]
+
+type
+  Context = object
+    ptrSize: int
+    globals: Table[uint32, TreeNode[NodeKind]]
+      ## global ID -> global's type. Only keeps a mapping for globals that
+      ## refer to addressable locations
+
+using
+  c: var Context
+  tree: PackedTree[NodeKind]
+  n: NodeIndex
+  bu: var ChangeSet[NodeKind]
+
+proc sizeAndAlignment(tree; n): tuple[size, align: uint32] =
+  case tree[n].kind
+  of Type:
+    sizeAndAlignment(tree, tree.child(tree.child(0), tree[n].val))
+  of Union, Record, Array:
+    (tree[n, 0].val, tree[n, 1].val)
+  of Int, UInt, Float:
+    (tree[n].val, tree[n].val)
+  else:
+    unreachable()
+
+proc lower(c; tree; n; bu) =
+  case tree[n].kind
+  of Copy:
+    if tree[n, 0].kind == Global:
+      # (Copy <global>) -> (Load <typ> (Copy <global>))
+      c.globals.withValue tree[n, 0].val, val:
+        bu.replace(n,
+          bu.buildTree(
+            tree(Load, node(val[]),
+              tree(Copy, node(Global, tree[n, 0].val)))))
+      # do nothing for simple globals
+    else:
+      c.lower(tree, tree.child(n, 0), bu)
+  of Asgn:
+    let (dst, src) = tree.pair(n)
+    if tree[dst].kind == Global:
+      # (Asgn <global> <src>) -> (Store <typ> (Copy <global>) <src'>)
+      let src2 = bu.openTree(tree, src):
+        c.lower(tree, src, bu)
+      bu.replace(n, bu.buildTree(
+        tree(Store, node(c.globals[tree[dst].val]),
+          tree(Copy, node(tree[dst])),
+          embed(src2))
+      ))
+    else:
+      c.lower(tree, dst, bu)
+      c.lower(tree, src, bu)
+  of Addr:
+    if tree[n, 0].kind == Global:
+      # the address of the location is now stored in the global
+      assert tree[n, 0].val in c.globals
+      bu.replace(n, bu.buildTree(
+        tree(Copy, node(tree[n, 0]))))
+    else:
+      c.lower(tree, tree.child(n, 0), bu)
+  of Global:
+    # must be a global that's used as a path element, as all other
+    # possibilities are handled by the previous branches
+    let id = tree[n].val
+    bu.replace(n, bu.buildTree(
+      tree(Deref, node(c.globals[id]),
+        tree(Copy, node(Global, id)))))
+  else:
+    for it in tree.filter(n, {Copy, Asgn, Addr, Global}):
+      c.lower(tree, it, bu)
+
+proc lowerGlobal(c; tree; n; bu) =
+  ## Turns the global loc into a simple global storing a pointer.
+  let data = tree.child(n, 1)
+
+  assert tree[data].kind == Data
+  let (s, a) = sizeAndAlignment(tree, tree.child(data, 0))
+  if tree.len(data) == 1:
+    # (Data <typ>) -> (Data <align> <size>)
+    bu.replace(n, bu.buildTree(
+      tree(GlobalDef,
+        node(UInt, c.ptrSize.uint32),
+        tree(Data,
+          # TODO: use packed values once supported, so that the full integer
+          #       range works
+          node(Immediate, a),
+          node(Immediate, s)))))
+  else:
+    # (Data <typ> <content>) -> (Data <align> <content>)
+    bu.replace(n, bu.buildTree(
+      tree(GlobalDef,
+        node(UInt, c.ptrSize.uint32),
+        tree(Data,
+          node(Immediate, a),
+          node(tree[data, 1]))))) # the string value stays
+
+proc lower*(tree; ptrSize: int): ChangeSet[NodeKind] =
+  ## Computes the changeset representing the lowering for a whole module
+  ## (`tree`). `ptrSize` is the size-in-bytes of a pointer.
+  var c = Context(ptrSize: ptrSize)
+  let (_, globals, procs) = tree.triplet(NodeIndex(0))
+
+  for i, it in tree.pairs(globals):
+    if tree[it].kind == GlobalLoc:
+      c.lowerGlobal(tree, it, result)
+      c.globals[uint32 i] = tree[it, 0]
+
+  # lower the procedure bodies:
+  for it in tree.items(procs):
+    if tree[it].kind == ProcDef:
+      c.lower(tree, tree.child(it, 2), result)

--- a/passes/syntax.nim
+++ b/passes/syntax.nim
@@ -38,6 +38,7 @@ type
 
     Module, TypeDefs, ProcDefs, ProcDef, Locals,
     Except, Params, GlobalDefs, GlobalDef, Import, Export
+    Data
 
     Break, Return, Case, If, Block, Stmts
 

--- a/passes/syntax.nim
+++ b/passes/syntax.nim
@@ -37,7 +37,7 @@ type
     CheckedCall, CheckedCallAsgn, Unwind, Choice
 
     Module, TypeDefs, ProcDefs, ProcDef, Locals,
-    Except, Params, GlobalDefs, GlobalDef, Import, Export
+    Except, Params, GlobalDefs, GlobalDef, GlobalLoc, Import, Export
     Data
 
     Break, Return, Case, If, Block, Stmts

--- a/phy/phy.nim
+++ b/phy/phy.nim
@@ -20,6 +20,7 @@ import
     lang3_checks,
     lang4_checks,
     lang5_checks,
+    lang6_checks,
     lang25_checks,
     lang30_checks,
     source_checks
@@ -32,6 +33,7 @@ import
     pass_aggregateParams,
     pass_aggregatesToBlob,
     pass_flattenPaths,
+    pass_globalsToPointer,
     pass_inlineTypes,
     pass_legalizeBlobOps,
     pass_localsToBlob,
@@ -76,6 +78,7 @@ type
     lang3 = "L3"
     lang4 = "L4"
     lang5 = "L5"
+    lang6 = "L6"
     lang25 = "L25"
     lang30 = "L30"
     langSource = "source"
@@ -172,6 +175,7 @@ proc syntaxCheck(code: PackedTree[syntax.NodeKind], lang: Language) =
   of lang3:  syntaxCheck(code, lang3_checks, module)
   of lang4:  syntaxCheck(code, lang4_checks, module)
   of lang5:  syntaxCheck(code, lang5_checks, module)
+  of lang6:  syntaxCheck(code, lang6_checks, module)
   of lang25: syntaxCheck(code, lang25_checks, module)
   of lang30: syntaxCheck(code, lang30_checks, module)
   else:      unreachable()
@@ -281,11 +285,16 @@ proc compile(tree: var PackedTree[syntax.NodeKind], source, target: Language) =
       measure "pass:flatten-paths":
         tree = tree.apply(pass_flattenPaths.lower(tree))
       current = lang4
+    of lang6:
+      syntaxCheck(tree, lang6_checks, module)
+      measure "pass:globals-to-pointer":
+        tree = tree.apply(pass_globalsToPointer.lower(tree, PointerSize))
+      current = lang5
     of lang25:
       syntaxCheck(tree, lang25_checks, module)
       measure "pass:basic-blocks":
         tree = tree.apply(pass25.lower(tree))
-      current = lang5
+      current = lang6
     of lang30:
       syntaxCheck(tree, lang30_checks, module)
       measure "pass:goto-rep":

--- a/phy/repl.nim
+++ b/phy/repl.nim
@@ -18,6 +18,7 @@ import
     pass0,
     pass_aggregateParams,
     pass_aggregatesToBlob,
+    pass_globalsToPointer,
     pass_legalizeBlobOps,
     pass_inlineTypes,
     pass_stackAlloc,
@@ -82,6 +83,7 @@ proc process(ctx: var ModuleCtx, reporter: Reporter,
     # lower to L0:
     m = m.apply(pass30.lower(m))
     m = m.apply(pass25.lower(m))
+    m = m.apply(pass_globalsToPointer.lower(m, 8))
     m = m.apply(pass_flattenPaths.lower(m))
     m = m.apply(pass_aggregateParams.lower(m, 8))
     m = m.apply(pass_aggregatesToBlob.lower(m, 8))

--- a/tests/pass0/t05_data_init.expected
+++ b/tests/pass0/t05_data_init.expected
@@ -1,0 +1,10 @@
+.type t0 () -> int
+.global g0 int 0
+.memory 4096
+.init 0 "@\x00\x00\x00"
+.reloc g0
+.start t0 p0
+  GetGlobal g0
+  LdInt32 0
+  Ret
+.end

--- a/tests/pass0/t05_data_init.test
+++ b/tests/pass0/t05_data_init.test
@@ -1,0 +1,14 @@
+discard """
+  output: "(Done 64)"
+"""
+(TypeDefs
+  (ProcTy (UInt 4)))
+(GlobalDefs
+  (GlobalDef (UInt 8) (Data 4 (StringVal "\x40\x00\x00\x00"))))
+(ProcDefs
+  (ProcDef (Type 0) 0 (Locals)
+    (List
+      (Block (Params)
+        (Return
+          (Load (UInt 4)
+            (Copy (Global 0))))))))

--- a/tests/pass0/t05_data_layout.expected
+++ b/tests/pass0/t05_data_layout.expected
@@ -1,0 +1,11 @@
+.type t0 () -> void
+.global g0 int 0
+.global g1 int 32
+.global g2 int 40
+.memory 4096
+.reloc g0
+.reloc g1
+.reloc g2
+.start t0 p0
+  Ret
+.end

--- a/tests/pass0/t05_data_layout.test
+++ b/tests/pass0/t05_data_layout.test
@@ -1,0 +1,14 @@
+discard """
+  output: "(Done)"
+"""
+(TypeDefs
+  (ProcTy (Void)))
+(GlobalDefs
+  (GlobalDef (UInt 8) (Data 1 3))
+  (GlobalDef (UInt 8) (Data 32 8))
+  (GlobalDef (UInt 8) (Data 4 4)))
+(ProcDefs
+  (ProcDef (Type 0) 0 (Locals)
+    (List
+      (Block (Params)
+        (Return)))))

--- a/tests/pass0/t05_data_uninit.expected
+++ b/tests/pass0/t05_data_uninit.expected
@@ -1,0 +1,9 @@
+.type t0 () -> int
+.global g0 int 0
+.memory 4096
+.reloc g0
+.start t0 p0
+  GetGlobal g0
+  LdInt64 0
+  Ret
+.end

--- a/tests/pass0/t05_data_uninit.test
+++ b/tests/pass0/t05_data_uninit.test
@@ -1,0 +1,14 @@
+discard """
+  output: "(Done 0)"
+"""
+(TypeDefs
+  (ProcTy (Int 8)))
+(GlobalDefs
+  (GlobalDef (UInt 8) (Data 1 8)))
+(ProcDefs
+  (ProcDef (Type 0) 0 (Locals)
+    (List
+      (Block (Params)
+        (Return
+          (Load (Int 8)
+            (Copy (Global 0))))))))

--- a/tests/passes/globals_to_pointer/addr.expected
+++ b/tests/passes/globals_to_pointer/addr.expected
@@ -1,0 +1,25 @@
+;$sexp
+(TypeDefs
+  (ProcTy (Void))
+  (Record 16 4
+    (Field 0 (Int 4))
+    (Field 4 (Int 4))
+    (Field 8 (Int 4))
+    (Field 12 (Int 4))))
+(GlobalDefs
+  (GlobalDef (UInt 8)
+    (Data 4 16)))
+(ProcDefs
+  (ProcDef (Type 0)
+    (Locals (Int 4) (Type 1))
+    (List
+      (Block (Params)
+        (Drop
+          (Copy (Global 0)))
+        (Drop
+          (Addr
+            (Field
+              (Deref (Type 1)
+                (Copy (Global 0)))
+              1)))
+        (Return)))))

--- a/tests/passes/globals_to_pointer/addr.test
+++ b/tests/passes/globals_to_pointer/addr.test
@@ -1,0 +1,20 @@
+discard """
+  description: "Make sure the `(Addr <global>)` lowering works"
+"""
+(TypeDefs
+  (ProcTy (Void))
+  (Record 16 4
+    (Field 0 (Int 4))
+    (Field 4 (Int 4))
+    (Field 8 (Int 4))
+    (Field 12 (Int 4))))
+(GlobalDefs
+  (GlobalLoc (Type 1) (Data (Type 1))))
+(ProcDefs
+  (ProcDef (Type 0)
+    (Locals (Int 4) (Type 1))
+    (List
+      (Block (Params)
+        (Drop (Addr (Global 0)))
+        (Drop (Addr (Field (Global 0) 1)))
+        (Return)))))

--- a/tests/passes/globals_to_pointer/asgn.expected
+++ b/tests/passes/globals_to_pointer/asgn.expected
@@ -1,0 +1,31 @@
+;$sexp
+(TypeDefs
+  (ProcTy (Void))
+  (Record 16 4
+    (Field 0 (Int 4))
+    (Field 4 (Int 4))
+    (Field 8 (Int 4))
+    (Field 12 (Int 4))))
+(GlobalDefs
+  (GlobalDef (UInt 8)
+    (Data 4 4))
+  (GlobalDef (UInt 8)
+    (Data 4 16)))
+(ProcDefs
+  (ProcDef (Type 0)
+    (Locals (Type 1))
+    (List
+      (Block (Params)
+        (Store (Int 4)
+          (Copy (Global 0))
+          (IntVal 100))
+        (Store (Type 1)
+          (Copy (Global 1))
+          (Copy (Local 0)))
+        (Asgn
+          (Field
+            (Deref (Type 1)
+              (Copy (Global 1)))
+            0)
+          (IntVal 200))
+        (Return)))))

--- a/tests/passes/globals_to_pointer/asgn.test
+++ b/tests/passes/globals_to_pointer/asgn.test
@@ -1,0 +1,26 @@
+discard """
+  description: "
+    Make sure lowering for `Asgn` with a global as the destination works.
+  "
+"""
+(TypeDefs
+  (ProcTy (Void))
+  (Record 16 4
+    (Field 0 (Int 4))
+    (Field 4 (Int 4))
+    (Field 8 (Int 4))
+    (Field 12 (Int 4))))
+(GlobalDefs
+  (GlobalLoc (Int 4)  (Data (Int 4)))
+  (GlobalLoc (Type 1) (Data (Type 1))))
+(ProcDefs
+  (ProcDef (Type 0)
+    (Locals (Type 1))
+    (List
+      (Block (Params)
+        (Asgn (Global 0) (IntVal 100))
+        (Asgn (Global 1) (Copy (Local 0)))
+        (Asgn
+          (Field (Global 1) 0)
+          (IntVal 200))
+        (Return)))))

--- a/tests/passes/globals_to_pointer/copy.expected
+++ b/tests/passes/globals_to_pointer/copy.expected
@@ -1,0 +1,31 @@
+;$sexp
+(TypeDefs
+  (ProcTy (Void))
+  (Record 16 4
+    (Field 0 (Int 4))
+    (Field 4 (Int 4))
+    (Field 8 (Int 4))
+    (Field 12 (Int 4))))
+(GlobalDefs
+  (GlobalDef (UInt 8)
+    (Data 4 4))
+  (GlobalDef (UInt 8)
+    (Data 4 16)))
+(ProcDefs
+  (ProcDef (Type 0)
+    (Locals (Int 4) (Type 1))
+    (List
+      (Block (Params)
+        (Asgn (Local 0)
+          (Load (Int 4)
+            (Copy (Global 0))))
+        (Asgn (Local 1)
+          (Load (Type 1)
+            (Copy (Global 1))))
+        (Asgn (Local 0)
+          (Copy
+            (Field
+              (Deref (Type 1)
+                (Copy (Global 1)))
+              1)))
+        (Return)))))

--- a/tests/passes/globals_to_pointer/copy.test
+++ b/tests/passes/globals_to_pointer/copy.test
@@ -1,0 +1,26 @@
+discard """
+  description: "
+    Make sure lowering for `Copy` with a global as the operand works.
+  "
+"""
+(TypeDefs
+  (ProcTy (Void))
+  (Record 16 4
+    (Field 0 (Int 4))
+    (Field 4 (Int 4))
+    (Field 8 (Int 4))
+    (Field 12 (Int 4))))
+(GlobalDefs
+  (GlobalLoc (Int 4)  (Data (Int 4)))
+  (GlobalLoc (Type 1) (Data (Type 1))))
+(ProcDefs
+  (ProcDef (Type 0)
+    (Locals (Int 4) (Type 1))
+    (List
+      (Block (Params)
+        (Asgn (Local 0) (Copy (Global 0)))
+        (Asgn (Local 1) (Copy (Global 1)))
+        (Asgn (Local 0)
+          (Copy
+            (Field (Global 1) 1)))
+        (Return)))))

--- a/tests/passes/globals_to_pointer/globals.expected
+++ b/tests/passes/globals_to_pointer/globals.expected
@@ -1,0 +1,21 @@
+;$sexp
+(TypeDefs
+  (Array 16 4 4 (Int 4))
+  (Record 32 8
+    (Field 0 (Type 0))
+    (Field 16 (Type 0)))
+  (Union 1 2 (Int 1) (UInt 1)))
+(GlobalDefs
+  (GlobalDef (Int 8) (IntVal 100))
+  (GlobalDef (Int 4) (IntVal 200))
+  (GlobalDef (UInt 8)
+    (Data 8 8))
+  (GlobalDef (UInt 8)
+    (Data 4 (StringVal "abcd")))
+  (GlobalDef (UInt 8)
+    (Data 4 16))
+  (GlobalDef (UInt 8)
+    (Data 8 32))
+  (GlobalDef (UInt 8)
+    (Data 2 1)))
+(ProcDefs)

--- a/tests/passes/globals_to_pointer/globals.test
+++ b/tests/passes/globals_to_pointer/globals.test
@@ -1,0 +1,19 @@
+discard """
+  description: "Make sure lowering for globals section works"
+"""
+(TypeDefs
+  (Array 16 4 4 (Int 4))
+  (Record 32 8
+    (Field 0 (Type 0))
+    (Field 16 (Type 0)))
+  (Union 1 2 (Int 1) (UInt 1)))
+(GlobalDefs
+  (GlobalDef (Int 8) (IntVal 100))
+  (GlobalDef (Int 4) (IntVal 200))
+  (GlobalLoc (Int 8) (Data (Int 8)))
+  (GlobalLoc (Int 4) (Data (Int 4) (StringVal "abcd")))
+  (GlobalLoc (Type 0) (Data (Type 0)))
+  (GlobalLoc (Type 1) (Data (Type 1)))
+  (GlobalLoc (Type 2) (Data (Type 2)))
+)
+(ProcDefs)

--- a/tests/passes/globals_to_pointer/runner.txt
+++ b/tests/passes/globals_to_pointer/runner.txt
@@ -1,0 +1,1 @@
+bin/phy --source:L6 --show:L5 --runner ${args=e} ${file}


### PR DESCRIPTION
## Summary

* add the `L6` IL, providing mutable global locations
* extend the `L0` IL with memory region support (`Data`)

## Details

* add the `Data` initializer for globals to the `L0` IL, which provides
  a convenient interface for VM module memory regions, initializer, and
  relocations
* implement the `Data` initializer in `pass0` and add tests for it
* add the `L6` IL, which extends the `L5` IL and is the new basis for
  the `L25` IL. It introduces `GlobalLoc` definitions, which define
  mutable global locations
* implement an `L6` -> `L5` lowering pass (`pass_globalsToPointer`) and
  add tests for it

Past the `L6`, a distinction between global locations (`GlobalLoc`) and
global constants (`GlobalDef`) still has to be kept for now, as the
legacy memory configuration still relies on global constants.