### PR TITLE
skully: fix various bugs

### DIFF
--- a/skully/backend.nim
+++ b/skully/backend.nim
@@ -1150,10 +1150,10 @@ proc genNumericConv(c; env; val: Expr, to: TypeId, bu) =
       bu.add typeRef(c, env, val.typ)
       bu.use val
 
-  template sizedConv(widen, narrow: NodeKind) =
+  template sizedConv(narrow, widen: NodeKind) =
     if dst.size(env.types) < src.size(env.types):
       convOp narrow
-    elif dst.size(env.types) > dst.size(env.types):
+    elif dst.size(env.types) > src.size(env.types):
       convOp widen
     else:
       # nothing to do
@@ -1185,7 +1185,7 @@ proc genNumericConv(c; env; val: Expr, to: TypeId, bu) =
     of ints, uints:
       convOp Conv
     of tkFloat:
-      sizedConv Promote, Demote
+      sizedConv Demote, Promote
     else:
       unreachable()
   of tkPtr, tkPointer, tkProc, tkCstring:

--- a/skully/backend.nim
+++ b/skully/backend.nim
@@ -1820,7 +1820,7 @@ proc genMagic(c; env: var MirEnv, tree; n; dest: Expr, stmts) =
         bu.subTree Copy:
           bu.subTree Field:
             lvalue(tree.argument(n, 0))
-            bu.add node(Immediate, 0)
+            bu.add node(Immediate, 1)
         bu.add node(Nil)
       bu.goto then
       bu.goto els

--- a/skully/backend.nim
+++ b/skully/backend.nim
@@ -1045,11 +1045,14 @@ proc getTypeInfoV2(c; env: var MirEnv, typ: TypeId): Expr =
 proc genDefault(c; env: var MirEnv; dest: Expr, typ: TypeId, bu) =
   let typ = env.types.canonical(typ)
   case env.types.headerFor(typ, Lowered).kind
-  of tkBool, tkChar, tkInt, tkUInt, tkRef, tkPtr, tkVar, tkLent, tkPointer:
+  of tkBool, tkChar, tkInt, tkUInt:
     genAsgn(dest, makeExpr(@[node(IntVal, c.lit.pack(0))], typ), bu)
   of tkFloat:
     genAsgn(dest, makeExpr(@[node(FloatVal, c.lit.pack(0.0))], typ), bu)
+  of tkRef, tkPtr, tkVar, tkLent, tkPointer, tkCstring, tkProc:
+    genAsgn(dest, makeExpr(@[node(Nil)], typ), bu)
   else:
+    # TODO: for seqs, closures, and openarrays, set the fields directly
     let size = env.types.headerFor(typ, Lowered).size(env.types)
     bu.subTree Clear:
       takeAddr(dest, bu)

--- a/skully/backend.nim
+++ b/skully/backend.nim
@@ -1920,7 +1920,7 @@ proc genMagic(c; env: var MirEnv, tree; n; dest: Expr, stmts) =
         bu.subTree Eq:
           bu.add typeRef(c, env, e.typ)
           bu.use e
-          bu.add node(IntVal, c.lit.pack(0))
+          bu.add node(Nil)
         bu.goto els
         bu.goto then
       stmts.join then
@@ -2094,7 +2094,7 @@ proc translateExpr(c; env: var MirEnv, tree; n; dest: Expr, stmts) =
                 bu.subTree Field:
                   lvalue callee
                   bu.add node(Immediate, 1)
-              bu.add node(IntVal, c.lit.pack(0))
+              bu.add node(Nil)
             bu.goto els
             bu.goto then
           stmts.join then
@@ -2300,7 +2300,7 @@ proc translateExpr(c; env: var MirEnv, tree; n; dest: Expr, stmts) =
       bu.subTree Field:
         bu.useLvalue dest
         bu.add node(Immediate, 0)
-      bu.add node(IntVal, c.lit.pack(0))
+      bu.add node(Nil)
     stmts.addStmt Asgn:
       bu.subTree Field:
         bu.useLvalue dest
@@ -2616,7 +2616,7 @@ proc translateStmt(env: var MirEnv, tree; n; stmts; c) =
   of mnkContinue:
     guardActive()
     stmts.addStmt Raise:
-      bu.add node(IntVal, 0)
+      bu.add node(Nil)
       c.genExit(tree, tree.child(n, 0), bu)
     c.prc.active = false
   of mnkRaise:
@@ -2624,7 +2624,7 @@ proc translateStmt(env: var MirEnv, tree; n; stmts; c) =
     # NimSkull exceptions are managed separately; there's nothing to pass
     # along to ``Raise``
     stmts.addStmt Raise:
-      bu.add node(IntVal, 0)
+      bu.add node(Nil)
       c.genExit(tree, tree.child(n, 0), bu)
     c.prc.active = false
   of mnkEmit, mnkAsm:

--- a/skully/backend.nim
+++ b/skully/backend.nim
@@ -998,7 +998,8 @@ proc translateValue(c; env: MirEnv, tree: MirTree, n: NodePosition,
             emit(c, env, tree, tree.child(n, 0), diff, b, bu)
       else:
         if env.types.headerFor(b, Lowered).kind in PointerLike:
-          # there are no pointer types in the IL; nothing to do
+          # all MIR pointer types map to the same IL pointer type;
+          # nothing special to do
           recurse(tree.child(n, 0), wantValue)
         else:
           assert not wantValue
@@ -1429,7 +1430,7 @@ proc genMagic(c; env: var MirEnv, tree; n; dest: Expr, stmts) =
   of mEqProc:
     let typ = env.types.canonical(tree[tree.argument(n, 0)].typ)
     if env.types.headerFor(typ, Lowered).kind == tkProc:
-      # simple integer equality suffices
+      # simple pointer equality suffices
       wrapAsgn Eq:
         bu.add typeRef(c, env, typ)
         value(tree.argument(n, 0))

--- a/skully/backend.nim
+++ b/skully/backend.nim
@@ -1596,14 +1596,14 @@ proc genMagic(c; env: var MirEnv, tree; n; dest: Expr, stmts) =
       bu.subTree Call:
         bu.add compilerProc(c, env, "cmpStrings")
         value(tree.argument(n, 0))
-        bu.add node(IntVal, 0)
+      bu.add node(IntVal, 0)
   of mLtStr:
     wrapAsgn Lt:
       bu.add typeRef(c, env, env.types.sizeType)
       bu.subTree Call:
         bu.add compilerProc(c, env, "cmpStrings")
         value(tree.argument(n, 0))
-        bu.add node(IntVal, 0)
+      bu.add node(IntVal, 0)
   of mFinished:
     # the status field is stored at the start of the env object, load it and
     # test whether the value is < 0

--- a/skully/backend.nim
+++ b/skully/backend.nim
@@ -1440,7 +1440,7 @@ proc genMagic(c; env: var MirEnv, tree; n; dest: Expr, stmts) =
       # TODO: use a proper short-circuiting ``and``, not a ``bitand``
       wrapAsgn BitAnd:
         bu.add typeRef(c, env, PointerType)
-        wrapAsgn Eq:
+        bu.subTree Eq:
           bu.add typeRef(c, env, PointerType)
           bu.subTree Copy:
             bu.subTree Field:
@@ -1450,7 +1450,7 @@ proc genMagic(c; env: var MirEnv, tree; n; dest: Expr, stmts) =
             bu.subTree Field:
               lvalue tree.argument(n, 1)
               bu.add node(Immediate, 0)
-        wrapAsgn Eq:
+        bu.subTree Eq:
           bu.add typeRef(c, env, PointerType)
           bu.subTree Copy:
             bu.subTree Field:

--- a/skully/backend.nim
+++ b/skully/backend.nim
@@ -1510,10 +1510,7 @@ proc genMagic(c; env: var MirEnv, tree; n; dest: Expr, stmts) =
       bu.add typeRef(c, env, tree[n].typ)
       value(tree.argument(n, 0))
       value(tree.argument(n, 1))
-  of mOrd:
-    wrapAsgn:
-      value(tree.argument(n, 0))
-  of mChr:
+  of mOrd, mChr:
     # it's a conversion, nothing more
     let input = c.gen(env, tree, NodePosition(tree.argument(n, 0)), true)
     wrapAsgn:

--- a/skully/backend.nim
+++ b/skully/backend.nim
@@ -669,6 +669,8 @@ proc genConst(c; env; tree; n; dest: Expr, stmts) =
     putIntoDest node(FloatVal, c.lit.pack(env.getFloat(tree[n].number)))
   of mnkProcVal:
     putIntoDest node(ProcVal, c.registerProc(tree[n].prc))
+  of mnkNilLit:
+    putIntoDest node(Nil)
   of mnkArrayConstr:
     for i, it in tree.args(n):
       let nDest = makeExpr tree[it].typ:


### PR DESCRIPTION
## Summary

Fix various bugs with `skully`. For the most part, they were about
incorrect code being emitted, resulting in misbehaving programs.

## Details

* fix size/alignment of embedded records (has no observable effect on
  compilation, at the moment)
* fix `nil` not being handled in constants, causing a crash
* fix incorrect code being emitted for closure equality tests
* fix pointer-location default initialization using an integer zero
* fix zero being used instead of `Nil` in various places
* fix wrong conversion operators being used for integer conversion
* fix integer extension conversion operators not being emitted
* fix `ord` not being translated to a conversion
* fix code emitted for `mDestroy` accessing the wrong field
* fix wrong code being emitted for `cast` where at least one operand is
  a float or imported type
