### PR TITLE
source2il: implement `CharTy` support

### DIFF
--- a/languages/specification.md
+++ b/languages/specification.md
@@ -38,6 +38,7 @@ texpr    ::= <ident>
           |  (VoidTy)
           |  (UnitTy)
           |  (BoolTy)
+          |  (CharTy)
           |  (IntTy)
           |  (FloatTy)
           |  (ArrayTy <intVal> <texpr>)

--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -253,6 +253,7 @@ proc evalType(c; t; n: NodeIndex): SemType =
   of VoidTy:  prim(tkVoid)
   of UnitTy:  prim(tkUnit)
   of BoolTy:  prim(tkBool)
+  of CharTy:  prim(tkChar)
   of IntTy:   prim(tkInt)
   of FloatTy: prim(tkFloat)
   of SourceKind.ArrayTy:

--- a/tests/expr/t05_char_type.nim
+++ b/tests/expr/t05_char_type.nim
@@ -1,0 +1,1 @@
+(TypeDecl (Ident "char") (CharTy))


### PR DESCRIPTION
Allow `CharTy` being used as a type expression, as specified by the
language definition.

`CharTy` appearing anywhere was erroneously considered a syntax error,
previously.