### PR TITLE
source2il: fix crash when copying records

### DIFF
--- a/phy/types.nim
+++ b/phy/types.nim
@@ -52,7 +52,8 @@ type
 const
   AggregateTypes* = {tkArray, tkTuple, tkRecord, tkUnion, tkSeq}
   ComplexTypes*   = AggregateTypes + {tkProc}
-    ## non-primitive types
+    ## non-scalar types made up of other complex or scalar types
+  AllTypes*       = {low(TypeKind) .. high(TypeKind)}
 
 proc cmp*(a, b: SemType): int =
   ## Establishes a total order for types, intended mainly for sorting them.

--- a/tests/expr/t17_seq_copy_6.test
+++ b/tests/expr/t17_seq_copy_6.test
@@ -1,0 +1,8 @@
+discard """
+  output: "(RecordCons (Field f (array 1 2 3))) : (RecordTy (Field f (SeqTy (IntTy))))"
+"""
+(Exprs
+  (Decl x (Seq (IntTy) 1 2 3))
+  (Decl y (RecordCons (Field f x)))
+  (Asgn (At x 0) 4)
+  y)


### PR DESCRIPTION
## Summary

Fix the compiler crashing for code where a record having a seq member
is copied.

## Details

The implementation for non-trivially-copyable records was missing,
causing the `unreachable` to trigger.

In order to prevent similar bugs going forward, the case statement for
producing the copy implementation is made exhaustive, using the new
`AllTypes` set. If a new aggregate type is added in the future, a
compile-time error will be reported if the new type is not handled.