### PR TITLE
source2il: fix crashes with erroneous code

### DIFF
--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -860,6 +860,8 @@ proc fitExprStrict(c; e: sink Expr, typ: SemType): Expr =
   ## returning an error-expression if not.
   if e.typ == typ:
     result = e # all good
+  elif tkError in {e.typ.kind, typ.kind}:
+    result = e # don't report follow-up errors
   else:
     c.error("expected expression of type $1 but got type $2" %
             [$typ, $e.typ])

--- a/phy/type_rendering.nim
+++ b/phy/type_rendering.nim
@@ -68,10 +68,7 @@ proc typeToString*(typ: SemType): string =
   of tkPointer:
     unreachable("pointer types should never reach rendering")
   of tkError:
-    # diagnostic messages should not show error types, therefore rendering is
-    # not implemented for them. If control-flow reaches here, it usually means
-    # that a guard against error types is missing somewhere
-    unreachable()
+    "?"
 
 proc `$`*(typ: SemType): string =
   ## A shortcut for `typeToString <#typeToString,SemType>`_.

--- a/tests/errors/README.md
+++ b/tests/errors/README.md
@@ -1,0 +1,3 @@
+This directory contains tests for error handling. More specifically, tests that
+make sure the compiler is able continue without crashing after encountering an
+error in the input program.

--- a/tests/errors/terror_in_call_argument.test
+++ b/tests/errors/terror_in_call_argument.test
@@ -1,0 +1,9 @@
+discard """
+  description: "Either the if or else branch has an error"
+  reject: true
+"""
+(Module
+  (ProcDecl (Ident "test") (UnitTy) (Params (ParamDecl (Ident "x") (IntTy)))
+    (Return))
+  (ProcDecl (Ident "main") (UnitTy) (Params)
+    (Call (Ident "test") (Ident "missing"))))

--- a/tests/errors/terror_in_call_argument.test
+++ b/tests/errors/terror_in_call_argument.test
@@ -1,5 +1,5 @@
 discard """
-  description: "Either the if or else branch has an error"
+  description: "A call argument has an error"
   reject: true
 """
 (Module

--- a/tests/errors/terror_in_if.test
+++ b/tests/errors/terror_in_if.test
@@ -1,0 +1,7 @@
+discard """
+  description: "Either the if or else branch has an error"
+  reject: true
+"""
+(If (Ident "true")
+  (Ident "missing")
+  (IntVal 10))

--- a/tests/errors/terror_in_if_1.test
+++ b/tests/errors/terror_in_if_1.test
@@ -1,5 +1,5 @@
 discard """
-  description: "Either the if or else branch has an error"
+  description: "The "then" part of an if has an error"
   reject: true
 """
 (If (Ident "true")

--- a/tests/errors/terror_in_if_2.test
+++ b/tests/errors/terror_in_if_2.test
@@ -1,0 +1,7 @@
+discard """
+  description: "The "else" part of an if has an error"
+  reject: true
+"""
+(If (Ident "true")
+  (IntVal 10)
+  (Ident "missing"))

--- a/tests/errors/terror_in_tuple_cons.test
+++ b/tests/errors/terror_in_tuple_cons.test
@@ -1,0 +1,5 @@
+discard """
+  description: "Either the if or else branch has an error"
+  reject: true
+"""
+(TupleCons (Ident "missing"))

--- a/tests/errors/terror_in_tuple_cons.test
+++ b/tests/errors/terror_in_tuple_cons.test
@@ -1,5 +1,5 @@
 discard """
-  description: "Either the if or else branch has an error"
+  description: "A tuple construction element has an error"
   reject: true
 """
 (TupleCons (Ident "missing"))


### PR DESCRIPTION
## Summary

Fix the compiler crashing for some instances of semantically
invalid code.

## Details

Error types reached into `typeToString`, triggering the `unreachable`
assertion and thus crashing the compiler.

* change `typeToString` to render errors as `?`. There are valid cases
  for an error type being rendered, such as when it's part of a
  composite type
* improve error recovery for tuple analysis. An element being an error
  no longer short-circuits analysis by returning an error
* use a single procedure for handling type unification (`unify`). This
  fixes unnecessary follow-up errors being reported for an `If` where
  unification fails due to one type being an error
* don't report unnecessary follow-up errors in `fitExprStrict`

Tests are added to make sure code that previously crashed the compiler
no longer does. The change to `typeToString` itself is enough to fix the
crash -- the other changes are to not report useless diagnostics.

---

## Notes For Reviewers
* found while using the language for some real-world code 