### PR TITLE
source2il: allow subtyping for call arguments

### DIFF
--- a/passes/source2il.nim
+++ b/passes/source2il.nim
@@ -1035,7 +1035,7 @@ proc userCallToIL(c; t; n: NodeIndex, expr; stmts): SemType =
         # only try fitting the argument if there's a corresponding parameter
         let arg =
           if i < prc.elems.len:
-            c.fitExprStrict(c.exprToIL(t, it), prc.elems[i])
+            c.fitExpr(c.exprToIL(t, it), prc.elems[i])
           else:
             c.exprToIL(t, it)
 

--- a/spec/interpreter.nim
+++ b/spec/interpreter.nim
@@ -848,6 +848,11 @@ proc interpret(c; lang; n: Node, then: sink Next): Node {.tailcall.} =
     for i in 0..<n.len - 1:
       inputs.add eval(c, lang, n[i][1])
 
+    # all lists must have the same number of arguments:
+    for i in 1..<inputs.len:
+      if inputs[i].len != inputs[0].len:
+        raise Failure.newException("")
+
     var output: seq[Node]
     for i in 0..<inputs[0].len:
       c.push()

--- a/tests/expr/t06_call_argument_subtype.test
+++ b/tests/expr/t06_call_argument_subtype.test
@@ -1,0 +1,13 @@
+discard """
+  description: "
+    A call argument's type must match the type of the corresponding
+    parameter.
+  "
+  output: "(TupleCons) : (UnitTy)"
+"""
+(Module
+  (ProcDecl (Ident "test") (UnitTy)
+    (Params (ParamDecl (Ident "x") (UnionTy (IntTy) (UnitTy))))
+    (TupleCons))
+  (ProcDecl (Ident "main") (UnitTy) (Params)
+    (Call (Ident "test") (TupleCons))))

--- a/tests/expr/t06_call_argument_type_mismatch_error.test
+++ b/tests/expr/t06_call_argument_type_mismatch_error.test
@@ -1,0 +1,13 @@
+discard """
+  description: "
+    A call argument's type must match the type of the corresponding
+    parameter.
+  "
+  reject: true
+"""
+(Module
+  (ProcDecl (Ident "test") (UnitTy)
+    (Params (ParamDecl (Ident "x") (IntTy)))
+    (TupleCons))
+  (ProcDecl (Ident "main") (UnitTy) (Params)
+    (Call (Ident "test") (TupleCons))))

--- a/tests/expr/t06_call_arity_mismatch_1_error.test
+++ b/tests/expr/t06_call_arity_mismatch_1_error.test
@@ -1,0 +1,12 @@
+discard """
+  description: "
+    The number of supplied arguments must match the number of parameters.
+  "
+  reject: true
+"""
+(Module
+  (ProcDecl (Ident "test") (UnitTy)
+    (Params (ParamDecl (Ident "x") (UnitTy)))
+    (TupleCons))
+  (ProcDecl (Ident "main") (UnitTy) (Params)
+    (Call (Ident "test") (TupleCons) (TupleCons))))

--- a/tests/expr/t06_call_arity_mismatch_2_error.test
+++ b/tests/expr/t06_call_arity_mismatch_2_error.test
@@ -1,0 +1,12 @@
+discard """
+  description: "
+    The number of supplied arguments must match the number of parameters.
+  "
+  reject: true
+"""
+(Module
+  (ProcDecl (Ident "test") (UnitTy)
+    (Params (ParamDecl (Ident "x") (UnitTy)))
+    (TupleCons))
+  (ProcDecl (Ident "main") (UnitTy) (Params)
+    (Call (Ident "test"))))


### PR DESCRIPTION
## Summary

The compiler previously didn't conform to the specification, disallowing
subtyping for call arguments. This is now fixed.

## Details

* use `fitExpr` instead of `fitExprStrict` for call argument type
  fitting, to allow for subtyping
* fix the `interpreter` ignoring mismatching lengths for call, which
  lead to either the interpreter crashing, or meta-language expressions
  erroneously evaluating successfully 
* add specification tests covering improper numbers of call arguments,
  argument type mismatches, and argument subtyping

---

## Notes For Reviewers
* found while using the language 